### PR TITLE
Allow turtle upgrades to act as tools and peripherals

### DIFF
--- a/src/main/java/dan200/computercraft/api/turtle/TurtleUpgradeType.java
+++ b/src/main/java/dan200/computercraft/api/turtle/TurtleUpgradeType.java
@@ -24,4 +24,22 @@ public enum TurtleUpgradeType
      * and can be interacted with the peripheral API (Such as the modem on Wireless Turtles).
      */
     Peripheral,
+
+    /**
+     * An upgrade which provides both a tool and a peripheral. This can be used when you wish
+     * your upgrade to also provide methods. For example, a pickaxe could provide methods
+     * determining whether it can break the given block or not.
+     */
+    Both,
+    ;
+
+    public boolean isTool()
+    {
+        return this == Tool || this == Both;
+    }
+
+    public boolean isPeripheral()
+    {
+        return this == Peripheral || this == Both;
+    }
 }

--- a/src/main/java/dan200/computercraft/shared/proxy/CCTurtleProxyCommon.java
+++ b/src/main/java/dan200/computercraft/shared/proxy/CCTurtleProxyCommon.java
@@ -126,7 +126,7 @@ public abstract class CCTurtleProxyCommon implements ICCTurtleProxy
     {
         if( family == ComputerFamily.Beginners )
         {
-            return upgrade.getType() == TurtleUpgradeType.Tool;
+            return upgrade.getType().isTool();
         }
         else
         {

--- a/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtle.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtle.java
@@ -649,7 +649,7 @@ public class TileTurtle extends TileComputerBase
             case 5:    upgrade = getUpgrade( TurtleSide.Left ); break;
             default: return false;
         }
-        if( upgrade != null && upgrade.getType() == TurtleUpgradeType.Peripheral )
+        if( upgrade != null && upgrade.getType().isPeripheral() )
         {
             return true;
         }

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
@@ -950,7 +950,7 @@ public class TurtleBrain implements ITurtleAccess
         {
             ITurtleUpgrade upgrade = getUpgrade( side );
             IPeripheral peripheral = null;
-            if( upgrade != null && upgrade.getType() == TurtleUpgradeType.Peripheral )
+            if( upgrade != null && upgrade.getType().isPeripheral() )
             {
                 peripheral = upgrade.createPeripheral( this, side );
             }

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleToolCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleToolCommand.java
@@ -31,7 +31,7 @@ public class TurtleToolCommand implements ITurtleCommand
             if( !m_side.isPresent() || m_side.get() == side )
             {
                 ITurtleUpgrade upgrade = turtle.getUpgrade( side );
-                if( upgrade != null && upgrade.getType() == TurtleUpgradeType.Tool )
+                if( upgrade != null && upgrade.getType().isTool() )
                 {
                     TurtleCommandResult result = upgrade.useTool( turtle, side, m_verb, m_direction.toWorldDir( turtle ) );
                     if( result.isSuccess() )


### PR DESCRIPTION
This may be useful when you want your tool to also provide additional methods. For instance, a pickaxe could provide methods to check whether it can break the block in front. 

This is used by CCTweaks' [Tool manipulator](https://github.com/SquidDev-CC/CCTweaks/wiki/Tool-host#tool-manipulator) to provide a `.use()` and `.swing()` methods, as well as the more specific `turtle.attack()` and `turtle.dig()`.

I'm not sure how much code you're happy with putting in the API classes. I'd be happy to move the `isTool()`/`isPeripheral()` methods to a helper class somewhere else if if you'd rather avoid having any code there.