### PR TITLE
Require the player to be interacting with the computer when typing

### DIFF
--- a/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
+++ b/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
@@ -20,6 +20,7 @@ import dan200.computercraft.shared.network.ComputerCraftPacket;
 import dan200.computercraft.shared.peripheral.diskdrive.TileDiskDrive;
 import dan200.computercraft.shared.peripheral.monitor.TileMonitor;
 import dan200.computercraft.shared.peripheral.printer.TilePrinter;
+import dan200.computercraft.shared.pocket.inventory.ContainerPocketComputer;
 import dan200.computercraft.shared.pocket.items.ItemPocketComputer;
 import dan200.computercraft.shared.proxy.ComputerCraftProxyCommon;
 import dan200.computercraft.shared.turtle.blocks.TileTurtle;
@@ -325,7 +326,7 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
     @Override
     public Object getPocketComputerGUI( EntityPlayer player, EnumHand hand )
     {
-        ContainerHeldItem container = new ContainerHeldItem( player, hand );
+        ContainerPocketComputer container = new ContainerPocketComputer( player, hand );
         if( container.getStack() != null && container.getStack().getItem() instanceof ItemPocketComputer )
         {
             return new GuiPocketComputer( container );

--- a/src/main/java/dan200/computercraft/shared/computer/core/IContainerComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/core/IContainerComputer.java
@@ -1,0 +1,20 @@
+package dan200.computercraft.shared.computer.core;
+
+import javax.annotation.Nullable;
+
+/**
+ * An instance of {@link net.minecraft.inventory.Container} which provides a computer. You should implement this
+ * if you provide custom computers/GUIs to interact with them.
+ */
+public interface IContainerComputer
+{
+    /**
+     * Get the computer you are interacting with.
+     *
+     * This will only be called on the server.
+     *
+     * @return The computer you are interacting with.
+     */
+    @Nullable
+    IComputer getComputer();
+}

--- a/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
@@ -20,6 +20,7 @@ import dan200.computercraft.shared.network.ComputerCraftPacket;
 import dan200.computercraft.shared.network.INetworkedThing;
 import dan200.computercraft.shared.util.NBTUtil;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -351,6 +352,17 @@ public class ServerComputer extends ServerTerminal
     @Override
     public void handlePacket( ComputerCraftPacket packet, EntityPlayer sender )
     {
+        // Allow Computer/Tile updates as they may happen at any time.
+        if (packet.requiresContainer()) {
+            if (sender == null) return;
+
+            Container container = sender.openContainer;
+            if (!(container instanceof IContainerComputer)) return;
+
+            IComputer computer = ((IContainerComputer) container).getComputer();
+            if (computer != this) return;
+        }
+
         // Receive packets sent from the client to the server
         switch( packet.m_packetType )
         {

--- a/src/main/java/dan200/computercraft/shared/computer/inventory/ContainerComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/inventory/ContainerComputer.java
@@ -7,10 +7,15 @@
 package dan200.computercraft.shared.computer.inventory;
 
 import dan200.computercraft.shared.computer.blocks.TileComputer;
+import dan200.computercraft.shared.computer.core.IComputer;
+import dan200.computercraft.shared.computer.core.IContainerComputer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 
+import javax.annotation.Nullable;
+
 public class ContainerComputer extends Container
+    implements IContainerComputer
 {
     private TileComputer m_computer;
     
@@ -23,5 +28,12 @@ public class ContainerComputer extends Container
     public boolean canInteractWith( EntityPlayer player )
     {
         return m_computer.isUseableByPlayer( player );
+    }
+
+    @Nullable
+    @Override
+    public IComputer getComputer()
+    {
+        return m_computer.getServerComputer();
     }
 }

--- a/src/main/java/dan200/computercraft/shared/network/ComputerCraftPacket.java
+++ b/src/main/java/dan200/computercraft/shared/network/ComputerCraftPacket.java
@@ -224,4 +224,12 @@ public class ComputerCraftPacket
             }
         }
     }
+
+    /**
+     * Determine whether this packet requires the player to be interacting with the
+     * target.
+     */
+    public boolean requiresContainer() {
+        return m_packetType != RequestComputerUpdate && m_packetType != RequestTileEntityUpdate;
+    }
 }

--- a/src/main/java/dan200/computercraft/shared/pocket/inventory/ContainerPocketComputer.java
+++ b/src/main/java/dan200/computercraft/shared/pocket/inventory/ContainerPocketComputer.java
@@ -1,0 +1,35 @@
+package dan200.computercraft.shared.pocket.inventory;
+
+import dan200.computercraft.shared.computer.core.IComputer;
+import dan200.computercraft.shared.computer.core.IContainerComputer;
+import dan200.computercraft.shared.media.inventory.ContainerHeldItem;
+import dan200.computercraft.shared.pocket.items.ItemPocketComputer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
+
+import javax.annotation.Nullable;
+
+public class ContainerPocketComputer extends ContainerHeldItem
+    implements IContainerComputer
+{
+    public ContainerPocketComputer( EntityPlayer player, EnumHand hand )
+    {
+        super( player, hand );
+    }
+
+    @Nullable
+    @Override
+    public IComputer getComputer()
+    {
+        ItemStack stack = getStack();
+        if( stack != null && stack.getItem() instanceof ItemPocketComputer )
+        {
+            return ((ItemPocketComputer) stack.getItem()).getServerComputer( stack );
+        }
+        else
+        {
+            return null;
+        }
+    }
+}

--- a/src/main/java/dan200/computercraft/shared/pocket/items/ItemPocketComputer.java
+++ b/src/main/java/dan200/computercraft/shared/pocket/items/ItemPocketComputer.java
@@ -279,6 +279,16 @@ public class ItemPocketComputer extends Item implements IComputerItem, IMedia
         return computer;
     }
 
+    public ServerComputer getServerComputer( ItemStack stack )
+    {
+        int instanceID = getInstanceID( stack );
+        if( instanceID >= 0 )
+        {
+            return ComputerCraft.serverComputerRegistry.get( instanceID );
+        }
+        return null;
+    }
+
     public ClientComputer createClientComputer( ItemStack stack )
     {
         int instanceID = getInstanceID( stack );

--- a/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
+++ b/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
@@ -42,6 +42,7 @@ import dan200.computercraft.shared.peripheral.modem.TileWirelessModem;
 import dan200.computercraft.shared.peripheral.monitor.TileMonitor;
 import dan200.computercraft.shared.peripheral.printer.ContainerPrinter;
 import dan200.computercraft.shared.peripheral.printer.TilePrinter;
+import dan200.computercraft.shared.pocket.inventory.ContainerPocketComputer;
 import dan200.computercraft.shared.pocket.items.ItemPocketComputer;
 import dan200.computercraft.shared.pocket.items.PocketComputerItemFactory;
 import dan200.computercraft.shared.pocket.recipes.PocketComputerUpgradeRecipe;
@@ -540,7 +541,7 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
                     if (tile != null && tile instanceof TileTurtle)
                     {
                         TileTurtle turtle = (TileTurtle) tile;
-                        return new ContainerTurtle( player.inventory, turtle.getAccess() );
+                        return new ContainerTurtle( player.inventory, turtle.getAccess(), turtle.getServerComputer() );
                     }
                     break;
                 }
@@ -550,7 +551,7 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
                 }
                 case ComputerCraft.pocketComputerGUIID:
                 {
-                    return new ContainerHeldItem( player, x == 0 ? EnumHand.MAIN_HAND : EnumHand.OFF_HAND );
+                    return new ContainerPocketComputer( player, x == 0 ? EnumHand.MAIN_HAND : EnumHand.OFF_HAND );
                 }
             }
             return null;

--- a/src/main/java/dan200/computercraft/shared/turtle/inventory/ContainerTurtle.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/inventory/ContainerTurtle.java
@@ -7,6 +7,8 @@
 package dan200.computercraft.shared.turtle.inventory;
 
 import dan200.computercraft.api.turtle.ITurtleAccess;
+import dan200.computercraft.shared.computer.core.IComputer;
+import dan200.computercraft.shared.computer.core.IContainerComputer;
 import dan200.computercraft.shared.turtle.blocks.TileTurtle;
 import dan200.computercraft.shared.turtle.core.TurtleBrain;
 import net.minecraft.entity.player.EntityPlayer;
@@ -16,7 +18,10 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
+import javax.annotation.Nullable;
+
 public class ContainerTurtle extends Container
+    implements IContainerComputer
 {
     private static final int PROGRESS_ID_SELECTED_SLOT = 0;
 
@@ -24,6 +29,7 @@ public class ContainerTurtle extends Container
     public final int m_turtleInvStartX;
 
     protected ITurtleAccess m_turtle;
+    private IComputer m_computer;
     private int m_selectedSlot;
 
     protected ContainerTurtle( IInventory playerInventory, ITurtleAccess turtle, int playerInvStartY, int turtleInvStartX )
@@ -69,6 +75,12 @@ public class ContainerTurtle extends Container
     public ContainerTurtle( IInventory playerInventory, ITurtleAccess turtle )
     {
         this( playerInventory, turtle, 134, 175 );
+    }
+
+    public ContainerTurtle( IInventory playerInventory, ITurtleAccess turtle, IComputer computer )
+    {
+        this( playerInventory, turtle );
+        m_computer = computer;
     }
 
     public int getSelectedSlot()
@@ -177,5 +189,12 @@ public class ContainerTurtle extends Container
             return tryItemMerge( player, slotNum, 0, 16, false );
         }
         return null;
+    }
+
+    @Nullable
+    @Override
+    public IComputer getComputer()
+    {
+        return m_computer;
     }
 }


### PR DESCRIPTION
Currently it is possible to fire events on any computer, irrespective of how far away you are from it. Whilst this has it's uses (such as MoarPeripherals's keyboard), it is subject to abuse.

This PR adds a `IContainerComputer` (not to be confused with `IComputerContainer`) which `Container`s can implement. When receiving a packet, the `ServerComputer` will ensure that the player has a container for this computer open, discarding the packet if not.

This will break mods which add additional computers or keyboard-esque items, but I don't see that as a major issue.

**Note:** I'm not 100% happy with this implementation, so any feedback welcome.