### PR TITLE
Performance improvements to fs.find

### DIFF
--- a/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
+++ b/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
@@ -466,9 +466,25 @@ public class FileSystem
     {
         // Match all the files on the system
         wildPath = sanitizePath( wildPath, true );
+
+        // If we don't have a wildcard at all just check the file exists
+        int starIndex = wildPath.indexOf( '*' );
+        if( starIndex == -1 )
+        {
+            return exists( wildPath ) ? new String[]{wildPath} : new String[0];
+        }
+
+        // Find the all non-wildcarded directories. For instance foo/bar/baz* -> foo/bar
+        int prevDir = wildPath.substring( 0, starIndex ).lastIndexOf( '/' );
+        String startDir = prevDir == -1 ? "" : wildPath.substring( 0, prevDir );
+
+        // If this isn't a directory then just abort
+        if( !isDir( startDir ) ) return new String[0];
+
+        // Scan as normal, starting from this directory
         Pattern wildPattern = Pattern.compile( "^\\Q" + wildPath.replaceAll( "\\*", "\\\\E[^\\\\/]*\\\\Q" ) + "\\E$" );
         List<String> matches = new ArrayList<String>();
-        findIn( "", matches, wildPattern );
+        findIn( startDir, matches, wildPattern );
 
         // Return matches
         String[] array = new String[ matches.size() ];


### PR DESCRIPTION
If the path includes no wildcards then it just checks it exists.

If it does, instead of scanning the entire tree, it works out the last
directory before the wildcard and starts scanning from there.

Closes #89 