### PR TITLE
Make threads daemon threads

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/HTTPRequest.java
+++ b/src/main/java/dan200/computercraft/core/apis/HTTPRequest.java
@@ -231,7 +231,7 @@ public class HTTPRequest
                 }
             }
         } );
-        
+        thread.setDaemon(true);
         thread.start();
     }
     

--- a/src/main/java/dan200/computercraft/core/computer/ComputerThread.java
+++ b/src/main/java/dan200/computercraft/core/computer/ComputerThread.java
@@ -113,6 +113,7 @@ public class ComputerThread
                                 } );
                                 
                                 // Run the task
+                                worker.setDaemon(true);
                                 worker.start();
                                 worker.join( 7000 );
                                 
@@ -173,7 +174,8 @@ public class ComputerThread
                     }
                 }
             }, "Computer Dispatch Thread" );
-                
+
+            m_thread.setDaemon(true);
             m_thread.start();
             m_running = true;
         }


### PR DESCRIPTION
Threads that aren't daemon threads can keep the JVM from shutting down.
I'm certain that this doesn't happen very often but if one of these
threads hangs it can cause the rest of the JVM to not shut down
when the main thread exits.
By making all threads daemon threads if the main thread terminates
the rest of these threads will shut down.