### PR TITLE
Monitor and terminal rendering improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ deploy
 *.ipr
 *.iws
 *.iml
-.idea/
+.idea
 .gradle
 luaj-2.0.3/lib
 luaj-2.0.3/*.jar

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ deploy
 *.ipr
 *.iws
 *.iml
+.idea/
 .gradle
 luaj-2.0.3/lib
 luaj-2.0.3/*.jar

--- a/src/main/java/dan200/computercraft/client/gui/FixedWidthFontRenderer.java
+++ b/src/main/java/dan200/computercraft/client/gui/FixedWidthFontRenderer.java
@@ -57,10 +57,16 @@ public class FixedWidthFontRenderer
 
     public void drawStringBackgroundPart( int x, int y, TextBuffer backgroundColour, double leftMarginSize, double rightMarginSize, boolean greyScale )
     {
-        // Draw the quads
         Tessellator tessellator = Tessellator.getInstance();
         VertexBuffer renderer = tessellator.getBuffer();
         renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
+        drawStringBackgroundPart( renderer, x, y, backgroundColour, leftMarginSize, rightMarginSize, greyScale );
+        tessellator.draw();
+    }
+
+    public void drawStringBackgroundPart( VertexBuffer renderer, int x, int y, TextBuffer backgroundColour, double leftMarginSize, double rightMarginSize, boolean greyScale )
+    {
+        // Draw the quads
         if( leftMarginSize > 0.0 )
         {
             int colour1 = "0123456789abcdef".indexOf( backgroundColour.charAt( 0 ) );
@@ -88,15 +94,20 @@ public class FixedWidthFontRenderer
             }
             drawQuad( renderer, x + i * FONT_WIDTH, y, colour, FONT_WIDTH );
         }
-        tessellator.draw();
     }
 
     public void drawStringTextPart( int x, int y, TextBuffer s, TextBuffer textColour, boolean greyScale )
     {
-        // Draw the quads
         Tessellator tessellator = Tessellator.getInstance();
         VertexBuffer renderer = tessellator.getBuffer();
         renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
+        drawStringTextPart(renderer, x, y, s, textColour, greyScale);
+        tessellator.draw();
+    }
+
+    public void drawStringTextPart( VertexBuffer renderer, int x, int y, TextBuffer s, TextBuffer textColour, boolean greyScale )
+    {
+        // Draw the quads
         for( int i = 0; i < s.length(); i++ )
         {
             // Switch colour
@@ -114,11 +125,13 @@ public class FixedWidthFontRenderer
             }
             drawChar( renderer, x + i * FONT_WIDTH, y, index, colour );
         }
-        tessellator.draw();
     }
 
     public void drawString( TextBuffer s, int x, int y, TextBuffer textColour, TextBuffer backgroundColour, double leftMarginSize, double rightMarginSize, boolean greyScale )
     {
+        Tessellator tess = Tessellator.getInstance();
+        VertexBuffer renderer = tess.getBuffer();
+
         // Draw background
         if( backgroundColour != null )
         {
@@ -126,7 +139,9 @@ public class FixedWidthFontRenderer
             m_textureManager.bindTexture( background );
 
             // Draw the quads
-            drawStringBackgroundPart( x, y, backgroundColour, leftMarginSize, rightMarginSize, greyScale );
+            renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
+            drawStringBackgroundPart( renderer, x, y, backgroundColour, leftMarginSize, rightMarginSize, greyScale );
+            tess.draw();
         }
     
         // Draw text
@@ -136,7 +151,9 @@ public class FixedWidthFontRenderer
             m_textureManager.bindTexture( font );
             
             // Draw the quads
-            drawStringTextPart( x, y, s, textColour, greyScale );
+            renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
+            drawStringTextPart( renderer, x, y, s, textColour, greyScale );
+            tess.draw();
         }
     }
 

--- a/src/main/java/dan200/computercraft/client/gui/FixedWidthFontRenderer.java
+++ b/src/main/java/dan200/computercraft/client/gui/FixedWidthFontRenderer.java
@@ -35,19 +35,42 @@ public class FixedWidthFontRenderer
         int column = index % 16;
         int row = index / 16;
         Colour colour = Colour.values()[ 15 - color ];
-        renderer.pos( x, y + FONT_HEIGHT, 0.0 ).tex( (double) (column * FONT_WIDTH) / 256.0, (double) ((row + 1) * FONT_HEIGHT) / 256.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-        renderer.pos( x + FONT_WIDTH, y + FONT_HEIGHT, 0.0 ).tex( (double) ((column + 1) * FONT_WIDTH) / 256.0, (double) ((row + 1) * FONT_HEIGHT) / 256.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-        renderer.pos( x + FONT_WIDTH, y, 0.0 ).tex( (double) ((column + 1) * FONT_WIDTH) / 256.0, (double) (row * FONT_HEIGHT) / 256.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+        // Top left triangle
+        // Top left
         renderer.pos( x, y, 0.0 ).tex( (double) (column * FONT_WIDTH) / 256.0, (double) (row * FONT_HEIGHT ) / 256.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+        // Bottom left
+        renderer.pos( x, y + FONT_HEIGHT, 0.0 ).tex( (double) (column * FONT_WIDTH) / 256.0, (double) ((row + 1) * FONT_HEIGHT) / 256.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+        // Top right
+        renderer.pos( x + FONT_WIDTH, y, 0.0 ).tex( (double) ((column + 1) * FONT_WIDTH) / 256.0, (double) (row * FONT_HEIGHT) / 256.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+
+        // Bottom right triangle
+        // Top right
+        renderer.pos( x + FONT_WIDTH, y, 0.0 ).tex( (double) ((column + 1) * FONT_WIDTH) / 256.0, (double) (row * FONT_HEIGHT) / 256.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+        // Bottom left
+        renderer.pos( x, y + FONT_HEIGHT, 0.0 ).tex( (double) (column * FONT_WIDTH) / 256.0, (double) ((row + 1) * FONT_HEIGHT) / 256.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+        // Bottom right
+        renderer.pos( x + FONT_WIDTH, y + FONT_HEIGHT, 0.0 ).tex( (double) ((column + 1) * FONT_WIDTH) / 256.0, (double) ((row + 1) * FONT_HEIGHT) / 256.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+
     }
 
     private void drawQuad( VertexBuffer renderer, double x, double y, int color, double width )
     {
         Colour colour = Colour.values()[ 15 - color ];
-        renderer.pos( x, y + FONT_HEIGHT, 0.0 ).tex( 0.0, 1.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-        renderer.pos( x + width, y + FONT_HEIGHT, 0.0 ).tex( 1.0, 1.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-        renderer.pos( x + width, y, 0.0 ).tex( 1.0, 0.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+        // Top left triangle
+        // Top left
         renderer.pos( x, y, 0.0 ).tex( 0.0, 0.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+        // Bottom left
+        renderer.pos( x, y + FONT_HEIGHT, 0.0 ).tex( 0.0, 1.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+        // Top right
+        renderer.pos( x + width, y, 0.0 ).tex( 1.0, 0.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+
+        // Bottom right triangle
+        // Top right
+        renderer.pos( x + width, y, 0.0 ).tex( 1.0, 0.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+        // Bottom left
+        renderer.pos( x, y + FONT_HEIGHT, 0.0 ).tex( 0.0, 1.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+        // Bottom right
+        renderer.pos( x + width, y + FONT_HEIGHT, 0.0 ).tex( 1.0, 1.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
     }
 
     private boolean isGreyScale( int colour )
@@ -59,7 +82,7 @@ public class FixedWidthFontRenderer
     {
         Tessellator tessellator = Tessellator.getInstance();
         VertexBuffer renderer = tessellator.getBuffer();
-        renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
+        renderer.begin( GL11.GL_TRIANGLES, DefaultVertexFormats.POSITION_TEX_COLOR );
         drawStringBackgroundPart( renderer, x, y, backgroundColour, leftMarginSize, rightMarginSize, greyScale );
         tessellator.draw();
     }
@@ -100,7 +123,7 @@ public class FixedWidthFontRenderer
     {
         Tessellator tessellator = Tessellator.getInstance();
         VertexBuffer renderer = tessellator.getBuffer();
-        renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
+        renderer.begin( GL11.GL_TRIANGLES, DefaultVertexFormats.POSITION_TEX_COLOR );
         drawStringTextPart(renderer, x, y, s, textColour, greyScale);
         tessellator.draw();
     }
@@ -139,7 +162,7 @@ public class FixedWidthFontRenderer
             m_textureManager.bindTexture( background );
 
             // Draw the quads
-            renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
+            renderer.begin( GL11.GL_TRIANGLES, DefaultVertexFormats.POSITION_TEX_COLOR );
             drawStringBackgroundPart( renderer, x, y, backgroundColour, leftMarginSize, rightMarginSize, greyScale );
             tess.draw();
         }
@@ -151,7 +174,7 @@ public class FixedWidthFontRenderer
             m_textureManager.bindTexture( font );
             
             // Draw the quads
-            renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
+            renderer.begin( GL11.GL_TRIANGLES, DefaultVertexFormats.POSITION_TEX_COLOR );
             drawStringTextPart( renderer, x, y, s, textColour, greyScale );
             tess.draw();
         }

--- a/src/main/java/dan200/computercraft/client/gui/widgets/WidgetTerminal.java
+++ b/src/main/java/dan200/computercraft/client/gui/widgets/WidgetTerminal.java
@@ -16,6 +16,8 @@ import dan200.computercraft.shared.util.Colour;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.VertexBuffer;
 import net.minecraft.util.ChatAllowedCharacters;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.input.Keyboard;
@@ -391,6 +393,7 @@ public class WidgetTerminal extends Widget
 
                 // Draw margins
                 TextBuffer emptyLine = new TextBuffer( ' ', tw );
+
                 if( m_topMargin > 0 )
                 {
                     fontRenderer.drawString( emptyLine, x, startY, terminal.getTextColourLine( 0 ), terminal.getBackgroundColourLine( 0 ), m_leftMargin, m_rightMargin, greyscale );
@@ -407,23 +410,23 @@ public class WidgetTerminal extends Widget
                     TextBuffer colour = terminal.getTextColourLine( line );
                     TextBuffer backgroundColour = terminal.getBackgroundColourLine( line );
                     fontRenderer.drawString( text, x, y, colour, backgroundColour, m_leftMargin, m_rightMargin, greyscale );
-                    if( tblink && ty == line )
-                    {
-                        if( tx >= 0 && tx < tw )
-                        {
-                            TextBuffer cursor = new TextBuffer( '_', 1 );
-                            TextBuffer cursorColour = new TextBuffer( "0123456789abcdef".charAt( terminal.getTextColour() ), 1 );
-                            fontRenderer.drawString(
-                                cursor,
-                                x + FixedWidthFontRenderer.FONT_WIDTH * tx,
-                                y,
-                                cursorColour, null,
-                                0, 0,
-                                greyscale
-                            );
-                        }
-                    }
-                    y = y + FixedWidthFontRenderer.FONT_HEIGHT;
+
+                    y += FixedWidthFontRenderer.FONT_HEIGHT;
+                }
+
+                if( tblink )
+                {
+                    TextBuffer cursor = new TextBuffer( '_', 1 );
+                    TextBuffer cursorColour = new TextBuffer( "0123456789abcdef".charAt( terminal.getTextColour() ), 1 );
+
+                    fontRenderer.drawString(
+                            cursor,
+                            x + FixedWidthFontRenderer.FONT_WIDTH * tx,
+                            startY + m_topMargin + FixedWidthFontRenderer.FONT_HEIGHT * ty,
+                            cursorColour, null,
+                            0, 0,
+                            greyscale
+                    );
                 }
             }
         }
@@ -433,14 +436,7 @@ public class WidgetTerminal extends Widget
             mc.getTextureManager().bindTexture( background );
             Colour black = Colour.Black;
             GlStateManager.color( black.getR(), black.getG(), black.getB(), 1.0f );
-            try
-            {
-                drawTexturedModalRect( startX, startY, 0, 0, getWidth(), getHeight() );
-            }
-            finally
-            {
-                GlStateManager.color( 1.0f, 1.0f, 1.0f, 1.0f );
-            }
+            drawTexturedModalRect( startX, startY, 0, 0, getWidth(), getHeight() );
         }
     }
 

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -246,15 +246,15 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
             try
             {
                 mc.getTextureManager().bindTexture( FixedWidthFontRenderer.background );
-                renderer.begin( GL11.GL_TRIANGLE_STRIP, DefaultVertexFormats.POSITION_TEX );
+                renderer.begin( GL11.GL_TRIANGLE_STRIP, DefaultVertexFormats.POSITION );
                 // Top left
-                renderer.pos( -TileMonitor.RENDER_MARGIN, TileMonitor.RENDER_MARGIN, 0.0D ).tex( 0.0, 0.0 ).endVertex();
+                renderer.pos( -TileMonitor.RENDER_MARGIN, TileMonitor.RENDER_MARGIN, 0.0 ).endVertex();
                 // Bottom left
-                renderer.pos( -TileMonitor.RENDER_MARGIN, -ySize - TileMonitor.RENDER_MARGIN, 0.0 ).tex( 0.0, 1.0 ).endVertex();
+                renderer.pos( -TileMonitor.RENDER_MARGIN, -ySize - TileMonitor.RENDER_MARGIN, 0.0 ).endVertex();
                 // Top right
-                renderer.pos( xSize + TileMonitor.RENDER_MARGIN, TileMonitor.RENDER_MARGIN, 0.0D ).tex( 1.0, 0.0 ).endVertex();
+                renderer.pos( xSize + TileMonitor.RENDER_MARGIN, TileMonitor.RENDER_MARGIN, 0.0 ).endVertex();
                 // Bottom right
-                renderer.pos( xSize + TileMonitor.RENDER_MARGIN, -ySize - TileMonitor.RENDER_MARGIN, 0.0 ).tex( 1.0, 1.0 ).endVertex();
+                renderer.pos( xSize + TileMonitor.RENDER_MARGIN, -ySize - TileMonitor.RENDER_MARGIN, 0.0 ).endVertex();
                 tessellator.draw();
             }
             finally

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -104,13 +104,6 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
             {
                 if( terminal != null )
                 {
-                    // Allocate display lists
-                    if( origin.m_renderDisplayList < 0 )
-                    {
-                        origin.m_renderDisplayList = GL11.glGenLists( 3 );
-                        redraw = true;
-                    }
-
                     // Draw a terminal
                     boolean greyscale = !clientTerminal.isColour();
                     int width = terminal.getWidth();

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -128,106 +128,91 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
 
                         // Draw background
                         mc.getTextureManager().bindTexture( FixedWidthFontRenderer.background );
-                        if( redraw )
+
+                        double marginXSize = TileMonitor.RENDER_MARGIN / xScale;
+                        double marginYSize = TileMonitor.RENDER_MARGIN / yScale;
+                        double marginSquash = marginYSize / (double) FixedWidthFontRenderer.FONT_HEIGHT;
+
+                        // Top and bottom margins
+                        GlStateManager.pushMatrix();
+                        try
                         {
-                            // Build background display list
-                            GL11.glNewList( origin.m_renderDisplayList, GL11.GL_COMPILE );
-                            try
-                            {
-                                double marginXSize = TileMonitor.RENDER_MARGIN / xScale;
-                                double marginYSize = TileMonitor.RENDER_MARGIN / yScale;
-                                double marginSquash = marginYSize / (double) FixedWidthFontRenderer.FONT_HEIGHT;
+                            renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
 
-                                // Top and bottom margins
-                                GlStateManager.pushMatrix();
-                                try
-                                {
-                                    GlStateManager.scale( 1.0, marginSquash, 1.0 );
-                                    GlStateManager.translate( 0.0, -marginYSize / marginSquash, 0.0 );
-                                    fontRenderer.drawStringBackgroundPart( 0, 0, terminal.getBackgroundColourLine( 0 ), marginXSize, marginXSize, greyscale );
-                                    GlStateManager.translate( 0.0, ( marginYSize + height * FixedWidthFontRenderer.FONT_HEIGHT ) / marginSquash, 0.0 );
-                                    fontRenderer.drawStringBackgroundPart( 0, 0, terminal.getBackgroundColourLine( height - 1 ), marginXSize, marginXSize, greyscale );
-                                }
-                                finally
-                                {
-                                    GlStateManager.popMatrix();
-                                }
+                            fontRenderer.drawStringBackgroundPart(
+                                    renderer, 0, (int) (-marginYSize / marginSquash),
+                                    terminal.getBackgroundColourLine( 0 ),
+                                    marginXSize, marginXSize,
+                                    greyscale
+                            );
 
-                                // Backgrounds
-                                for( int y = 0; y < height; ++y )
-                                {
-                                    fontRenderer.drawStringBackgroundPart(
-                                            0, FixedWidthFontRenderer.FONT_HEIGHT * y,
-                                            terminal.getBackgroundColourLine( y ),
-                                            marginXSize, marginXSize,
-                                            greyscale
-                                    );
-                                }
-                            }
-                            finally
-                            {
-                                GL11.glEndList();
-                            }
+                            fontRenderer.drawStringBackgroundPart(
+                                    renderer, 0, (int) ((-marginYSize + height * FixedWidthFontRenderer.FONT_HEIGHT) / marginSquash),
+                                    terminal.getBackgroundColourLine( height - 1 ),
+                                    marginXSize, marginXSize,
+                                    greyscale
+                            );
+
+                            GlStateManager.scale( 1.0, marginSquash, 1.0 );
+                            tessellator.draw();
                         }
-                        GlStateManager.callList( origin.m_renderDisplayList );
+                        finally
+                        {
+                            GlStateManager.popMatrix();
+                        }
+
+                        // Backgrounds
+                        renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
+
+                        for( int y = 0; y < height; ++y )
+                        {
+                            fontRenderer.drawStringBackgroundPart(
+                                    renderer,
+                                    0, FixedWidthFontRenderer.FONT_HEIGHT * y,
+                                    terminal.getBackgroundColourLine( y ),
+                                    marginXSize, marginXSize,
+                                    greyscale
+                            );
+                        }
+
+                        tessellator.draw();
 
                         // Draw text
                         mc.getTextureManager().bindTexture( FixedWidthFontRenderer.font );
-                        if( redraw )
+
+                        renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
+
+                        // Lines
+                        for( int y = 0; y < height; ++y )
                         {
-                            // Build text display list
-                            GL11.glNewList( origin.m_renderDisplayList + 1, GL11.GL_COMPILE );
-                            try
-                            {
-                                // Lines
-                                for( int y = 0; y < height; ++y )
-                                {
-                                    fontRenderer.drawStringTextPart(
-                                            0, FixedWidthFontRenderer.FONT_HEIGHT * y,
-                                            terminal.getLine( y ),
-                                            terminal.getTextColourLine( y ),
-                                            greyscale
-                                    );
-                                }
-                            }
-                            finally
-                            {
-                                GL11.glEndList();
-                            }
+                            fontRenderer.drawStringTextPart(
+                                    renderer,
+                                    0, FixedWidthFontRenderer.FONT_HEIGHT * y,
+                                    terminal.getLine( y ),
+                                    terminal.getTextColourLine( y ),
+                                    greyscale
+                            );
                         }
-                        GlStateManager.callList( origin.m_renderDisplayList + 1 );
+
+                        tessellator.draw();
 
                         // Draw cursor
                         mc.getTextureManager().bindTexture( FixedWidthFontRenderer.font );
-                        if( redraw )
+
+                        // Cursor
+                        if( ComputerCraft.getGlobalCursorBlink() && terminal.getCursorBlink() && cursorX >= 0 && cursorX < width && cursorY >= 0 && cursorY < height )
                         {
-                            // Build cursor display list
-                            GL11.glNewList( origin.m_renderDisplayList + 2, GL11.GL_COMPILE );
-                            try
-                            {
-                                // Cursor
-                                if( terminal.getCursorBlink() && cursorX >= 0 && cursorX < width && cursorY >= 0 && cursorY < height )
-                                {
-                                    TextBuffer cursor = new TextBuffer( "_" );
-                                    TextBuffer cursorColour = new TextBuffer( "0123456789abcdef".charAt( terminal.getTextColour() ), 1 );
-                                    fontRenderer.drawString(
-                                            cursor,
-                                            FixedWidthFontRenderer.FONT_WIDTH * cursorX,
-                                            FixedWidthFontRenderer.FONT_HEIGHT * cursorY,
-                                            cursorColour, null,
-                                            0, 0,
-                                            greyscale
-                                    );
-                                }
-                            }
-                            finally
-                            {
-                                GL11.glEndList();
-                            }
-                        }
-                        if( ComputerCraft.getGlobalCursorBlink() )
-                        {
-                            GlStateManager.callList( origin.m_renderDisplayList + 2 );
+                            TextBuffer cursor = new TextBuffer( "_" );
+                            TextBuffer cursorColour = new TextBuffer( "0123456789abcdef".charAt( terminal.getTextColour() ), 1 );
+
+                            fontRenderer.drawString(
+                                    cursor,
+                                    FixedWidthFontRenderer.FONT_WIDTH * cursorX,
+                                    FixedWidthFontRenderer.FONT_HEIGHT * cursorY,
+                                    cursorColour, null,
+                                    0, 0,
+                                    greyscale
+                            );
                         }
                     }
                     finally

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -11,7 +11,6 @@ import dan200.computercraft.client.gui.FixedWidthFontRenderer;
 import dan200.computercraft.core.terminal.Terminal;
 import dan200.computercraft.core.terminal.TextBuffer;
 import dan200.computercraft.shared.common.ClientTerminal;
-import dan200.computercraft.shared.common.ITerminal;
 import dan200.computercraft.shared.peripheral.monitor.TileMonitor;
 import dan200.computercraft.shared.util.Colour;
 import dan200.computercraft.shared.util.DirectionUtil;
@@ -21,11 +20,8 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.VertexBuffer;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.MinecraftForgeClient;
 import org.lwjgl.opengl.GL11;
 
 public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMonitor>
@@ -143,18 +139,18 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
                                 double marginSquash = marginYSize / (double) FixedWidthFontRenderer.FONT_HEIGHT;
 
                                 // Top and bottom margins
-                                GL11.glPushMatrix();
+                                GlStateManager.pushMatrix();
                                 try
                                 {
-                                    GL11.glScaled( 1.0, marginSquash, 1.0 );
-                                    GL11.glTranslated( 0.0, -marginYSize / marginSquash, 0.0 );
+                                    GlStateManager.scale( 1.0, marginSquash, 1.0 );
+                                    GlStateManager.translate( 0.0, -marginYSize / marginSquash, 0.0 );
                                     fontRenderer.drawStringBackgroundPart( 0, 0, terminal.getBackgroundColourLine( 0 ), marginXSize, marginXSize, greyscale );
-                                    GL11.glTranslated( 0.0, ( marginYSize + height * FixedWidthFontRenderer.FONT_HEIGHT ) / marginSquash, 0.0 );
+                                    GlStateManager.translate( 0.0, ( marginYSize + height * FixedWidthFontRenderer.FONT_HEIGHT ) / marginSquash, 0.0 );
                                     fontRenderer.drawStringBackgroundPart( 0, 0, terminal.getBackgroundColourLine( height - 1 ), marginXSize, marginXSize, greyscale );
                                 }
                                 finally
                                 {
-                                    GL11.glPopMatrix();
+                                    GlStateManager.popMatrix();
                                 }
 
                                 // Backgrounds
@@ -243,13 +239,21 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
                 {
                     // Draw a big black quad
                     mc.getTextureManager().bindTexture( FixedWidthFontRenderer.background );
-                    renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
-                    Colour colour = Colour.Black;
-                    renderer.pos( -TileMonitor.RENDER_MARGIN, -ySize - TileMonitor.RENDER_MARGIN, 0.0 ).tex( 0.0, 1.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-                    renderer.pos( xSize + TileMonitor.RENDER_MARGIN, -ySize - TileMonitor.RENDER_MARGIN, 0.0 ).tex( 1.0, 1.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-                    renderer.pos( xSize + TileMonitor.RENDER_MARGIN, TileMonitor.RENDER_MARGIN, 0.0D ).tex( 1.0, 0.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-                    renderer.pos( -TileMonitor.RENDER_MARGIN, TileMonitor.RENDER_MARGIN, 0.0D ).tex( 0.0, 0.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-                    renderer.pos( -TileMonitor.RENDER_MARGIN, -ySize - TileMonitor.RENDER_MARGIN, 0.0 ).tex( 0.0, 1.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+                    final Colour colour = Colour.Black;
+
+                    final float r = colour.getR();
+                    final float g = colour.getG();
+                    final float b = colour.getB();
+
+                    renderer.begin( GL11.GL_TRIANGLE_STRIP, DefaultVertexFormats.POSITION_TEX_COLOR );
+                    // Top left
+                    renderer.pos( -TileMonitor.RENDER_MARGIN, TileMonitor.RENDER_MARGIN, 0.0D ).tex( 0.0, 0.0 ).color( r, g, b, 1.0f ).endVertex();
+                    // Bottom left
+                    renderer.pos( -TileMonitor.RENDER_MARGIN, -ySize - TileMonitor.RENDER_MARGIN, 0.0 ).tex( 0.0, 1.0 ).color( r, g, b, 1.0f ).endVertex();
+                    // Top right
+                    renderer.pos( xSize + TileMonitor.RENDER_MARGIN, TileMonitor.RENDER_MARGIN, 0.0D ).tex( 1.0, 0.0 ).color( r, g, b, 1.0f ).endVertex();
+                    // Bottom right
+                    renderer.pos( xSize + TileMonitor.RENDER_MARGIN, -ySize - TileMonitor.RENDER_MARGIN, 0.0 ).tex( 1.0, 1.0 ).color( r, g, b, 1.0f ).endVertex();
                     tessellator.draw();
                 }
             }
@@ -264,13 +268,15 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
             try
             {
                 mc.getTextureManager().bindTexture( FixedWidthFontRenderer.background );
-                renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
-                Colour colour = Colour.Black;
-                renderer.pos( -TileMonitor.RENDER_MARGIN, -ySize - TileMonitor.RENDER_MARGIN, 0.0 ).tex( 0.0, 1.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-                renderer.pos( xSize + TileMonitor.RENDER_MARGIN, -ySize - TileMonitor.RENDER_MARGIN, 0.0 ).tex( 1.0, 1.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-                renderer.pos( xSize + TileMonitor.RENDER_MARGIN, TileMonitor.RENDER_MARGIN, 0.0D ).tex( 1.0, 0.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-                renderer.pos( -TileMonitor.RENDER_MARGIN, TileMonitor.RENDER_MARGIN, 0.0D ).tex( 0.0, 0.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-                renderer.pos( -TileMonitor.RENDER_MARGIN, -ySize - TileMonitor.RENDER_MARGIN, 0.0 ).tex( 0.0, 1.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+                renderer.begin( GL11.GL_TRIANGLE_STRIP, DefaultVertexFormats.POSITION_TEX );
+                // Top left
+                renderer.pos( -TileMonitor.RENDER_MARGIN, TileMonitor.RENDER_MARGIN, 0.0D ).tex( 0.0, 0.0 ).endVertex();
+                // Bottom left
+                renderer.pos( -TileMonitor.RENDER_MARGIN, -ySize - TileMonitor.RENDER_MARGIN, 0.0 ).tex( 0.0, 1.0 ).endVertex();
+                // Top right
+                renderer.pos( xSize + TileMonitor.RENDER_MARGIN, TileMonitor.RENDER_MARGIN, 0.0D ).tex( 1.0, 0.0 ).endVertex();
+                // Bottom right
+                renderer.pos( xSize + TileMonitor.RENDER_MARGIN, -ySize - TileMonitor.RENDER_MARGIN, 0.0 ).tex( 1.0, 1.0 ).endVertex();
                 tessellator.draw();
             }
             finally

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -130,7 +130,7 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
                         GlStateManager.pushMatrix();
                         try
                         {
-                            renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
+                            renderer.begin( GL11.GL_TRIANGLES, DefaultVertexFormats.POSITION_TEX_COLOR );
 
                             fontRenderer.drawStringBackgroundPart(
                                     renderer, 0, (int) (-marginYSize / marginSquash),
@@ -155,7 +155,7 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
                         }
 
                         // Backgrounds
-                        renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
+                        renderer.begin( GL11.GL_TRIANGLES, DefaultVertexFormats.POSITION_TEX_COLOR );
 
                         for( int y = 0; y < height; ++y )
                         {
@@ -173,7 +173,7 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
                         // Draw text
                         mc.getTextureManager().bindTexture( FixedWidthFontRenderer.font );
 
-                        renderer.begin( GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR );
+                        renderer.begin( GL11.GL_TRIANGLES, DefaultVertexFormats.POSITION_TEX_COLOR );
 
                         // Lines
                         for( int y = 0; y < height; ++y )

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -140,7 +140,7 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
                             );
 
                             fontRenderer.drawStringBackgroundPart(
-                                    renderer, 0, (int) ((-marginYSize + height * FixedWidthFontRenderer.FONT_HEIGHT) / marginSquash),
+                                    renderer, 0, (int) ((height * FixedWidthFontRenderer.FONT_HEIGHT) / marginSquash),
                                     terminal.getBackgroundColourLine( height - 1 ),
                                     marginXSize, marginXSize,
                                     greyscale
@@ -264,7 +264,6 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
         }
         finally
         {
-            GlStateManager.color( 1.0f, 1.0f, 1.0f, 1.0f );
             GlStateManager.popMatrix();
         }
     }

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/TileMonitor.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/TileMonitor.java
@@ -47,7 +47,6 @@ public class TileMonitor extends TilePeripheralBase
     private final Set<IComputerAccess> m_computers;
 
     public long m_lastRenderFrame = -1; // For rendering use only
-    public int m_renderDisplayList = -1; // For rendering use only
 
     private boolean m_destroyed;
     private boolean m_ignoreMe;
@@ -89,11 +88,6 @@ public class TileMonitor extends TilePeripheralBase
             {
                 contractNeighbours();
             }
-        }
-        if( m_renderDisplayList >= 0 )
-        {
-            ComputerCraft.deleteDisplayLists( m_renderDisplayList, 3 );
-            m_renderDisplayList = -1;
         }
     }
 


### PR DESCRIPTION
I've made some changes to how monitors are rendered, and by changing how text is rendered, terminal rendering got some of these improvements as well.

In particular:
- I removed all usages of `GL_QUADS` and replaced them with something more appropriate. This primitive type has been deprecated because OpenGL doesn't know what quads are. Thus, all primitives rendered with `GL_QUADS` are triangulated on the CPU before drawing, which is just a waste of time.
- I replaced any direct OpenGL code I could find with Minecraft's equivalents. This includes:
  - Replacing calls like `glTranslatef` with `GlStateManager.translate`
  - Substituting the display list conundrum with calls to `Tessellator`, which allows Minecraft to use VBOs here!
- Microoptimisations here and there

These changes only apply to monitor-related code.