### PR TITLE
Ensure GPS coordinates are numbers

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/apis/gps
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/gps
@@ -103,7 +103,7 @@ function locate( _nTimeout, _bDebug )
 			local sSide, sChannel, sReplyChannel, tMessage, nDistance = p1, p2, p3, p4, p5
 			if sSide == sModemSide and sChannel == os.getComputerID() and sReplyChannel == CHANNEL_GPS and nDistance then
 				-- Received the correct message from the correct modem: use it to determine position
-				if type(tMessage) == "table" and #tMessage == 3 then
+				if type(tMessage) == "table" and #tMessage == 3 and type(tMessage[1]) == "number" and type(tMessage[2]) == "number" and type(tMessage[3]) == "number" then
 					local tFix = { vPosition = vector.new( tMessage[1], tMessage[2], tMessage[3] ), nDistance = nDistance }
 					if _bDebug then
 						print( tFix.nDistance.." metres from "..tostring( tFix.vPosition ) )

--- a/src/main/resources/assets/computercraft/lua/rom/apis/gps
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/gps
@@ -103,7 +103,7 @@ function locate( _nTimeout, _bDebug )
 			local sSide, sChannel, sReplyChannel, tMessage, nDistance = p1, p2, p3, p4, p5
 			if sSide == sModemSide and sChannel == os.getComputerID() and sReplyChannel == CHANNEL_GPS and nDistance then
 				-- Received the correct message from the correct modem: use it to determine position
-				if type(tMessage) == "table" and #tMessage == 3 and type(tMessage[1]) == "number" and type(tMessage[2]) == "number" and type(tMessage[3]) == "number" then
+				if type(tMessage) == "table" and #tMessage == 3 and tonumber(tMessage[1]) and tonumber(tMessage[2]) and tonumber(tMessage[3]) then
 					local tFix = { vPosition = vector.new( tMessage[1], tMessage[2], tMessage[3] ), nDistance = nDistance }
 					if _bDebug then
 						print( tFix.nDistance.." metres from "..tostring( tFix.vPosition ) )

--- a/src/main/resources/assets/computercraft/lua/rom/apis/vector
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/vector
@@ -76,9 +76,9 @@ local vmetatable = {
 
 function new( x, y, z )
 	local v = {
-		x = x or 0,
-		y = y or 0,
-		z = z or 0
+		x = type(x) == "number" and x or 0,
+		y = type(y) == "number" and y or 0,
+		z = type(z) == "number" and z or 0
 	}
 	setmetatable( v, vmetatable )
 	return v

--- a/src/main/resources/assets/computercraft/lua/rom/apis/vector
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/vector
@@ -76,9 +76,9 @@ local vmetatable = {
 
 function new( x, y, z )
 	local v = {
-		x = type(x) == "number" and x or 0,
-		y = type(y) == "number" and y or 0,
-		z = type(z) == "number" and z or 0
+		x = tonumber(x) or 0,
+		y = tonumber(y) or 0,
+		z = tonumber(z) or 0
 	}
 	setmetatable( v, vmetatable )
 	return v


### PR DESCRIPTION
See #138

This can be tested by running the following code on a computer:

```lua
local modemSide = nil
for n, side in ipairs(rs.getSides()) do
    if peripheral.getType(side) == "modem" and peripheral.call(side, "isWireless") then
        modemSide = side
        break
    end
end

if not modemSide then error("Cannot find modem", 0) end

local modem = peripheral.wrap(modemSide)

modem.open(gps.CHANNEL_GPS)
while true do
    local _, side, channel, repl, message, distance = os.pullEvent("modem_message")
    if side == modemSide and channel == gps.CHANNEL_GPS and message == "PING" and distance then
        modem.transmit(repl, gps.CHANNEL_GPS, { {}, {}, {} })
    end
end
 ```

and then running `gps locate` on another. Without this patch the program will exit, with it it should work normally.