### PR TITLE
Configurable file descriptor limit

### DIFF
--- a/src/main/java/dan200/computercraft/ComputerCraft.java
+++ b/src/main/java/dan200/computercraft/ComputerCraft.java
@@ -242,6 +242,10 @@ public class ComputerCraft
         prop.setComment( "The disk space limit for floppy disks, in bytes" );
         floppySpaceLimit = prop.getInt();
 
+        prop = config.get(Configuration.CATEGORY_GENERAL, "maximumFilesOpen", maximumFilesOpen);
+        prop.setComment( "How many files a computer can have open at the same time" );
+        maximumFilesOpen = prop.getInt();
+
         prop = config.get(Configuration.CATEGORY_GENERAL, "turtlesNeedFuel", turtlesNeedFuel);
         prop.setComment( "Set whether Turtles require fuel to move" );
         turtlesNeedFuel = prop.getBoolean( turtlesNeedFuel );

--- a/src/main/java/dan200/computercraft/ComputerCraft.java
+++ b/src/main/java/dan200/computercraft/ComputerCraft.java
@@ -123,6 +123,7 @@ public class ComputerCraft
 
     public static int computerSpaceLimit = 1000 * 1000;
     public static int floppySpaceLimit = 125 * 1000;
+    public static int maximumFilesOpen = 128;
 
     // Blocks and Items
     public static class Blocks

--- a/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
+++ b/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
@@ -651,12 +651,20 @@ public class FileSystem
         }
     }
 
-    private synchronized IMountedFile openFile( IMountedFile file ) throws FileSystemException
+    private synchronized IMountedFile openFile( IMountedFile file, Closeable handle ) throws FileSystemException
     {
         synchronized( m_openFiles )
         {
             if( m_openFiles.size() >= ComputerCraft.maximumFilesOpen )
             {
+                if( handle != null )
+                {
+                    try {
+                        handle.close();
+                    } catch ( IOException ignored ) {
+                        // shrug
+                    }
+                }
                 throw new FileSystemException("Too many files already open");
             }
 
@@ -721,7 +729,7 @@ public class FileSystem
                     throw new UnsupportedOperationException();
                 }
             };
-            return (IMountedFileNormal) openFile( file );
+            return (IMountedFileNormal) openFile( file, reader );
         }
         return null;
     }
@@ -773,7 +781,7 @@ public class FileSystem
                     writer.flush();
                 }
             };
-            return (IMountedFileNormal) openFile( file );
+            return (IMountedFileNormal) openFile( file, writer );
         }
         return null;
     }
@@ -811,7 +819,7 @@ public class FileSystem
                     throw new UnsupportedOperationException();
                 }
             };
-            return (IMountedFileBinary) openFile( file );
+            return (IMountedFileBinary) openFile( file, stream );
         }
         return null;
     }
@@ -849,7 +857,7 @@ public class FileSystem
                     stream.flush();
                 }
             };
-            return (IMountedFileBinary) openFile( file );
+            return (IMountedFileBinary) openFile( file, stream );
         }
         return null;
     }

--- a/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
+++ b/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
@@ -651,7 +651,7 @@ public class FileSystem
         }
     }
 
-    private synchronized IMountedFile openFile( IMountedFile file, Closeable handle ) throws FileSystemException
+    private synchronized <T extends IMountedFile> T openFile(T file, Closeable handle) throws FileSystemException
     {
         synchronized( m_openFiles )
         {
@@ -729,7 +729,7 @@ public class FileSystem
                     throw new UnsupportedOperationException();
                 }
             };
-            return (IMountedFileNormal) openFile( file, reader );
+            return openFile( file, reader );
         }
         return null;
     }
@@ -781,7 +781,7 @@ public class FileSystem
                     writer.flush();
                 }
             };
-            return (IMountedFileNormal) openFile( file, writer );
+            return openFile( file, writer );
         }
         return null;
     }
@@ -819,7 +819,7 @@ public class FileSystem
                     throw new UnsupportedOperationException();
                 }
             };
-            return (IMountedFileBinary) openFile( file, stream );
+            return openFile( file, stream );
         }
         return null;
     }
@@ -857,7 +857,7 @@ public class FileSystem
                     stream.flush();
                 }
             };
-            return (IMountedFileBinary) openFile( file, stream );
+            return openFile( file, stream );
         }
         return null;
     }

--- a/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
+++ b/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
@@ -6,6 +6,7 @@
 
 package dan200.computercraft.core.filesystem;
 
+import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.api.filesystem.IMount;
 import dan200.computercraft.api.filesystem.IWritableMount;
 
@@ -654,7 +655,7 @@ public class FileSystem
     {
         synchronized( m_openFiles )
         {
-            if( m_openFiles.size() >= 4 )
+            if( m_openFiles.size() >= ComputerCraft.maximumFilesOpen )
             {
                 throw new FileSystemException("Too many files already open");
             }

--- a/src/main/resources/assets/computercraft/lang/en_US.lang
+++ b/src/main/resources/assets/computercraft/lang/en_US.lang
@@ -56,3 +56,4 @@ gui.computercraft:config.turtle_fuel_limit=Turtle fuel limit
 gui.computercraft:config.advanced_turtle_fuel_limit=Advanced Turtle fuel limit
 gui.computercraft:config.turtles_obey_block_protection=Turtles obey block protection
 gui.computercraft:config.turtles_can_push=Turtles can push entities
+gui.computercraft:config.maximum_files_open=Maximum files open per computer


### PR DESCRIPTION
This adds a configurable file handle limit, defaulting to 128, to prevent players from exhausting the server's file descriptors. This is in response to issue #144.

The limit is always active and can be configured with `I:maximumFilesOpen`. To "disable" it, just set the limit to a really high value. Negative or zero values will simply prevent files from being read and written, making all computers useless.

Once the limit is reached, `fs.open` will return `nil`.