### PR TITLE
Various fixes for 1.9.4

### DIFF
--- a/src/main/java/dan200/computercraft/ComputerCraft.java
+++ b/src/main/java/dan200/computercraft/ComputerCraft.java
@@ -53,9 +53,10 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
@@ -366,14 +367,14 @@ public class ComputerCraft
         player.openGui( instance, ComputerCraft.turtleGUIID, player.getEntityWorld(), pos.getX(), pos.getY(), pos.getZ() );
     }
 
-    public static void openPrintoutGUI( EntityPlayer player )
+    public static void openPrintoutGUI( EntityPlayer player, EnumHand hand )
     {
-        player.openGui( ComputerCraft.instance, ComputerCraft.printoutGUIID, player.getEntityWorld(), 0, 0, 0 );
+        player.openGui( ComputerCraft.instance, ComputerCraft.printoutGUIID, player.getEntityWorld(), hand.ordinal(), 0, 0 );
     }
 
-    public static void openPocketComputerGUI( EntityPlayer player )
+    public static void openPocketComputerGUI( EntityPlayer player, EnumHand hand )
     {
-        player.openGui( ComputerCraft.instance, ComputerCraft.pocketComputerGUIID, player.getEntityWorld(), 0, 0, 0 );
+        player.openGui( ComputerCraft.instance, ComputerCraft.pocketComputerGUIID, player.getEntityWorld(), hand.ordinal(), 0, 0 );
     }
 
     public static File getBaseDir()

--- a/src/main/java/dan200/computercraft/client/gui/widgets/MousePos.java
+++ b/src/main/java/dan200/computercraft/client/gui/widgets/MousePos.java
@@ -1,0 +1,19 @@
+/**
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2016. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.client.gui.widgets;
+
+public class MousePos
+{
+	public int x;
+	public int y;
+
+	public MousePos( int x, int y )
+	{
+		this.x = x;
+		this.y = y;
+	}
+}

--- a/src/main/java/dan200/computercraft/client/gui/widgets/Widget.java
+++ b/src/main/java/dan200/computercraft/client/gui/widgets/Widget.java
@@ -6,8 +6,6 @@
 
 package dan200.computercraft.client.gui.widgets;
 
-import dan200.computercraftedu.client.gui.widgets.MousePos;
-import dan200.computercraftedu.client.gui.widgets.WidgetContainer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.client.gui.FontRenderer;

--- a/src/main/java/dan200/computercraft/client/gui/widgets/WidgetContainer.java
+++ b/src/main/java/dan200/computercraft/client/gui/widgets/WidgetContainer.java
@@ -1,0 +1,344 @@
+/**
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2016. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+
+package dan200.computercraft.client.gui.widgets;
+
+import dan200.computercraft.client.gui.widgets.Widget;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+
+import java.util.ArrayList;
+
+public class WidgetContainer extends Widget
+{
+	private ArrayList<Widget> m_widgets;
+	private Widget m_modalWidget;
+
+	public WidgetContainer( int x, int y, int w, int h )
+	{
+		super( x, y, w, h );
+		m_widgets = new ArrayList<Widget>();
+		m_modalWidget = null;
+	}
+
+	public void addWidget( Widget widget )
+	{
+		m_widgets.add( widget );
+		widget.setParent( this );
+	}
+
+	public void setModalWidget( Widget widget )
+	{
+		m_modalWidget = widget;
+		if( widget != null )
+		{
+			widget.setParent( this );
+		}
+	}
+
+	public Widget getModalWidget()
+	{
+		return m_modalWidget;
+	}
+
+	@Override
+	public void update()
+	{
+		for( int i=0; i<m_widgets.size(); ++i )
+		{
+			m_widgets.get( i ).update();
+		}
+		if( m_modalWidget != null )
+		{
+			m_modalWidget.update();
+		}
+	}
+
+	@Override
+	public void draw( Minecraft mc, int xOrigin, int yOrigin, int mouseX, int mouseY )
+	{
+		for( int i=0; i<m_widgets.size(); ++i )
+		{
+			Widget widget = m_widgets.get( i );
+			if( widget.isVisible() )
+			{
+				widget.draw(
+						mc,
+						xOrigin + getXPosition(),
+						yOrigin + getYPosition(),
+						(m_modalWidget == null) ? (mouseX - getXPosition()) : -99,
+						(m_modalWidget == null) ? (mouseY - getYPosition()) : -99
+				);
+			}
+		}
+		if( m_modalWidget != null )
+		{
+			if( m_modalWidget.isVisible() )
+			{
+				GlStateManager.pushMatrix();
+				try
+				{
+					GlStateManager.translate( 0.0f, 0.0f, 200.0f );
+					m_modalWidget.draw(
+							mc,
+							xOrigin + getXPosition(),
+							yOrigin + getYPosition(),
+							mouseX - getXPosition(),
+							mouseY - getYPosition()
+					);
+				}
+				finally
+				{
+					GlStateManager.popMatrix();
+				}
+			}
+		}
+	}
+
+	@Override
+	public void drawForeground( Minecraft mc, int xOrigin, int yOrigin, int mouseX, int mouseY )
+	{
+		for( int i=0; i<m_widgets.size(); ++i )
+		{
+			Widget widget = m_widgets.get( i );
+			if( widget.isVisible() )
+			{
+				widget.drawForeground(
+						mc,
+						xOrigin + getXPosition(),
+						yOrigin + getYPosition(),
+						(m_modalWidget == null) ? (mouseX - getXPosition()) : -99,
+						(m_modalWidget == null) ? (mouseY - getYPosition()) : -99
+				);
+			}
+		}
+
+		if( m_modalWidget != null )
+		{
+			if( m_modalWidget.isVisible() )
+			{
+				GlStateManager.pushMatrix();
+				try
+				{
+					GlStateManager.translate( 0.0f, 0.0f, 200.0f );
+					m_modalWidget.drawForeground(
+							mc,
+							xOrigin + getXPosition(),
+							yOrigin + getYPosition(),
+							mouseX - getXPosition(),
+							mouseY - getYPosition()
+					);
+				}
+				finally
+				{
+					GlStateManager.popMatrix();
+				}
+			}
+		}
+	}
+
+	@Override
+	public void modifyMousePosition( MousePos pos )
+	{
+		pos.x -= getXPosition();
+		pos.y -= getYPosition();
+		if( m_modalWidget == null )
+		{
+			for( int i = 0; i < m_widgets.size(); ++i )
+			{
+				Widget widget = m_widgets.get( i );
+				if( widget.isVisible() )
+				{
+					widget.modifyMousePosition( pos );
+				}
+			}
+		}
+		else
+		{
+			if( m_modalWidget.isVisible() )
+			{
+				m_modalWidget.modifyMousePosition( pos );
+			}
+		}
+		pos.x += getXPosition();
+		pos.y += getYPosition();
+	}
+
+	@Override
+	public boolean suppressItemTooltips( Minecraft mc, int xOrigin, int yOrigin, int mouseX, int mouseY )
+	{
+		if( m_modalWidget == null )
+		{
+			for( int i = 0; i < m_widgets.size(); ++i )
+			{
+				Widget widget = m_widgets.get( i );
+				if( widget.isVisible() )
+				{
+					if( widget.suppressItemTooltips(
+							mc,
+							xOrigin + getXPosition(),
+							yOrigin + getYPosition(),
+							mouseX - getXPosition(),
+							mouseY - getYPosition()
+					) )
+					{
+						return true;
+					}
+				}
+			}
+		}
+		else
+		{
+			if( m_modalWidget.isVisible() && m_modalWidget.suppressItemTooltips(
+					mc,
+					xOrigin + getXPosition(),
+					yOrigin + getYPosition(),
+					mouseX - getXPosition(),
+					mouseY - getYPosition()
+			) )
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public boolean suppressKeyPress( char c, int k )
+	{
+		if( m_modalWidget == null )
+		{
+			for( int i = 0; i < m_widgets.size(); ++i )
+			{
+				Widget widget = m_widgets.get( i );
+				if( widget.isVisible() )
+				{
+					if( widget.suppressKeyPress( c, k ) )
+					{
+						return true;
+					}
+				}
+			}
+		}
+		else
+		{
+			if( m_modalWidget.isVisible() )
+			{
+				if( m_modalWidget.suppressKeyPress( c, k ) )
+				{
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public void handleMouseInput( int mouseX, int mouseY )
+	{
+		if( m_modalWidget == null )
+		{
+			for( int i = 0; i < m_widgets.size(); ++i )
+			{
+				Widget widget = m_widgets.get( i );
+				if( widget.isVisible() )
+				{
+					widget.handleMouseInput(
+							mouseX - getXPosition(),
+							mouseY - getYPosition()
+					);
+				}
+			}
+		}
+		else
+		{
+			if( m_modalWidget.isVisible() )
+			{
+				m_modalWidget.handleMouseInput(
+						mouseX - getXPosition(),
+						mouseY - getYPosition()
+				);
+			}
+		}
+	}
+
+	@Override
+	public void handleKeyboardInput()
+	{
+		if( m_modalWidget == null )
+		{
+			for( int i = 0; i < m_widgets.size(); ++i )
+			{
+				Widget widget = m_widgets.get( i );
+				if( widget.isVisible() )
+				{
+					widget.handleKeyboardInput();
+				}
+			}
+		}
+		else
+		{
+			if( m_modalWidget.isVisible() )
+			{
+				m_modalWidget.handleKeyboardInput();
+			}
+		}
+	}
+
+	@Override
+	public void mouseClicked( int mouseX, int mouseY, int mouseButton )
+	{
+		if( m_modalWidget == null )
+		{
+			for( int i = 0; i < m_widgets.size(); ++i )
+			{
+				Widget widget = m_widgets.get( i );
+				if( widget.isVisible() )
+				{
+					widget.mouseClicked(
+							mouseX - getXPosition(),
+							mouseY - getYPosition(),
+							mouseButton
+					);
+				}
+			}
+		}
+		else
+		{
+			if( m_modalWidget.isVisible() )
+			{
+				m_modalWidget.mouseClicked(
+						mouseX - getXPosition(),
+						mouseY - getYPosition(),
+						mouseButton
+				);
+			}
+		}
+	}
+
+	@Override
+	public void keyTyped( char c, int k )
+	{
+		if( m_modalWidget == null )
+		{
+			for( int i = 0; i < m_widgets.size(); ++i )
+			{
+				Widget widget = m_widgets.get( i );
+				if( widget.isVisible() )
+				{
+					widget.keyTyped( c, k );
+				}
+			}
+		}
+		else
+		{
+			if( m_modalWidget.isVisible() )
+			{
+				m_modalWidget.keyTyped( c, k );
+			}
+		}
+	}
+}

--- a/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
+++ b/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
@@ -14,6 +14,7 @@ import dan200.computercraft.shared.computer.core.ClientComputer;
 import dan200.computercraft.shared.computer.core.ComputerFamily;
 import dan200.computercraft.shared.computer.items.ItemComputer;
 import dan200.computercraft.shared.media.inventory.ContainerHeldItem;
+import dan200.computercraft.shared.media.items.ItemDiskLegacy;
 import dan200.computercraft.shared.media.items.ItemPrintout;
 import dan200.computercraft.shared.network.ComputerCraftPacket;
 import dan200.computercraft.shared.peripheral.diskdrive.TileDiskDrive;
@@ -28,6 +29,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.client.renderer.color.IItemColor;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.Item;
@@ -47,6 +49,8 @@ import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 
 import java.io.File;
@@ -62,12 +66,12 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
     public ComputerCraftProxyClient()
     {
     }
-    
+
     // IComputerCraftProxy implementation
-    
+
     @Override
     public void init()
-    {        
+    {
         super.init();
         m_tick = 0;
         m_renderFrame = 0;
@@ -172,6 +176,10 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
             "advanced_pocket_computer_off", "advanced_pocket_computer_on", "advanced_pocket_computer_blinking", "advanced_pocket_computer_on_modem_on", "advanced_pocket_computer_blinking_modem_on",
         } );
 
+        // Setup item colours
+		mc.getItemColors().registerItemColorHandler(new DiskColorHandler(ComputerCraft.Items.disk), ComputerCraft.Items.disk);
+		mc.getItemColors().registerItemColorHandler(new DiskColorHandler(ComputerCraft.Items.diskExpanded), ComputerCraft.Items.diskExpanded);
+
         // Setup renderers
         ClientRegistry.bindTileEntitySpecialRenderer( TileMonitor.class, new TileEntityMonitorRenderer() );
 
@@ -225,7 +233,7 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
         ModelBakery.registerItemVariants( item, resources );
         Minecraft.getMinecraft().getRenderItem().getItemModelMesher().register( item, definition );
     }
-    
+
     @Override
     public boolean isClient()
     {
@@ -255,7 +263,7 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
     {
         return m_fixedWidthFontRenderer;
     }
-            
+
     @Override
     public String getRecordInfo( ItemStack recordStack )
     {
@@ -267,7 +275,7 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
             return super.getRecordInfo( recordStack );
         }
     }
-    
+
     @Override
     public void playRecord( SoundEvent record, String recordInfo, World world, BlockPos pos )
     {
@@ -278,19 +286,19 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
             mc.ingameGUI.setRecordPlayingMessage( recordInfo );
         }
     }
-    
+
     @Override
     public Object getDiskDriveGUI( InventoryPlayer inventory, TileDiskDrive drive )
     {
         return new GuiDiskDrive( inventory, drive );
     }
-    
+
     @Override
     public Object getComputerGUI( TileComputer computer )
     {
         return new GuiComputer( computer );
     }
-    
+
     @Override
     public Object getPrinterGUI( InventoryPlayer inventory, TilePrinter printer )
     {
@@ -405,7 +413,7 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
         FMLCommonHandler.instance().bus().register( handlers );
         MinecraftForge.EVENT_BUS.register( handlers );
     }
-                
+
     public class ForgeHandlers
     {
         public ForgeHandlers()
@@ -491,4 +499,21 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
             }
         }
     }
+
+	@SideOnly(Side.CLIENT)
+	private static class DiskColorHandler implements IItemColor
+	{
+		private final ItemDiskLegacy disk;
+
+		private DiskColorHandler(ItemDiskLegacy disk)
+		{
+			this.disk = disk;
+		}
+
+		@Override
+		public int getColorFromItemstack(ItemStack stack, int layer)
+		{
+			return layer == 0 ? 0xFFFFFF : disk.getColor(stack);
+		}
+	}
 }

--- a/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
+++ b/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
@@ -34,11 +34,11 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.IThreadListener;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.IThreadListener;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderHandEvent;
@@ -176,7 +176,7 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
             "advanced_pocket_computer_off", "advanced_pocket_computer_on", "advanced_pocket_computer_blinking", "advanced_pocket_computer_on_modem_on", "advanced_pocket_computer_blinking_modem_on",
         } );
 
-        // Setup item colours
+        // Setup
 		mc.getItemColors().registerItemColorHandler(new DiskColorHandler(ComputerCraft.Items.disk), ComputerCraft.Items.disk);
 		mc.getItemColors().registerItemColorHandler(new DiskColorHandler(ComputerCraft.Items.diskExpanded), ComputerCraft.Items.diskExpanded);
 
@@ -312,9 +312,9 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
     }
 
     @Override
-    public Object getPrintoutGUI( InventoryPlayer inventory )
+    public Object getPrintoutGUI( EntityPlayer player, EnumHand hand )
     {
-        ContainerHeldItem container = new ContainerHeldItem( inventory );
+        ContainerHeldItem container = new ContainerHeldItem( player, hand );
         if( container.getStack() != null && container.getStack().getItem() instanceof ItemPrintout )
         {
             return new GuiPrintout( container );
@@ -323,9 +323,9 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
     }
 
     @Override
-    public Object getPocketComputerGUI( InventoryPlayer inventory )
+    public Object getPocketComputerGUI( EntityPlayer player, EnumHand hand )
     {
-        ContainerHeldItem container = new ContainerHeldItem( inventory );
+        ContainerHeldItem container = new ContainerHeldItem( player, hand );
         if( container.getStack() != null && container.getStack().getItem() instanceof ItemPocketComputer )
         {
             return new GuiPocketComputer( container );

--- a/src/main/java/dan200/computercraft/server/proxy/ComputerCraftProxyServer.java
+++ b/src/main/java/dan200/computercraft/server/proxy/ComputerCraftProxyServer.java
@@ -12,7 +12,9 @@ import dan200.computercraft.shared.peripheral.diskdrive.TileDiskDrive;
 import dan200.computercraft.shared.peripheral.printer.TilePrinter;
 import dan200.computercraft.shared.proxy.ComputerCraftProxyCommon;
 import dan200.computercraft.shared.turtle.blocks.TileTurtle;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -88,13 +90,13 @@ public class ComputerCraftProxyServer extends ComputerCraftProxyCommon
     }
 
     @Override
-    public Object getPrintoutGUI( InventoryPlayer inventory )
+    public Object getPrintoutGUI( EntityPlayer player, EnumHand hand )
     {
         return null;
     }
 
     @Override
-    public Object getPocketComputerGUI( InventoryPlayer inventory )
+    public Object getPocketComputerGUI( EntityPlayer player, EnumHand hand )
     {
         return null;
     }

--- a/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
+++ b/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
@@ -204,7 +204,7 @@ public abstract class BlockGeneric extends Block implements
             TileGeneric generic = (TileGeneric)tile;
             return generic.getBounds();
         }
-        return NULL_AABB;
+        return FULL_BLOCK_AABB;
     }
 
     @Override
@@ -237,7 +237,7 @@ public abstract class BlockGeneric extends Block implements
                 return aabb;
             }
         }
-        return NULL_AABB;
+        return FULL_BLOCK_AABB;
     }
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
+++ b/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
@@ -152,7 +152,7 @@ public abstract class BlockGeneric extends Block implements
     }
 
     @Override
-    public final void onNeighborChange( IBlockAccess world, BlockPos pos, BlockPos neighborPos )
+    public final void neighborChanged( IBlockState state, World world, BlockPos pos, Block block )
     {
         TileEntity tile = world.getTileEntity( pos );
         if( tile != null && tile instanceof TileGeneric )

--- a/src/main/java/dan200/computercraft/shared/common/TileGeneric.java
+++ b/src/main/java/dan200/computercraft/shared/common/TileGeneric.java
@@ -65,9 +65,11 @@ public abstract class TileGeneric extends TileEntity
 
     public final void updateBlock()
     {
+        markDirty();
         BlockPos pos = getPos();
+        IBlockState state = worldObj.getBlockState( pos );
         worldObj.markBlockRangeForRenderUpdate( pos, pos );
-        worldObj.markChunkDirty( pos, this );
+        worldObj.notifyBlockUpdate( getPos(), state, state, 3 );
     }
 
     protected final void setBlockState( IBlockState newState )
@@ -207,5 +209,20 @@ public abstract class TileGeneric extends TileEntity
                 break;
             }
         }
+    }
+
+    @Override
+    public NBTTagCompound getUpdateTag ()
+    {
+        NBTTagCompound tag = super.getUpdateTag();
+        writeDescription( tag );
+        return tag;
+    }
+
+    @Override
+    public void handleUpdateTag (NBTTagCompound tag)
+    {
+        super.handleUpdateTag(tag);
+        readDescription( tag );
     }
 }

--- a/src/main/java/dan200/computercraft/shared/media/inventory/ContainerHeldItem.java
+++ b/src/main/java/dan200/computercraft/shared/media/inventory/ContainerHeldItem.java
@@ -8,19 +8,19 @@ package dan200.computercraft.shared.media.inventory;
 
 import dan200.computercraft.shared.util.InventoryUtil;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
 
 public class ContainerHeldItem extends Container
 {
     private final ItemStack m_stack;
-    private final int m_slot;
+    private final EnumHand m_hand;
 
-    public ContainerHeldItem( InventoryPlayer player )
+    public ContainerHeldItem( EntityPlayer player, EnumHand hand )
     {
-        m_slot = player.currentItem;
-        m_stack = InventoryUtil.copyItem( player.getStackInSlot( m_slot ) );
+        m_hand = hand;
+        m_stack = InventoryUtil.copyItem( player.getHeldItem( hand ) );
     }
 
     public ItemStack getStack()
@@ -33,7 +33,7 @@ public class ContainerHeldItem extends Container
     {
         if( player != null && player.isEntityAlive() )
         {
-            ItemStack stack = player.inventory.getStackInSlot( m_slot );
+            ItemStack stack = player.getHeldItem( m_hand );
             if( (stack == m_stack) || (stack != null && m_stack != null && stack.getItem() == m_stack.getItem()) )
             {
                 return true;

--- a/src/main/java/dan200/computercraft/shared/media/items/ItemPrintout.java
+++ b/src/main/java/dan200/computercraft/shared/media/items/ItemPrintout.java
@@ -20,11 +20,11 @@ import net.minecraft.world.World;
 import java.util.List;
 
 public class ItemPrintout extends Item
-{    
+{
     public static final int LINES_PER_PAGE = 21;
     public static final int LINE_MAX_LENGTH = 25;
     public static final int MAX_PAGES = 16;
-    
+
     public enum Type
     {
         Single,
@@ -39,7 +39,7 @@ public class ItemPrintout extends Item
         setUnlocalizedName( "computercraft:page" );
         setCreativeTab( ComputerCraft.mainCreativeTab );
     }
-    
+
     @Override
     public void getSubItems( Item itemID, CreativeTabs tabs, List list )
     {
@@ -47,7 +47,7 @@ public class ItemPrintout extends Item
         list.add( createMultipleFromTitleAndText( null, new String[ 2*LINES_PER_PAGE ], new String[ 2*LINES_PER_PAGE ] ) );
         list.add( createBookFromTitleAndText( null, new String[ 2*LINES_PER_PAGE ], new String[ 2*LINES_PER_PAGE ] ) );
     }
-    
+
     @Override
     public void addInformation( ItemStack itemstack, EntityPlayer par2EntityPlayer, List list, boolean flag )
     {
@@ -57,7 +57,7 @@ public class ItemPrintout extends Item
             list.add( title );
         }
     }
-    
+
     @Override
     public String getUnlocalizedName( ItemStack stack )
     {
@@ -79,18 +79,17 @@ public class ItemPrintout extends Item
             }
         }
     }
-    
+
     @Override
     public ActionResult<ItemStack> onItemRightClick( ItemStack stack, World world, EntityPlayer player, EnumHand hand )
     {
         if( !world.isRemote )
         {
-            ComputerCraft.openPrintoutGUI( player );
-            return new ActionResult<ItemStack>( EnumActionResult.SUCCESS, stack );
+            ComputerCraft.openPrintoutGUI( player, hand );
         }
-        return new ActionResult<ItemStack>( EnumActionResult.PASS, stack );
+        return new ActionResult<ItemStack>( EnumActionResult.SUCCESS, stack );
     }
-    
+
     private static ItemStack createFromTitleAndText( Type type, String title, String[] text, String[] colours )
     {
         // Calculate damage
@@ -150,12 +149,12 @@ public class ItemPrintout extends Item
         // Return stack
         return stack;
     }
-    
+
     public static ItemStack createSingleFromTitleAndText( String title, String[] text, String[] colours )
     {
         return createFromTitleAndText( Type.Single, title, text, colours );
     }
-    
+
     public static ItemStack createMultipleFromTitleAndText( String title, String[] text, String[] colours )
     {
         return createFromTitleAndText( Type.Multiple, title, text, colours );
@@ -196,7 +195,7 @@ public class ItemPrintout extends Item
         }
         return null;
     }
-    
+
     public static int getPageCount( ItemStack stack )
     {
         NBTTagCompound nbt = stack.getTagCompound();
@@ -206,7 +205,7 @@ public class ItemPrintout extends Item
         }
         return 1;
     }
-    
+
     public static String[] getText( ItemStack stack )
     {
         NBTTagCompound nbt = stack.getTagCompound();
@@ -224,8 +223,8 @@ public class ItemPrintout extends Item
             }
         }
         return lines;
-    }    
-    
+    }
+
     public static String[] getColours( ItemStack stack )
     {
         NBTTagCompound nbt = stack.getTagCompound();

--- a/src/main/java/dan200/computercraft/shared/media/items/RecordMedia.java
+++ b/src/main/java/dan200/computercraft/shared/media/items/RecordMedia.java
@@ -13,6 +13,7 @@ import net.minecraft.item.ItemRecord;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 
 // An implementation of IMedia for ItemRecord's
 public class RecordMedia implements IMedia
@@ -43,7 +44,7 @@ public class RecordMedia implements IMedia
     public SoundEvent getAudio( ItemStack stack )
     {
         ItemRecord itemRecord = (ItemRecord)stack.getItem();
-        return itemRecord.getSound();
+        return ObfuscationReflectionHelper.getPrivateValue(ItemRecord.class, itemRecord, "field_185076_b");
     }
     
     @Override

--- a/src/main/java/dan200/computercraft/shared/peripheral/common/ItemCable.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/common/ItemCable.java
@@ -89,7 +89,7 @@ public class ItemCable extends ItemPeripheralBase
                 if( stack.stackSize > 0 )
                 {
                     world.setBlockState( pos, existingState.withProperty( BlockCable.Properties.CABLE, true ), 3 );
-                    world.playSound( null, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, ComputerCraft.Blocks.cable.getSoundType().getBreakSound(), SoundCategory.BLOCKS, (ComputerCraft.Blocks.cable.getSoundType().getVolume() + 1.0F ) / 2.0F, ComputerCraft.Blocks.cable.getSoundType().getPitch() * 0.8F);
+                    world.playSound( null, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, ComputerCraft.Blocks.cable.getSoundType().getPlaceSound(), SoundCategory.BLOCKS, (ComputerCraft.Blocks.cable.getSoundType().getVolume() + 1.0F ) / 2.0F, ComputerCraft.Blocks.cable.getSoundType().getPitch() * 0.8F);
                     stack.stackSize--;
                     
                     TileEntity tile = world.getTileEntity( pos );
@@ -119,7 +119,7 @@ public class ItemCable extends ItemPeripheralBase
                     if( stack.stackSize > 0 )
                     {
                         world.setBlockState( offset, offsetExistingState.withProperty( BlockCable.Properties.MODEM, BlockCableModemVariant.fromFacing( side.getOpposite() ) ), 3 );
-                        world.playSound( null, offset.getX() + 0.5, offset.getY() + 0.5, offset.getZ() + 0.5, ComputerCraft.Blocks.cable.getSoundType().getBreakSound(), SoundCategory.BLOCKS, (ComputerCraft.Blocks.cable.getSoundType().getVolume() + 1.0F ) / 2.0F, ComputerCraft.Blocks.cable.getSoundType().getPitch() * 0.8F);
+                        world.playSound( null, offset.getX() + 0.5, offset.getY() + 0.5, offset.getZ() + 0.5, ComputerCraft.Blocks.cable.getSoundType().getPlaceSound(), SoundCategory.BLOCKS, (ComputerCraft.Blocks.cable.getSoundType().getVolume() + 1.0F ) / 2.0F, ComputerCraft.Blocks.cable.getSoundType().getPitch() * 0.8F);
                         stack.stackSize--;
 
                         TileEntity tile = world.getTileEntity( offset );
@@ -139,7 +139,7 @@ public class ItemCable extends ItemPeripheralBase
                     if( stack.stackSize > 0 )
                     {
                         world.setBlockState( offset, offsetExistingState.withProperty( BlockCable.Properties.CABLE, true ), 3 );
-                        world.playSound( null, offset.getX() + 0.5, offset.getY() + 0.5, offset.getZ() + 0.5, ComputerCraft.Blocks.cable.getSoundType().getBreakSound(), SoundCategory.BLOCKS, (ComputerCraft.Blocks.cable.getSoundType().getVolume() + 1.0F ) / 2.0F, ComputerCraft.Blocks.cable.getSoundType().getPitch() * 0.8F);
+                        world.playSound( null, offset.getX() + 0.5, offset.getY() + 0.5, offset.getZ() + 0.5, ComputerCraft.Blocks.cable.getSoundType().getPlaceSound(), SoundCategory.BLOCKS, (ComputerCraft.Blocks.cable.getSoundType().getVolume() + 1.0F ) / 2.0F, ComputerCraft.Blocks.cable.getSoundType().getPitch() * 0.8F);
                         stack.stackSize--;
 
                         TileEntity tile = world.getTileEntity( offset );

--- a/src/main/java/dan200/computercraft/shared/pocket/items/ItemPocketComputer.java
+++ b/src/main/java/dan200/computercraft/shared/pocket/items/ItemPocketComputer.java
@@ -30,10 +30,12 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundEvent;
-import net.minecraft.util.text.translation.I18n;;
+import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
 
 import java.util.List;
+
+;
 
 public class ItemPocketComputer extends Item implements IComputerItem, IMedia
 {
@@ -169,10 +171,9 @@ public class ItemPocketComputer extends Item implements IComputerItem, IMedia
             {
                 computer.turnOn();
             }
-            ComputerCraft.openPocketComputerGUI( player );
-            return new ActionResult<ItemStack>( EnumActionResult.SUCCESS, stack );
+            ComputerCraft.openPocketComputerGUI( player, hand );
         }
-        return new ActionResult<ItemStack>( EnumActionResult.PASS, stack );
+        return new ActionResult<ItemStack>( EnumActionResult.SUCCESS, stack );
     }
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
+++ b/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
@@ -15,7 +15,6 @@ import dan200.computercraft.shared.computer.blocks.BlockCommandComputer;
 import dan200.computercraft.shared.computer.blocks.BlockComputer;
 import dan200.computercraft.shared.computer.blocks.TileCommandComputer;
 import dan200.computercraft.shared.computer.blocks.TileComputer;
-import dan200.computercraft.shared.computer.core.ClientComputer;
 import dan200.computercraft.shared.computer.core.ComputerFamily;
 import dan200.computercraft.shared.computer.core.ServerComputer;
 import dan200.computercraft.shared.computer.inventory.ContainerComputer;
@@ -63,16 +62,15 @@ import net.minecraft.item.ItemRecord;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.Packet;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.IThreadListener;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.IThreadListener;
-import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.world.WorldEvent;
-import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.common.network.FMLNetworkEvent;
@@ -127,8 +125,9 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
         Item item = recordStack.getItem();
         if( item instanceof ItemRecord )
         {
-            ItemRecord record = (ItemRecord)item;
-            return record.getRecordNameLocal();
+            ItemRecord record = (ItemRecord) item;
+            String key = ObfuscationReflectionHelper.getPrivateValue( ItemRecord.class, record, "field_185077_c" );
+            return I18n.translateToLocal( key );
         }
         return null;
     }

--- a/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
+++ b/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
@@ -63,6 +63,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.Packet;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.IThreadListener;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
@@ -86,7 +87,7 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
     public ComputerCraftProxyCommon()
     {
     }
-    
+
     // IComputerCraftProxy implementation
 
     @Override
@@ -94,17 +95,17 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
     {
         registerItems();
     }
-    
-    @Override        
+
+    @Override
     public void init()
     {
         registerTileEntities();
         registerForgeHandlers();
     }
-    
+
     @Override
     public abstract boolean isClient();
-    
+
     @Override
     public abstract boolean getGlobalCursorBlink();
 
@@ -118,12 +119,12 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
 
     @Override
     public abstract Object getFixedWidthFontRenderer();
-    
+
     @Override
     public String getRecordInfo( ItemStack recordStack )
     {
         Item item = recordStack.getItem();
-        if( item instanceof ItemRecord )
+        if (item instanceof ItemRecord)
         {
             ItemRecord record = (ItemRecord) item;
             String key = ObfuscationReflectionHelper.getPrivateValue( ItemRecord.class, record, "field_185077_c" );
@@ -131,13 +132,13 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
         }
         return null;
     }
-        
+
     @Override
     public abstract void playRecord( SoundEvent record, String recordInfo, World world, BlockPos pos );
-    
+
     @Override
     public abstract Object getDiskDriveGUI( InventoryPlayer inventory, TileDiskDrive drive );
-    
+
     @Override
     public abstract Object getComputerGUI( TileComputer computer );
 
@@ -148,24 +149,23 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
     public abstract Object getTurtleGUI( InventoryPlayer inventory, TileTurtle turtle );
 
     @Override
-    public abstract Object getPrintoutGUI( InventoryPlayer inventory );
+    public abstract Object getPrintoutGUI( EntityPlayer player, EnumHand hand );
 
     @Override
-    public abstract Object getPocketComputerGUI( InventoryPlayer inventory );
+    public abstract Object getPocketComputerGUI( EntityPlayer player, EnumHand hand );
 
     public abstract File getWorldDir( World world );
-    
-    @Override 
+
+    @Override
     public void handlePacket( final ComputerCraftPacket packet, final EntityPlayer player )
     {
         IThreadListener listener = player.getServer();
-        if( listener != null )
+        if (listener != null)
         {
-            if( listener.isCallingFromMinecraftThread() )
+            if (listener.isCallingFromMinecraftThread())
             {
                 processPacket( packet, player );
-            }
-            else
+            } else
             {
                 listener.addScheduledTask( new Runnable()
                 {
@@ -181,7 +181,7 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
 
     private void processPacket( ComputerCraftPacket packet, EntityPlayer player )
     {
-        switch( packet.m_packetType )
+        switch (packet.m_packetType)
         {
             ///////////////////////////////////
             // Packets from Client to Server //
@@ -195,7 +195,7 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
             {
                 int instance = packet.m_dataInt[0];
                 ServerComputer computer = ComputerCraft.serverComputerRegistry.get( instance );
-                if( computer != null )
+                if (computer != null)
                 {
                     computer.handlePacket( packet, player );
                 }
@@ -209,13 +209,13 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
                 BlockPos pos = new BlockPos( x, y, z );
                 World world = player.getEntityWorld();
                 TileEntity tileEntity = world.getTileEntity( pos );
-                if( tileEntity != null && tileEntity instanceof TileGeneric )
+                if (tileEntity != null && tileEntity instanceof TileGeneric)
                 {
-                    TileGeneric generic = (TileGeneric)tileEntity;
+                    TileGeneric generic = (TileGeneric) tileEntity;
                     Packet description = generic.getUpdatePacket();
-                    if( description != null )
+                    if (description != null)
                     {
-                        ((EntityPlayerMP)player).connection.sendPacket( description );
+                        ((EntityPlayerMP) player).connection.sendPacket( description );
                     }
                 }
                 break;
@@ -280,93 +280,93 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
         // Computer
         ItemStack computer = ComputerItemFactory.create( -1, null, ComputerFamily.Normal );
         GameRegistry.addRecipe( computer,
-            "XXX", "XYX", "XZX",
-            'X', Blocks.STONE,
-            'Y', Items.REDSTONE,
-            'Z', Blocks.GLASS_PANE
+                "XXX", "XYX", "XZX",
+                'X', Blocks.STONE,
+                'Y', Items.REDSTONE,
+                'Z', Blocks.GLASS_PANE
         );
 
         // Advanced Computer
         ItemStack advancedComputer = ComputerItemFactory.create( -1, null, ComputerFamily.Advanced );
         GameRegistry.addRecipe( advancedComputer,
-            "XXX", "XYX", "XZX",
-            'X', Items.GOLD_INGOT,
-            'Y', Items.REDSTONE,
-            'Z', Blocks.GLASS_PANE
+                "XXX", "XYX", "XZX",
+                'X', Items.GOLD_INGOT,
+                'Y', Items.REDSTONE,
+                'Z', Blocks.GLASS_PANE
         );
 
         // Disk Drive
         ItemStack diskDrive = PeripheralItemFactory.create( PeripheralType.DiskDrive, null, 1 );
         GameRegistry.addRecipe( diskDrive,
-            "XXX", "XYX", "XYX",
-            'X', Blocks.STONE,
-            'Y', Items.REDSTONE
+                "XXX", "XYX", "XYX",
+                'X', Blocks.STONE,
+                'Y', Items.REDSTONE
         );
-        
+
         // Wireless Modem
         ItemStack wirelessModem = PeripheralItemFactory.create( PeripheralType.WirelessModem, null, 1 );
         GameRegistry.addRecipe( wirelessModem,
-            "XXX", "XYX", "XXX",
-            'X', Blocks.STONE,
-            'Y', Items.ENDER_PEARL
+                "XXX", "XYX", "XXX",
+                'X', Blocks.STONE,
+                'Y', Items.ENDER_PEARL
         );
-                
+
         // Monitor
         ItemStack monitor = PeripheralItemFactory.create( PeripheralType.Monitor, null, 1 );
         GameRegistry.addRecipe( monitor,
-            "XXX", "XYX", "XXX",
-            'X', Blocks.STONE,
-            'Y', Blocks.GLASS_PANE
+                "XXX", "XYX", "XXX",
+                'X', Blocks.STONE,
+                'Y', Blocks.GLASS_PANE
         );
-                
+
         // PrinterEmpty
         ItemStack printer = PeripheralItemFactory.create( PeripheralType.Printer, null, 1 );
         GameRegistry.addRecipe( printer,
-            "XXX", "XYX", "XZX",
-            'X', Blocks.STONE,
-            'Y', Items.REDSTONE,
-            'Z', new ItemStack( Items.DYE, 1, 0 ) // 0 = Black
+                "XXX", "XYX", "XZX",
+                'X', Blocks.STONE,
+                'Y', Items.REDSTONE,
+                'Z', new ItemStack( Items.DYE, 1, 0 ) // 0 = Black
         );
 
         // Advanced Monitor
         ItemStack advancedMonitors = PeripheralItemFactory.create( PeripheralType.AdvancedMonitor, null, 4 );
         GameRegistry.addRecipe( advancedMonitors,
-            "XXX", "XYX", "XXX",
-            'X', Items.GOLD_INGOT,
-            'Y', Blocks.GLASS_PANE
+                "XXX", "XYX", "XXX",
+                'X', Items.GOLD_INGOT,
+                'Y', Blocks.GLASS_PANE
         );
 
         // Networking Cable
         ItemStack cable = PeripheralItemFactory.create( PeripheralType.Cable, null, 6 );
         GameRegistry.addRecipe( cable,
-            " X ", "XYX", " X ",
-            'X', Blocks.STONE,
-            'Y', Items.REDSTONE
+                " X ", "XYX", " X ",
+                'X', Blocks.STONE,
+                'Y', Items.REDSTONE
         );
-        
+
         // Wired Modem
         ItemStack wiredModem = PeripheralItemFactory.create( PeripheralType.WiredModem, null, 1 );
         GameRegistry.addRecipe( wiredModem,
-            "XXX", "XYX", "XXX",
-            'X', Blocks.STONE,
-            'Y', Items.REDSTONE
+                "XXX", "XYX", "XXX",
+                'X', Blocks.STONE,
+                'Y', Items.REDSTONE
         );
 
         // Computer
         ItemStack commandComputer = ComputerItemFactory.create( -1, null, ComputerFamily.Command );
         GameRegistry.addRecipe( commandComputer,
-            "XXX", "XYX", "XZX",
-            'X', Blocks.STONE,
-            'Y', Blocks.COMMAND_BLOCK,
-            'Z', Blocks.GLASS_PANE
+                "XXX", "XYX", "XZX",
+                'X', Blocks.STONE,
+                'Y', Blocks.COMMAND_BLOCK,
+                'Z', Blocks.GLASS_PANE
         );
 
         // Advanced Modem
         ItemStack advancedModem = PeripheralItemFactory.create( PeripheralType.AdvancedModem, null, 1 );
         GameRegistry.addRecipe( advancedModem,
-            "XXX", "XYX", "XXX",
-            'X', Items.GOLD_INGOT,
-            'Y', Items.ENDER_EYE
+                "XXX", "XYX", "XXX",
+                'X', Items.GOLD_INGOT,
+                'Y', Items.ENDER_EYE
         );
 
         // Disk
@@ -376,24 +376,24 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
         ItemStack paper = new ItemStack( Items.PAPER, 1 );
         ItemStack redstone = new ItemStack( Items.REDSTONE, 1 );
         ItemStack basicDisk = ItemDiskLegacy.createFromIDAndColour( -1, null, Colour.Blue.getHex() );
-        GameRegistry.addRecipe( new ImpostorShapelessRecipe( basicDisk, new Object[] { redstone, paper } ) );
+        GameRegistry.addRecipe( new ImpostorShapelessRecipe( basicDisk, new Object[]{redstone, paper} ) );
 
-        for( int colour=0; colour<16; ++colour )
+        for (int colour = 0; colour < 16; ++colour)
         {
-            ItemStack disk = ItemDiskLegacy.createFromIDAndColour( -1, null, Colour.values()[ colour ].getHex() );
+            ItemStack disk = ItemDiskLegacy.createFromIDAndColour( -1, null, Colour.values()[colour].getHex() );
             ItemStack dye = new ItemStack( Items.DYE, 1, colour );
-            for( int otherColour=0; otherColour<16; ++otherColour )
+            for (int otherColour = 0; otherColour < 16; ++otherColour)
             {
-                if( colour != otherColour )
+                if (colour != otherColour)
                 {
-                    ItemStack otherDisk = ItemDiskLegacy.createFromIDAndColour( -1, null, Colour.values()[ colour ].getHex() );
-                    GameRegistry.addRecipe( new ImpostorShapelessRecipe( disk, new Object[] {
-                        otherDisk, dye
+                    ItemStack otherDisk = ItemDiskLegacy.createFromIDAndColour( -1, null, Colour.values()[colour].getHex() );
+                    GameRegistry.addRecipe( new ImpostorShapelessRecipe( disk, new Object[]{
+                            otherDisk, dye
                     } ) );
                 }
             }
-            GameRegistry.addRecipe( new ImpostorShapelessRecipe( disk, new Object[] {
-                redstone, paper, dye
+            GameRegistry.addRecipe( new ImpostorShapelessRecipe( disk, new Object[]{
+                    redstone, paper, dye
             } ) );
         }
 
@@ -406,27 +406,27 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
 
         // Impostor Printout recipes (to fool NEI)
         ItemStack string = new ItemStack( Items.STRING, 1, 0 );
-        GameRegistry.addRecipe( new ImpostorShapelessRecipe( multiplePrintout, new Object[] { singlePrintout, singlePrintout, string } ) );
+        GameRegistry.addRecipe( new ImpostorShapelessRecipe( multiplePrintout, new Object[]{singlePrintout, singlePrintout, string} ) );
 
         ItemStack leather = new ItemStack( Items.LEATHER, 1, 0 );
-        GameRegistry.addRecipe( new ImpostorShapelessRecipe( bookPrintout, new Object[] { leather, singlePrintout, string } ) );
+        GameRegistry.addRecipe( new ImpostorShapelessRecipe( bookPrintout, new Object[]{leather, singlePrintout, string} ) );
 
         // Pocket Computer
         ItemStack pocketComputer = PocketComputerItemFactory.create( -1, null, ComputerFamily.Normal, false );
         GameRegistry.addRecipe( pocketComputer,
-            "XXX", "XYX", "XZX",
-            'X', Blocks.STONE,
-            'Y', Items.GOLDEN_APPLE,
-            'Z', Blocks.GLASS_PANE
+                "XXX", "XYX", "XZX",
+                'X', Blocks.STONE,
+                'Y', Items.GOLDEN_APPLE,
+                'Z', Blocks.GLASS_PANE
         );
 
         // Advanced Pocket Computer
         ItemStack advancedPocketComputer = PocketComputerItemFactory.create( -1, null, ComputerFamily.Advanced, false );
         GameRegistry.addRecipe( advancedPocketComputer,
-            "XXX", "XYX", "XZX",
-            'X', Items.GOLD_INGOT,
-            'Y', Items.GOLDEN_APPLE,
-            'Z', Blocks.GLASS_PANE
+                "XXX", "XYX", "XZX",
+                'X', Items.GOLD_INGOT,
+                'Y', Items.GOLDEN_APPLE,
+                'Z', Blocks.GLASS_PANE
         );
 
         // Wireless Pocket Computer
@@ -437,8 +437,8 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
         ItemStack advancedWirelessPocketComputer = PocketComputerItemFactory.create( -1, null, ComputerFamily.Advanced, true );
 
         // Impostor Pocket Computer recipes (to fool NEI)
-        GameRegistry.addRecipe( new ImpostorRecipe( 1, 2, new ItemStack[] { wirelessModem, pocketComputer }, wirelessPocketComputer ) );
-        GameRegistry.addRecipe( new ImpostorRecipe( 1, 2, new ItemStack[] { wirelessModem, advancedPocketComputer }, advancedWirelessPocketComputer ) );
+        GameRegistry.addRecipe( new ImpostorRecipe( 1, 2, new ItemStack[]{wirelessModem, pocketComputer}, wirelessPocketComputer ) );
+        GameRegistry.addRecipe( new ImpostorRecipe( 1, 2, new ItemStack[]{wirelessModem, advancedPocketComputer}, advancedWirelessPocketComputer ) );
 
         // Skulls (Easter Egg)
         // Dan
@@ -455,7 +455,7 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
         cloudyHead.setTagCompound( tag );
         GameRegistry.addShapelessRecipe( cloudyHead, monitor, new ItemStack( Items.SKULL, 1, 1 ) );
     }
-    
+
     private void registerTileEntities()
     {
         // Tile Entities
@@ -470,7 +470,7 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
 
         // Register peripheral providers
         ComputerCraftAPI.registerPeripheralProvider( new DefaultPeripheralProvider() );
-        if( ComputerCraft.enableCommandBlock )
+        if (ComputerCraft.enableCommandBlock)
         {
             ComputerCraftAPI.registerPeripheralProvider( new CommandBlockPeripheralProvider() );
         }
@@ -481,35 +481,35 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
         // Register media providers
         ComputerCraftAPI.registerMediaProvider( new DefaultMediaProvider() );
     }
-        
+
     private void registerForgeHandlers()
     {
         ForgeHandlers handlers = new ForgeHandlers();
         MinecraftForge.EVENT_BUS.register( handlers );
         NetworkRegistry.INSTANCE.registerGuiHandler( ComputerCraft.instance, handlers );
     }
-            
+
     public class ForgeHandlers implements
-        IGuiHandler
+            IGuiHandler
     {
         private ForgeHandlers()
         {
         }
 
         // IGuiHandler implementation
-        
+
         @Override
         public Object getServerGuiElement( int id, EntityPlayer player, World world, int x, int y, int z )
         {
             BlockPos pos = new BlockPos( x, y, z );
-            switch( id )
+            switch (id)
             {
                 case ComputerCraft.diskDriveGUIID:
                 {
                     TileEntity tile = world.getTileEntity( pos );
-                    if( tile != null && tile instanceof TileDiskDrive )
+                    if (tile != null && tile instanceof TileDiskDrive)
                     {
-                        TileDiskDrive drive = (TileDiskDrive)tile;
+                        TileDiskDrive drive = (TileDiskDrive) tile;
                         return new ContainerDiskDrive( player.inventory, drive );
                     }
                     break;
@@ -517,9 +517,9 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
                 case ComputerCraft.computerGUIID:
                 {
                     TileEntity tile = world.getTileEntity( pos );
-                    if( tile != null && tile instanceof TileComputer )
+                    if (tile != null && tile instanceof TileComputer)
                     {
-                        TileComputer computer = (TileComputer)tile;
+                        TileComputer computer = (TileComputer) tile;
                         return new ContainerComputer( computer );
                     }
                     break;
@@ -527,9 +527,9 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
                 case ComputerCraft.printerGUIID:
                 {
                     TileEntity tile = world.getTileEntity( pos );
-                    if( tile != null && tile instanceof TilePrinter )
+                    if (tile != null && tile instanceof TilePrinter)
                     {
-                        TilePrinter printer = (TilePrinter)tile;
+                        TilePrinter printer = (TilePrinter) tile;
                         return new ContainerPrinter( player.inventory, printer );
                     }
                     break;
@@ -537,20 +537,20 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
                 case ComputerCraft.turtleGUIID:
                 {
                     TileEntity tile = world.getTileEntity( pos );
-                    if( tile != null && tile instanceof TileTurtle )
+                    if (tile != null && tile instanceof TileTurtle)
                     {
-                        TileTurtle turtle = (TileTurtle)tile;
+                        TileTurtle turtle = (TileTurtle) tile;
                         return new ContainerTurtle( player.inventory, turtle.getAccess() );
                     }
                     break;
                 }
                 case ComputerCraft.printoutGUIID:
                 {
-                    return new ContainerHeldItem( player.inventory );
+                    return new ContainerHeldItem( player, x == 0 ? EnumHand.MAIN_HAND : EnumHand.MAIN_HAND );
                 }
                 case ComputerCraft.pocketComputerGUIID:
                 {
-                    return new ContainerHeldItem( player.inventory );
+                    return new ContainerHeldItem( player, x == 0 ? EnumHand.MAIN_HAND : EnumHand.OFF_HAND );
                 }
             }
             return null;
@@ -560,14 +560,14 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
         public Object getClientGuiElement( int id, EntityPlayer player, World world, int x, int y, int z )
         {
             BlockPos pos = new BlockPos( x, y, z );
-            switch( id )
+            switch (id)
             {
                 case ComputerCraft.diskDriveGUIID:
                 {
                     TileEntity tile = world.getTileEntity( pos );
-                    if( tile != null && tile instanceof TileDiskDrive )
+                    if (tile != null && tile instanceof TileDiskDrive)
                     {
-                        TileDiskDrive drive = (TileDiskDrive)tile;
+                        TileDiskDrive drive = (TileDiskDrive) tile;
                         return getDiskDriveGUI( player.inventory, drive );
                     }
                     break;
@@ -575,9 +575,9 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
                 case ComputerCraft.computerGUIID:
                 {
                     TileEntity tile = world.getTileEntity( pos );
-                    if( tile != null && tile instanceof TileComputer )
+                    if (tile != null && tile instanceof TileComputer)
                     {
-                        TileComputer computer = (TileComputer)tile;
+                        TileComputer computer = (TileComputer) tile;
                         return getComputerGUI( computer );
                     }
                     break;
@@ -585,9 +585,9 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
                 case ComputerCraft.printerGUIID:
                 {
                     TileEntity tile = world.getTileEntity( pos );
-                    if( tile != null && tile instanceof TilePrinter )
+                    if (tile != null && tile instanceof TilePrinter)
                     {
-                        TilePrinter printer = (TilePrinter)tile;
+                        TilePrinter printer = (TilePrinter) tile;
                         return getPrinterGUI( player.inventory, printer );
                     }
                     break;
@@ -595,20 +595,20 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
                 case ComputerCraft.turtleGUIID:
                 {
                     TileEntity tile = world.getTileEntity( pos );
-                    if( tile != null && tile instanceof TileTurtle )
+                    if (tile != null && tile instanceof TileTurtle)
                     {
-                        TileTurtle turtle = (TileTurtle)tile;
+                        TileTurtle turtle = (TileTurtle) tile;
                         return getTurtleGUI( player.inventory, turtle );
                     }
                     break;
                 }
                 case ComputerCraft.printoutGUIID:
                 {
-                    return getPrintoutGUI( player.inventory );
+                    return getPrintoutGUI( player, x == 0 ? EnumHand.MAIN_HAND : EnumHand.OFF_HAND );
                 }
                 case ComputerCraft.pocketComputerGUIID:
                 {
-                    return getPocketComputerGUI( player.inventory );
+                    return getPocketComputerGUI( player, x == 0 ? EnumHand.MAIN_HAND : EnumHand.OFF_HAND );
                 }
             }
             return null;
@@ -631,7 +631,7 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
         @SubscribeEvent
         public void onClientTick( TickEvent.ClientTickEvent event )
         {
-            if( event.phase == TickEvent.Phase.START )
+            if (event.phase == TickEvent.Phase.START)
             {
                 ComputerCraft.clientComputerRegistry.update();
             }
@@ -640,7 +640,7 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
         @SubscribeEvent
         public void onServerTick( TickEvent.ServerTickEvent event )
         {
-            if( event.phase == TickEvent.Phase.START )
+            if (event.phase == TickEvent.Phase.START)
             {
                 MainThread.executePendingTasks();
                 ComputerCraft.serverComputerRegistry.update();

--- a/src/main/java/dan200/computercraft/shared/proxy/IComputerCraftProxy.java
+++ b/src/main/java/dan200/computercraft/shared/proxy/IComputerCraftProxy.java
@@ -14,6 +14,7 @@ import dan200.computercraft.shared.turtle.blocks.TileTurtle;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -38,8 +39,8 @@ public interface IComputerCraftProxy
     public Object getComputerGUI( TileComputer computer );
     public Object getPrinterGUI( InventoryPlayer inventory, TilePrinter printer );
     public Object getTurtleGUI( InventoryPlayer inventory, TileTurtle turtle );
-    public abstract Object getPrintoutGUI( InventoryPlayer inventory );
-    public abstract Object getPocketComputerGUI( InventoryPlayer inventory );
+    public abstract Object getPrintoutGUI( EntityPlayer player, EnumHand hand );
+    public abstract Object getPocketComputerGUI( EntityPlayer player, EnumHand hand );
 
     public File getWorldDir( World world );
     public void handlePacket( ComputerCraftPacket packet, EntityPlayer player );

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
@@ -505,7 +505,7 @@ public class TurtleBrain implements ITurtleAccess
         }
 
         // Create a new turtle
-        if( world.isBlockLoaded( pos ) && world.setBlockState( pos, oldBlock.getDefaultState(), 3 ) )
+        if( world.isBlockLoaded( pos ) && world.setBlockState( pos, oldBlock.getDefaultState(), 0 ) )
         {
             Block block = world.getBlockState( pos ).getBlock();
             if( block == oldBlock )
@@ -525,6 +525,7 @@ public class TurtleBrain implements ITurtleAccess
                     oldWorld.setBlockToAir( oldPos );
 
                     // Make sure everybody knows about it
+                    newTurtle.updateBlock();
                     newTurtle.updateInput();
                     newTurtle.updateOutput();
                     return true;

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtlePlaceCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtlePlaceCommand.java
@@ -240,6 +240,10 @@ public class TurtlePlaceCommand implements ITurtleCommand
             placed = true;
             turtlePlayer.loadInventory( stackCopy );
         }
+        else if( hitEntity.processInitialInteract( turtlePlayer, stackCopy, EnumHand.MAIN_HAND ) )
+        {
+            placed = true;
+        }
         else if( hitEntity instanceof EntityLivingBase )
         {
             placed = item.itemInteractionForEntity( stackCopy, turtlePlayer, (EntityLivingBase)hitEntity, EnumHand.MAIN_HAND );

--- a/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleTool.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleTool.java
@@ -281,8 +281,7 @@ public class TurtleTool implements ITurtleUpgrade
 
             // Destroy the block
             IBlockState previousState = world.getBlockState( newPosition );
-            Block previousBlock = previousState.getBlock();
-            world.playSound( null, newPosition, previousBlock.getSoundType().getBreakSound(), SoundCategory.BLOCKS, (previousBlock.getSoundType().getVolume() + 1.0F) / 2.0F, previousBlock.getSoundType().getPitch() * 0.8F );
+			world.playEvent(2001, newPosition, Block.getStateId(previousState));
             world.setBlockToAir( newPosition );
 
             // Remember the previous block

--- a/src/main/resources/assets/computercraft/models/item/advanced_computer.json
+++ b/src/main/resources/assets/computercraft/models/item/advanced_computer.json
@@ -1,3 +1,3 @@
 {
-    "parent": "computercraft:block/advanced_computer_blinking",
+    "parent": "computercraft:block/advanced_computer_blinking"
 }


### PR DESCRIPTION
This should enable ComputerCraft 1.80pr0 to work as expected on Minecraft 1.9.4. These changes are pretty much copy and pasted from Unborked, so should be relatively stable.

## List of bugs addressed in this PR
 - All floppy discs are white (#117)
 - Turtle rendering issues (#113, #111, #134, probably more)
 - `turtle.dig` using server side method (#122)
 - Computers not turning on (#133)
 - Ghost peripheral when moving (#131)
 - Redstone not updating (#129)
 - Pocket computers cannot be used in the off-hand (#152)