### PR TITLE
Various model improvements

### DIFF
--- a/src/main/resources/assets/computercraft/models/block/modem.json
+++ b/src/main/resources/assets/computercraft/models/block/modem.json
@@ -16,5 +16,37 @@
                 "east":  { "uv": [ 13, 2, 16, 14 ], "texture": "#front" }
             }
         }
-    ]
+    ],
+    "display": {
+        "gui": {
+            "rotation": [ 30, 45, 0 ],
+            "translation": [ 3.2, -2, 0],
+            "scale":[ 0.75, 0.75, 0.75 ]
+        },
+        "ground": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 3, 0],
+            "scale":[ 0.25, 0.25, 0.25 ]
+        },
+        "fixed": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 0, 0],
+            "scale":[ 0.5, 0.5, 0.5 ]
+        },
+        "thirdperson_righthand": {
+            "rotation": [ 75, 180, 0 ],
+            "translation": [ 0, 2.5, 0],
+            "scale": [ 0.375, 0.375, 0.375 ]
+        },
+        "firstperson_righthand": {
+            "rotation": [ 0, 45, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale": [ 0.40, 0.40, 0.40 ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [ 0, 45, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale": [ 0.40, 0.40, 0.40 ]
+        }
+    }
 }

--- a/src/main/resources/assets/computercraft/models/item/advanced_pocket_computer_blinking.json
+++ b/src/main/resources/assets/computercraft/models/item/advanced_pocket_computer_blinking.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/pocketComputerBlinkAdvanced"
     }

--- a/src/main/resources/assets/computercraft/models/item/advanced_pocket_computer_blinking_modem_on.json
+++ b/src/main/resources/assets/computercraft/models/item/advanced_pocket_computer_blinking_modem_on.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/pocketComputerBlinkAdvanced",
         "layer1": "computercraft:items/pocketComputerModemLight"

--- a/src/main/resources/assets/computercraft/models/item/advanced_pocket_computer_off.json
+++ b/src/main/resources/assets/computercraft/models/item/advanced_pocket_computer_off.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/pocketComputerAdvanced"
     }

--- a/src/main/resources/assets/computercraft/models/item/advanced_pocket_computer_on.json
+++ b/src/main/resources/assets/computercraft/models/item/advanced_pocket_computer_on.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/pocketComputerOnAdvanced"
     }

--- a/src/main/resources/assets/computercraft/models/item/advanced_pocket_computer_on_modem_on.json
+++ b/src/main/resources/assets/computercraft/models/item/advanced_pocket_computer_on_modem_on.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/pocketComputerOnAdvanced",
         "layer1": "computercraft:items/pocketComputerModemLight"

--- a/src/main/resources/assets/computercraft/models/item/book.json
+++ b/src/main/resources/assets/computercraft/models/item/book.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/book"
     }

--- a/src/main/resources/assets/computercraft/models/item/disk.json
+++ b/src/main/resources/assets/computercraft/models/item/disk.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/diskFrame",
         "layer1": "computercraft:items/diskColour"

--- a/src/main/resources/assets/computercraft/models/item/diskExpanded.json
+++ b/src/main/resources/assets/computercraft/models/item/diskExpanded.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/diskFrame",
         "layer1": "computercraft:items/diskColour"

--- a/src/main/resources/assets/computercraft/models/item/pages.json
+++ b/src/main/resources/assets/computercraft/models/item/pages.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/pageBundle"
     }

--- a/src/main/resources/assets/computercraft/models/item/pocketComputer.json
+++ b/src/main/resources/assets/computercraft/models/item/pocketComputer.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/pocketComputer"
     }

--- a/src/main/resources/assets/computercraft/models/item/pocket_computer_blinking.json
+++ b/src/main/resources/assets/computercraft/models/item/pocket_computer_blinking.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/pocketComputerBlink"
     }

--- a/src/main/resources/assets/computercraft/models/item/pocket_computer_blinking_modem_on.json
+++ b/src/main/resources/assets/computercraft/models/item/pocket_computer_blinking_modem_on.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/pocketComputerBlink",
         "layer1": "computercraft:items/pocketComputerModemLight"

--- a/src/main/resources/assets/computercraft/models/item/pocket_computer_on.json
+++ b/src/main/resources/assets/computercraft/models/item/pocket_computer_on.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/pocketComputerOn"
     }

--- a/src/main/resources/assets/computercraft/models/item/pocket_computer_on_modem_on.json
+++ b/src/main/resources/assets/computercraft/models/item/pocket_computer_on_modem_on.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/pocketComputerOn",
         "layer1": "computercraft:items/pocketComputerModemLight"

--- a/src/main/resources/assets/computercraft/models/item/printout.json
+++ b/src/main/resources/assets/computercraft/models/item/printout.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/page"
     }

--- a/src/main/resources/assets/computercraft/models/item/treasureDisk.json
+++ b/src/main/resources/assets/computercraft/models/item/treasureDisk.json
@@ -1,5 +1,5 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "computercraft:items/diskFrame",
         "layer1": "computercraft:items/diskColour"


### PR DESCRIPTION
This ensures the main modem texture is facing towards the screen. Sorry, I should have caught this in my earlier PR.

Before:
![java_2017-05-01_22-38-00](https://cloud.githubusercontent.com/assets/4346137/25596046/261db440-2ebf-11e7-85f1-24310dbf9de9.png)

After:
![java_2017-05-01_22-36-24](https://cloud.githubusercontent.com/assets/4346137/25596044/21b21a0e-2ebf-11e7-8497-e1f8f685d00a.png)

We also use `item/generated` instead of `builtin/generated` for items, meaning they look better when in entity form and 3rd person.
