### PR TITLE
Handle tile entity changes

### DIFF
--- a/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
+++ b/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
@@ -46,7 +46,7 @@ public abstract class BlockGeneric extends Block implements
     public final void dropBlockAsItemWithChance( World world, BlockPos pos, IBlockState state, float chance, int fortune )
     {
     }
-        
+
     @Override
     public final List<ItemStack> getDrops( IBlockAccess world, BlockPos pos, IBlockState state, int fortune )
     {
@@ -107,7 +107,7 @@ public abstract class BlockGeneric extends Block implements
     {
         Block.spawnAsEntity( world, pos, stack );
     }
-    
+
     @Override
     public final void breakBlock( World world, BlockPos pos, IBlockState newState )
     {
@@ -159,6 +159,17 @@ public abstract class BlockGeneric extends Block implements
         {
             TileGeneric generic = (TileGeneric)tile;
             generic.onNeighbourChange();
+        }
+    }
+
+    @Override
+    public final void onNeighborChange( IBlockAccess world, BlockPos pos, BlockPos neighbour )
+    {
+        TileEntity tile = world.getTileEntity( pos );
+        if( tile instanceof TileGeneric )
+        {
+            TileGeneric generic = (TileGeneric)tile;
+            generic.onNeighbourTileEntityChange( neighbour );
         }
     }
 

--- a/src/main/java/dan200/computercraft/shared/common/TileGeneric.java
+++ b/src/main/java/dan200/computercraft/shared/common/TileGeneric.java
@@ -95,6 +95,10 @@ public abstract class TileGeneric extends TileEntity
     {
     }
 
+    public void onNeighbourTileEntityChange( BlockPos neighbour )
+    {
+    }
+
     public boolean isSolidOnSide( int side )
     {
         return true;

--- a/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputerBase.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputerBase.java
@@ -197,6 +197,12 @@ public abstract class TileComputerBase extends TileGeneric
     }
 
     @Override
+    public void onNeighbourTileEntityChange( BlockPos neighbour )
+    {
+        updateInput( neighbour );
+    }
+
+    @Override
     public void update()
     {
         if( !worldObj.isRemote )
@@ -307,6 +313,21 @@ public abstract class TileComputerBase extends TileGeneric
         return localSide;
     }
 
+    private void updateSideInput( ServerComputer computer, EnumFacing dir, BlockPos offset )
+    {
+        EnumFacing offsetSide = dir.getOpposite();
+        int localDir = remapLocalSide( DirectionUtil.toLocal( this, dir ) );
+        if( !isRedstoneBlockedOnSide( localDir ) )
+        {
+            computer.setRedstoneInput( localDir, RedstoneUtil.getRedstoneOutput( worldObj, offset, offsetSide ) );
+            computer.setBundledRedstoneInput( localDir, RedstoneUtil.getBundledRedstoneOutput( worldObj, offset, offsetSide ) );
+        }
+        if( !isPeripheralBlockedOnSide( localDir ) )
+        {
+            computer.setPeripheral( localDir, PeripheralUtil.getPeripheral( worldObj, offset, offsetSide ) );
+        }
+    }
+
     public void updateInput()
     {
         if( worldObj == null || worldObj.isRemote )
@@ -321,17 +342,29 @@ public abstract class TileComputerBase extends TileGeneric
             BlockPos pos = computer.getPosition();
             for( EnumFacing dir : EnumFacing.VALUES )
             {
+                updateSideInput( computer, dir, pos.offset( dir ) );
+            }
+        }
+    }
+
+    public void updateInput( BlockPos neighbour )
+    {
+        if( worldObj == null || worldObj.isRemote )
+        {
+            return;
+        }
+
+        ServerComputer computer = getServerComputer();
+        if( computer != null )
+        {
+            BlockPos pos = computer.getPosition();
+            for( EnumFacing dir : EnumFacing.VALUES )
+            {
                 BlockPos offset = pos.offset( dir );
-                EnumFacing offsetSide = dir.getOpposite();
-                int localDir = remapLocalSide( DirectionUtil.toLocal( this, dir ) );
-                if( !isRedstoneBlockedOnSide( localDir ) )
+                if ( offset.equals( neighbour ) )
                 {
-                    computer.setRedstoneInput( localDir, RedstoneUtil.getRedstoneOutput( worldObj, offset, offsetSide ) );
-                    computer.setBundledRedstoneInput( localDir, RedstoneUtil.getBundledRedstoneOutput( worldObj, offset, offsetSide ) );
-                }
-                if( !isPeripheralBlockedOnSide( localDir ) )
-                {
-                    computer.setPeripheral( localDir, PeripheralUtil.getPeripheral( worldObj, offset, offsetSide ) );
+                    updateSideInput( computer, dir, offset );
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Currently CC ignores updates from
```java
class Block {
//...
    public void onNeighborChange( IBlockAccess world, BlockPos pos, BlockPos neighbour );
//...
}
```

This method is called when tile entity changes (e.g. `TileEntity.markDirty`, `World.setTileEntity`). Supporting this callback fixes interactions with blocks that change TE without block update (at the cost of increased number of peripheral updates).

Main example would be vanilla furnace, that first changes block, which causes new TE to be created (and wrapped in peripheral), but then restores old one, which currently causes peripheral to keep reference to invalidated TE.