### PR TITLE
Various extensions to the HTTP API

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/HTTPAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/HTTPAPI.java
@@ -69,7 +69,7 @@ public class HTTPAPI implements ILuaAPI
         }
     }
     
-    private static ILuaObject wrapBufferedReader( final BufferedReader reader, final int responseCode, final Map<String, Map<Integer, String>> responseHeaders )
+    private static ILuaObject wrapBufferedReader( final BufferedReader reader, final int responseCode, final Map<String, String> responseHeaders )
     {
         return new ILuaObject() {
             @Override

--- a/src/main/java/dan200/computercraft/core/apis/HTTPRequest.java
+++ b/src/main/java/dan200/computercraft/core/apis/HTTPRequest.java
@@ -6,6 +6,7 @@
 
 package dan200.computercraft.core.apis;
 
+import com.google.common.base.Joiner;
 import dan200.computercraft.ComputerCraft;
 
 import java.io.*;
@@ -207,16 +208,10 @@ public class HTTPRequest
                             m_result = result.toString();
                             m_responseCode = connection.getResponseCode();
 
-                            Map<String, Map<Integer, String>> headers = m_responseHeaders = new HashMap<String, Map<Integer, String>>();
+                            Joiner joiner = Joiner.on( ',' );
+                            Map<String, String> headers = m_responseHeaders = new HashMap<String, String>();
                             for (Map.Entry<String, List<String>> header : connection.getHeaderFields().entrySet()) {
-                                Map<Integer, String> values = new HashMap<Integer, String>();
-
-                                int i = 0;
-                                for (String value : header.getValue()) {
-                                    values.put(++i, value);
-                                }
-
-                                headers.put(header.getKey(), values);
+                                headers.put(header.getKey(), joiner.join( header.getValue() ));
                             }
                         }
                     }
@@ -264,7 +259,7 @@ public class HTTPRequest
         }
     }
 
-    public Map<String, Map<Integer, String>> getResponseHeaders() {
+    public Map<String, String> getResponseHeaders() {
         synchronized (m_lock) {
             return m_responseHeaders;
         }
@@ -299,5 +294,5 @@ public class HTTPRequest
     private boolean m_success;
     private String m_result;
     private int m_responseCode;
-    private Map<String, Map<Integer, String>> m_responseHeaders;
+    private Map<String, String> m_responseHeaders;
 }

--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -643,11 +643,11 @@ if http then
         local ok, err = nativeHTTPRequest( _url, _post, _headers )
         if ok then
             while true do
-                local event, param1, param2 = os.pullEvent()
+                local event, param1, param2, param3 = os.pullEvent()
                 if event == "http_success" and param1 == _url then
                     return param2
                 elseif event == "http_failure" and param1 == _url then
-                    return nil, param2
+                    return nil, param2, param3
                 end
             end
         end

--- a/src/main/resources/assets/computercraft/lua/rom/help/changelog
+++ b/src/main/resources/assets/computercraft/lua/rom/help/changelog
@@ -1,3 +1,8 @@
+New Features in ComputerCraft 1.80:
+
+* Added .getResponseHeaders() to HTTP responses.
+* Return a HTTP response when a HTTP error occurs.
+
 New Features in ComputerCraft 1.79:
 
 * Ported ComputerCraftEdu to Minecraft 1.8.9

--- a/src/main/resources/assets/computercraft/lua/rom/help/http
+++ b/src/main/resources/assets/computercraft/lua/rom/help/http
@@ -5,4 +5,4 @@ http.get( url, [headers] )
 http.post( url, postData, [headers] )
 
 The HTTP API may be disabled in ComputerCraft.cfg
-A period of time after a http.request() call is made, a "http_success" or "http_failure" event will be raised. Arguments are the url and a file handle if successful. http.get() and http.post() block until this event fires instead.
+A period of time after a http.request() call is made, a "http_success" or "http_failure" event will be raised. Arguments are the url and a file handle if successful. Arguments are nil, an error message, and (optionally) a file handle if the request failed. http.get() and http.post() block until this event fires instead.

--- a/src/main/resources/assets/computercraft/lua/rom/help/whatsnew
+++ b/src/main/resources/assets/computercraft/lua/rom/help/whatsnew
@@ -1,6 +1,6 @@
-New Features in ComputerCraft 1.79:
+New Features in ComputerCraft 1.80:
 
-* Ported ComputerCraftEdu to Minecraft 1.8.9
-* Fixed a handful of bugs in ComputerCraft
+* Added .getResponseHeaders() to HTTP responses.
+* Return a HTTP response when a HTTP error occurs.
 
 Type "help changelog" to see the full version history.


### PR DESCRIPTION
This adds a couple of additional features to the `http` API.

 - A response is returned on the event of a HTTP error (such as 404).
 - Responses include the response headers.

## Examples
### Fetching an invalid page:
```lua
local response, err, err_response = http.get("https://google.com/404.txt")
if response == nil then
    printError("Cannot connect: " .. err)
   if err_response then print(err_response:readAll():find("<title>[^<]+</title>")) end
end
```
will display an error message and the title of the page.

### Accessing response headers
```lua
local response, err = http.get("https://google.com/404.txt")
if reponse == nil then
    printError("Cannot connect: " .. err)
else
    print("Connected OK.")
    print(textutils.serialize(response.getResponseHeaders()))
end
displays something like:
```lua
{
  [ "X-XSS-Protection" ] = {
    "1; mode=block",
  },
  Date = {
    "Mon, 01 May 2017 16:33:21 GMT",
  },
}
```