### PR TITLE
Fix redstone connectivity on turtles

### DIFF
--- a/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputerBase.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputerBase.java
@@ -22,10 +22,10 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ITickable;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.EnumFacing;
 
 public abstract class TileComputerBase extends TileGeneric
     implements IComputerTile, IDirectionalTile, ITickable
@@ -143,7 +143,8 @@ public abstract class TileComputerBase extends TileGeneric
     @Override
     public boolean getRedstoneConnectivity( EnumFacing side )
     {
-        int localDir = remapLocalSide( DirectionUtil.toLocal( this, side ) );
+        if( side == null ) return false;
+        int localDir = remapLocalSide( DirectionUtil.toLocal( this, side.getOpposite() ) );
         return !isRedstoneBlockedOnSide( localDir );
     }
 


### PR DESCRIPTION
The side marks the direction relative to the wire, rather than the side of the block it is attempting to connect to. Therefore needs to be flipped.

Closes #149

## Screenshots:
Before: note redstone connects to side with modem.
![2017-05-01_21 42 19](https://cloud.githubusercontent.com/assets/4346137/25594235/942d8e0e-2eb7-11e7-8c8b-93b03d228e3a.png)

After: redstone now connects to side without modem, and is blocked on side with modem. This is the expected behaviour.
![2017-05-01_21 42 05](https://cloud.githubusercontent.com/assets/4346137/25594255/aadc5a5e-2eb7-11e7-8ca5-0aa8874945e6.png)
