### PR TITLE
Send termination signals unless the computer is off

### DIFF
--- a/src/main/java/dan200/computercraft/core/computer/Computer.java
+++ b/src/main/java/dan200/computercraft/core/computer/Computer.java
@@ -285,7 +285,7 @@ public class Computer
     {
         synchronized( this )
         {
-            if( m_state == State.Running )
+            if( m_state != State.Off && m_machine != null )
             {
                 if( hard ) 
                 {


### PR DESCRIPTION
If a shutdown has been queued, then the abort message is not set. This allows for programs to run for a significantly longer period of time, bypassing the "too long without yielding" error.

## Example
Run the following code, and press Ctrl+S after a couple of seconds.

```lua
local i = 1
while true do
    print(i, os.clock())
    i = i + 1
end
```

Without this patch, the computer will run forever. This can be observed by opening VisualVM and looking at the thread view: there will be a coroutine which is still running.

Note that using `os.shutdown()` does not reproduce this issue. I believe there is a threading issue somewhere, this is something to investigate further.