### PR TITLE
Sort the result of FileSystem.list

### DIFF
--- a/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
+++ b/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
@@ -10,7 +10,6 @@ import dan200.computercraft.api.filesystem.IMount;
 import dan200.computercraft.api.filesystem.IWritableMount;
 
 import java.io.*;
-import java.nio.charset.Charset;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -441,6 +440,7 @@ public class FileSystem
         // Return list
         String[] array = new String[ list.size() ];
         list.toArray(array);
+        Arrays.sort( array );
         return array;
     }
 


### PR DESCRIPTION
This ensures `fs.list` and `fs.find` always return the same result.

For some reason, the ComputerCraft jar was being packaged differently on some platforms, causing files to appear in a different order. As computers depend on the `colors` API being loaded before `colours`, we need to ensure that they are loaded in a consistent order.

I'm not sure this is the best solution - just sorting in `JarMount`  would be sufficient. We could also sort inside the `bios.lua` file instead. Or manually load `colors` before `colours`.