### PR TITLE
Make monitor text glow in the dark

### DIFF
--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -104,6 +104,7 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
             // Draw the contents
             GlStateManager.depthMask( false );
             GlStateManager.disableLighting();
+            mc.entityRenderer.disableLightmap();
             try
             {
                 if( terminal != null )
@@ -256,6 +257,7 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
             finally
             {
                 GlStateManager.depthMask( true );
+                mc.entityRenderer.enableLightmap();
                 GlStateManager.enableLighting();
             }
 

--- a/src/main/resources/assets/computercraft/lua/rom/help/changelog
+++ b/src/main/resources/assets/computercraft/lua/rom/help/changelog
@@ -3,6 +3,7 @@ New Features in ComputerCraft 1.80:
 * Added .getResponseHeaders() to HTTP responses.
 * Return a HTTP response when a HTTP error occurs.
 * Added a GUI to change ComputerCraft config options
+* Monitor text now glows in the dark
 
 New Features in ComputerCraft 1.79:
 

--- a/src/main/resources/assets/computercraft/lua/rom/help/whatsnew
+++ b/src/main/resources/assets/computercraft/lua/rom/help/whatsnew
@@ -3,5 +3,6 @@ New Features in ComputerCraft 1.80:
 * Added .getResponseHeaders() to HTTP responses.
 * Return a HTTP response when a HTTP error occurs.
 * Added a GUI to change ComputerCraft config options
+* Monitor text now glows in the dark
 
 Type "help changelog" to see the full version history.


### PR DESCRIPTION
An alternative to #177, monitor text now glows in the dark. I'm putting this in a separate PR as it shares nothing with the original.

![](https://cloud.githubusercontent.com/assets/4346137/25725033/1af5a286-3116-11e7-8760-d759a76ffe24.png)

Closes #177.