### PR TITLE
Create a CONTRIBUTING.md file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ deploy
 *.ipr
 *.iws
 *.iml
+.idea/
 .gradle
 luaj-2.0.3/lib
 luaj-2.0.3/*.jar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+Contributing
+============
+
+While ComputerCraft will no longer be actively developed by Daniel Ratcliffe, you may still contribute pull requests which will be reviewed and incorporated into releases periodically. A pull requests is more likely to be accepted if it meets the following criteria:
+
+* It does not add any new dependencies for compiling, running or using the mod.
+* It does not break compatibility with world saves or programs created with previous versions of the mod.
+* It does not add unneccessary complexity for users of the mod, and maintains the accessibility for which the mod is known.
+* It does not add unneccessary complexity or stylistic changes to the code, especially where functionality is not being changed.
+* It does not create bugs!
+
+The pull requests most likely to be accepted are those which fix bugs, simplify code, or make the mod compatible with newer versions of Minecraft.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 Contributing
 ============
 
-While ComputerCraft will no longer be actively developed by Daniel Ratcliffe, you may still contribute pull requests which will be reviewed and incorporated into releases periodically. A pull requests is more likely to be accepted if it meets the following criteria:
+While ComputerCraft will no longer be actively developed by Daniel Ratcliffe, you may still contribute pull requests which will be reviewed and incorporated into releases periodically. A pull request is more likely to be accepted if it meets the following criteria:
 
 * It does not add any new dependencies for compiling, running or using the mod.
 * It does not break compatibility with world saves or programs created with previous versions of the mod.
-* It does not add unneccessary complexity for users of the mod, and maintains the accessibility for which the mod is known.
-* It does not add unneccessary complexity or stylistic changes to the code, especially where functionality is not being changed.
+* It does not add unnecessary complexity for users of the mod, and maintains the accessibility for which the mod is known.
+* It does not add unnecessary complexity or stylistic changes to the code, especially where functionality is not being changed.
 * It does not create bugs!
 
 The pull requests most likely to be accepted are those which fix bugs, simplify code, or make the mod compatible with newer versions of Minecraft.

--- a/README.md
+++ b/README.md
@@ -11,16 +11,3 @@ About this Repository
 ComputerCraft was originally released in late 2011 by [Daniel Ratcliffe](https://twitter.com/DanTwoHundred). In early 2017, after working on the mod solo for five years, it was decided to release the source code publicly to allow Dan to devote time to other projects. This repository marks the first public release of this source code.
 
 The code in this repository will always represent the "bleeding edge" of the ComputerCraft codebase, but stable builds back to 1.79 will be marked on the [Releases](https://github.com/dan200/ComputerCraft/releases) page.
-
-Contributing
-============
-
-While ComputerCraft will no longer be actively developed by Daniel Ratcliffe, you may still contribute pull requests which will be reviewed and incorporated into releases periodically. A pull requests is more likely to be accepted if it meets the following criteria:
-
-* It does not add any new dependencies for compiling, running or using the mod.
-* It does not break compatibility with world saves or programs created with previous versions of the mod.
-* It does not add unneccessary complexity for users of the mod, and maintains the accessibility for which the mod is known.
-* It does not add unneccessary complexity or stylistic changes to the code, especially where functionality is not being changed.
-* It does not create bugs!
-
-The pull requests most likely to be accepted are those which fix bugs, simplify code, or make the mod compatible with newer versions of Minecraft.


### PR DESCRIPTION
This PR moves the "Contributing" section from `README.md` into a new file called `CONTRIBUTING.md`, which GitHub will automatically link to on the Pull Request creation page ([see this](https://github.com/blog/1184-contributing-guidelines)).

This should make the readme less noisy for passersby, while confronting actual contributors directly.