### PR TITLE
Add travis.yml file to project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+
+script: ./gradlew build --no-daemon
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/s


### PR DESCRIPTION
Travis CI is a free continuous integration server available for free for open source projects.

This is the example run of this commit on travis CI.
https://travis-ci.org/JLLeitschuh/ComputerCraft/builds/227628331

Because I don't have permission to modify your repository or attach github integrations to your repository you will have to enable travis CI.

To do so, go to the travis CI site:
https://travis-ci.org/

Once you have given travis CI permission through github you can enable it on this project.

Simply toggle on travis CI for this project on the https://travis-ci.org/profile/dan200 page.
![screen shot 2017-05-01 at 12 04 18 pm](https://cloud.githubusercontent.com/assets/1323708/25584997/7193af3c-2e66-11e7-8267-b1ccb654d1ed.png)

You can then use travis CI to ensure that fixes and PR's still compile.

Since you don't seem to have any unit tests you don't really have any guarantees there but at least this gives you the peace of mind that everything compiles.

If you are interested, travis could be configured to automatically do releases on a monthly basis or even after every PR is merged.
