### PR TITLE
Fix compilation error

### DIFF
--- a/src/main/java/dan200/computercraft/shared/turtle/items/ItemTurtleBase.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/items/ItemTurtleBase.java
@@ -24,7 +24,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.text.translation.I18n;;
+import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
 
 import java.util.ArrayList;


### PR DESCRIPTION
Per [JLS syntax](https://docs.oracle.com/javase/specs/jls/se8/html/jls-19.html#jls-19-7) empty statements are not allowed in import list.

Though it seems to be accepted by `javac` and some IDEs (not Eclipse).