### PR TITLE
Impose additional limitations on disk and computer labels

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/OSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/OSAPI.java
@@ -8,6 +8,7 @@ package dan200.computercraft.core.apis;
 
 import dan200.computercraft.api.lua.ILuaContext;
 import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.shared.util.StringUtil;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -266,11 +267,7 @@ public class OSAPI implements ILuaAPI
                     {
                         throw new LuaException( "Expected string or nil" );
                     }
-                    label = (String)args[0];
-                    if( label.length() > 32 )
-                    {
-                        label = label.substring( 0, 32 );
-                    }
+                    label = StringUtil.normaliseLabel( (String) args[0] );
                 }
                 m_apiEnvironment.setLabel( label );
                 return null;

--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
@@ -12,6 +12,7 @@ import dan200.computercraft.api.media.IMedia;
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.shared.media.items.ItemDiskLegacy;
+import dan200.computercraft.shared.util.StringUtil;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
@@ -87,6 +88,7 @@ public class DiskDrivePeripheral implements IPeripheral
                 if( media != null )
                 {
                     ItemStack disk = m_diskDrive.getDiskStack();
+                    label = StringUtil.normaliseLabel( label );
                     if( media.setLabel( disk, label ) )
                     {
                         m_diskDrive.setDiskStack( disk );

--- a/src/main/java/dan200/computercraft/shared/util/StringUtil.java
+++ b/src/main/java/dan200/computercraft/shared/util/StringUtil.java
@@ -1,0 +1,20 @@
+package dan200.computercraft.shared.util;
+
+import java.util.regex.Pattern;
+
+public class StringUtil
+{
+    private static final Pattern INVALID_PATTERN = Pattern.compile( "[^ -~]" );
+
+    public static String normaliseLabel( String label )
+    {
+        label = INVALID_PATTERN.matcher( label ).replaceAll( "" );
+
+        if( label.length() > 32 )
+        {
+            label = label.substring( 0, 32 );
+        }
+
+        return label;
+    }
+}

--- a/src/main/java/dan200/computercraft/shared/util/StringUtil.java
+++ b/src/main/java/dan200/computercraft/shared/util/StringUtil.java
@@ -1,20 +1,20 @@
 package dan200.computercraft.shared.util;
 
-import java.util.regex.Pattern;
-
 public class StringUtil
 {
-    private static final Pattern INVALID_PATTERN = Pattern.compile( "[^ -~]" );
-
     public static String normaliseLabel( String label )
     {
-        label = INVALID_PATTERN.matcher( label ).replaceAll( "" );
+        StringBuilder builder = new StringBuilder();
 
-        if( label.length() > 32 )
+        for (int i = 0; i < label.length() && builder.length() < 32; i++)
         {
-            label = label.substring( 0, 32 );
+            char c = label.charAt( i );
+            if( (c >= ' ' && c <= '~') || (c >= 161 && c <= 172) || (c >= 174 && c <= 255) )
+            {
+                builder.append( c );
+            }
         }
 
-        return label;
+        return builder.toString();
     }
 }

--- a/src/main/java/dan200/computercraft/shared/util/StringUtil.java
+++ b/src/main/java/dan200/computercraft/shared/util/StringUtil.java
@@ -4,6 +4,8 @@ public class StringUtil
 {
     public static String normaliseLabel( String label )
     {
+        if( label == null ) return null;
+
         int length = Math.min( 32, label.length() );
         StringBuilder builder = new StringBuilder( length );
         for (int i = 0; i < length; i++)

--- a/src/main/java/dan200/computercraft/shared/util/StringUtil.java
+++ b/src/main/java/dan200/computercraft/shared/util/StringUtil.java
@@ -4,14 +4,18 @@ public class StringUtil
 {
     public static String normaliseLabel( String label )
     {
-        StringBuilder builder = new StringBuilder();
-
-        for (int i = 0; i < label.length() && builder.length() < 32; i++)
+        int length = Math.min( 32, label.length() );
+        StringBuilder builder = new StringBuilder( length );
+        for (int i = 0; i < length; i++)
         {
             char c = label.charAt( i );
             if( (c >= ' ' && c <= '~') || (c >= 161 && c <= 172) || (c >= 174 && c <= 255) )
             {
                 builder.append( c );
+            }
+            else
+            {
+                builder.append( '?' );
             }
         }
 


### PR DESCRIPTION
 - Disk labels are limited at 32 characters (like computer lables are)
 - Labels can now only include characters within the printable range (` ` to `~`).

I wasn't sure where to put the normalisation function so created a new class for it. Please say if there is a better place for it.

Closes #147 