### PR TITLE
General improvements to the documentation

### DIFF
--- a/src/main/java/dan200/computercraft/api/ComputerCraftAPI.java
+++ b/src/main/java/dan200/computercraft/api/ComputerCraftAPI.java
@@ -8,13 +8,16 @@ package dan200.computercraft.api;
 
 import dan200.computercraft.api.filesystem.IMount;
 import dan200.computercraft.api.filesystem.IWritableMount;
+import dan200.computercraft.api.media.IMedia;
 import dan200.computercraft.api.media.IMediaProvider;
+import dan200.computercraft.api.peripheral.IComputerAccess;
+import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.api.peripheral.IPeripheralProvider;
 import dan200.computercraft.api.permissions.ITurtlePermissionProvider;
 import dan200.computercraft.api.redstone.IBundledRedstoneProvider;
 import dan200.computercraft.api.turtle.ITurtleUpgrade;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import java.lang.reflect.Method;
@@ -52,12 +55,16 @@ public final class ComputerCraftAPI
     }
 
     /**
-     * Creates a numbered directory in a subfolder of the save directory for a given world, and returns that number.<br>
-     * Use in conjuction with createSaveDirMount() to create a unique place for your peripherals or media items to store files.<br>
-     * @param world The world for which the save dir should be created. This should be the serverside world object.
+     * Creates a numbered directory in a subfolder of the save directory for a given world, and returns that number.
+     *
+     * Use in conjunction with createSaveDirMount() to create a unique place for your peripherals or media items to store files.
+     *
+     * @param world         The world for which the save dir should be created. This should be the server side world object.
      * @param parentSubPath The folder path within the save directory where the new directory should be created. eg: "computercraft/disk"
-     * @return The numerical value of the name of the new folder, or -1 if the folder could not be created for some reason.<br>
-     * eg: if createUniqueNumberedSaveDir( world, "computer/disk" ) was called returns 42, then "computer/disk/42" is now available for writing.
+     * @return The numerical value of the name of the new folder, or -1 if the folder could not be created for some reason.
+     *
+     * eg: if createUniqueNumberedSaveDir( world, "computer/disk" ) was called returns 42, then "computer/disk/42" is now
+     * available for writing.
      * @see #createSaveDirMount(World, String, long)
      */
     public static int createUniqueNumberedSaveDir( World world, String parentSubPath )
@@ -73,21 +80,23 @@ public final class ComputerCraftAPI
         }
         return -1;
     }
-    
+
     /**
-     * Creates a file system mount that maps to a subfolder of the save directory for a given world, and returns it.<br>
-     * Use in conjuction with IComputerAccess.mount() or IComputerAccess.mountWritable() to mount a folder from the
-     * users save directory onto a computers file system.<br>
-     * @param world The world for which the save dir can be found. This should be the serverside world object.
-     * @param subPath The folder path within the save directory that the mount should map to. eg: "computer/disk/42".<br>
-     * Use createUniqueNumberedSaveDir() to create a new numbered folder to use.
-     * @param capacity The ammount of data that can be stored in the directory before it fills up, in bytes.
+     * Creates a file system mount that maps to a subfolder of the save directory for a given world, and returns it.
+     *
+     * Use in conjunction with IComputerAccess.mount() or IComputerAccess.mountWritable() to mount a folder from the
+     * users save directory onto a computers file system.
+     *
+     * @param world    The world for which the save dir can be found. This should be the server side world object.
+     * @param subPath  The folder path within the save directory that the mount should map to. eg: "computer/disk/42".
+     *                 Use createUniqueNumberedSaveDir() to create a new numbered folder to use.
+     * @param capacity The amount of data that can be stored in the directory before it fills up, in bytes.
      * @return The mount, or null if it could be created for some reason. Use IComputerAccess.mount() or IComputerAccess.mountWritable()
      * to mount this on a Computers' file system.
      * @see #createUniqueNumberedSaveDir(World, String)
-     * @see dan200.computercraft.api.peripheral.IComputerAccess#mount(String, dan200.computercraft.api.filesystem.IMount)
-     * @see dan200.computercraft.api.peripheral.IComputerAccess#mountWritable(String, dan200.computercraft.api.filesystem.IWritableMount)
-     * @see dan200.computercraft.api.filesystem.IMount
+     * @see IComputerAccess#mount(String, IMount)
+     * @see IComputerAccess#mountWritable(String, IWritableMount)
+     * @see IMount
      * @see IWritableMount
      */
     public static IWritableMount createSaveDirMount( World world, String subPath, long capacity )
@@ -103,19 +112,24 @@ public final class ComputerCraftAPI
         }
         return null;
     }
-     
+
     /**
-     * Creates a file system mount to a resource folder, and returns it.<br>
-     * Use in conjuction with IComputerAccess.mount() or IComputerAccess.mountWritable() to mount a resource folder onto a computers file system.<br>
-     * The files in this mount will be a combination of files in the specified mod jar, and resource packs that contain resources with the same domain and path.<br>
+     * Creates a file system mount to a resource folder, and returns it.
+     *
+     * Use in conjunction with IComputerAccess.mount() or IComputerAccess.mountWritable() to mount a resource folder
+     * onto a computer's file system.
+     *
+     * The files in this mount will be a combination of files in the specified mod jar, and resource packs that contain
+     * resources with the same domain and path.
+     *
      * @param modClass A class in whose jar to look first for the resources to mount. Using your main mod class is recommended. eg: MyMod.class
-     * @param domain The domain under which to look for resources. eg: "mymod"
-     * @param subPath The domain under which to look for resources. eg: "mymod/lua/myfiles"
-     * @return The mount, or null if it could be created for some reason. Use IComputerAccess.mount() or IComputerAccess.mountWritable()
-     * to mount this on a Computers' file system.
-     * @see dan200.computercraft.api.peripheral.IComputerAccess#mount(String, dan200.computercraft.api.filesystem.IMount)
-     * @see dan200.computercraft.api.peripheral.IComputerAccess#mountWritable(String, IWritableMount)
-     * @see dan200.computercraft.api.filesystem.IMount
+     * @param domain   The domain under which to look for resources. eg: "mymod"
+     * @param subPath  The domain under which to look for resources. eg: "mymod/lua/myfiles"
+     * @return The mount, or {@code null} if it could be created for some reason. Use IComputerAccess.mount() or
+     * IComputerAccess.mountWritable() to mount this on a Computers' file system.
+     * @see IComputerAccess#mount(String, IMount)
+     * @see IComputerAccess#mountWritable(String, IWritableMount)
+     * @see IMount
      */
     public static IMount createResourceMount( Class modClass, String domain, String subPath )
     {
@@ -130,9 +144,10 @@ public final class ComputerCraftAPI
         }
         return null;
     }
-     
+
     /**
-     * Registers a peripheral handler to convert blocks into IPeripheral implementations.
+     * Registers a peripheral handler to convert blocks into {@link IPeripheral} implementations.
+     *
      * @see dan200.computercraft.api.peripheral.IPeripheral
      * @see dan200.computercraft.api.peripheral.IPeripheralProvider
      */
@@ -153,6 +168,7 @@ public final class ComputerCraftAPI
      * Registers a new turtle turtle for use in ComputerCraft. After calling this,
      * users should be able to craft Turtles with your new turtle. It is recommended to call
      * this during the load() method of your mod.
+     *
      * @see dan200.computercraft.api.turtle.ITurtleUpgrade
      */
     public static void registerTurtleUpgrade( ITurtleUpgrade upgrade )
@@ -173,6 +189,7 @@ public final class ComputerCraftAPI
 
     /**
      * Registers a bundled redstone handler to provide bundled redstone output for blocks
+     *
      * @see dan200.computercraft.api.redstone.IBundledRedstoneProvider
      */
     public static void registerBundledRedstoneProvider( IBundledRedstoneProvider handler )
@@ -190,9 +207,10 @@ public final class ComputerCraftAPI
 
     /**
      * If there is a Computer or Turtle at a certain position in the world, get it's bundled redstone output.
-     * @see dan200.computercraft.api.redstone.IBundledRedstoneProvider
+     *
      * @return If there is a block capable of emitting bundled redstone at the location, it's signal (0-65535) will be returned.
      * If there is no block capable of emitting bundled redstone at the location, -1 will be returned.
+     * @see dan200.computercraft.api.redstone.IBundledRedstoneProvider
      */
     public static int getBundledRedstoneOutput( World world, BlockPos pos, EnumFacing side )
     {
@@ -209,7 +227,8 @@ public final class ComputerCraftAPI
     }
 
     /**
-     * Registers a media handler to provide IMedia implementations for Items
+     * Registers a media handler to provide {@link IMedia} implementations for Items
+     *
      * @see dan200.computercraft.api.media.IMediaProvider
      */
     public static void registerMediaProvider( IMediaProvider handler )
@@ -227,6 +246,7 @@ public final class ComputerCraftAPI
 
     /**
      * Registers a permission handler to restrict where turtles can move or build
+     *
      * @see dan200.computercraft.api.permissions.ITurtlePermissionProvider
      */
     public static void registerPermissionProvider( ITurtlePermissionProvider handler )
@@ -245,7 +265,7 @@ public final class ComputerCraftAPI
     // The functions below here are private, and are used to interface with the non-API ComputerCraft classes.
     // Reflection is used here so you can develop your mod without decompiling ComputerCraft and including
     // it in your solution, and so your mod won't crash if ComputerCraft is installed.
-    
+
     private static void findCC()
     {
         if( !ccSearched ) {
@@ -300,9 +320,9 @@ public final class ComputerCraftAPI
             System.out.println( "ComputerCraftAPI: ComputerCraft method " + name + " not found." );
             return null;
         }
-    }    
-    
-    private static boolean ccSearched = false;    
+    }
+
+    private static boolean ccSearched = false;
     private static Class computerCraft = null;
     private static Method computerCraft_getVersion = null;
     private static Method computerCraft_createUniqueNumberedSaveDir = null;

--- a/src/main/java/dan200/computercraft/api/filesystem/IMount.java
+++ b/src/main/java/dan200/computercraft/api/filesystem/IMount.java
@@ -6,52 +6,66 @@
 
 package dan200.computercraft.api.filesystem;
 
+import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.peripheral.IComputerAccess;
+import net.minecraft.world.World;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
 /**
- * Represents a read only part of a virtual filesystem that can be mounted onto a computercraft using IComputerAccess.mount().
- * Ready made implementations of this interface can be created using ComputerCraftAPI.createSaveDirMount() or ComputerCraftAPI.createResourceMount(), or you're free to implement it yourselves!
- * @see dan200.computercraft.api.ComputerCraftAPI#createSaveDirMount(World, String)
- * @see dan200.computercraft.api.ComputerCraftAPI#createResourceMount(Class, String, String)
- * @see dan200.computercraft.api.peripheral.IComputerAccess#mount(String, IMount)
+ * Represents a read only part of a virtual filesystem that can be mounted onto a computer using
+ * {@link IComputerAccess#mount(String, IMount)}
+ *
+ * Ready made implementations of this interface can be created using
+ * {@link ComputerCraftAPI#createSaveDirMount(World, String, long)} or
+ * {@link ComputerCraftAPI#createResourceMount(Class, String, String)}, or you're free to implement it yourselves!
+ *
+ * @see ComputerCraftAPI#createSaveDirMount(World, String, long)
+ * @see ComputerCraftAPI#createResourceMount(Class, String, String)
+ * @see IComputerAccess#mount(String, IMount)
  * @see IWritableMount
  */
 public interface IMount
 {
     /**
      * Returns whether a file with a given path exists or not.
+     *
      * @param path A file path in normalised format, relative to the mount location. ie: "programs/myprogram"
-     * @return true if the file exists, false otherwise
+     * @return If the file exists.
      */
     public boolean exists( String path ) throws IOException;
 
     /**
      * Returns whether a file with a given path is a directory or not.
-     * @param path A file path in normalised format, relative to the mount location. ie: "programs/myprograms"
-     * @return true if the file exists and is a directory, false otherwise
+     *
+     * @param path A file path in normalised format, relative to the mount location. ie: "programs/myprograms".
+     * @return If the file exists and is a directory
      */
     public boolean isDirectory( String path ) throws IOException;
 
     /**
      * Returns the file names of all the files in a directory.
-     * @param path A file path in normalised format, relative to the mount location. ie: "programs/myprograms"
-     * @param contents A list of strings. Add all the file names to this list
+     *
+     * @param path     A file path in normalised format, relative to the mount location. ie: "programs/myprograms".
+     * @param contents A list of strings. Add all the file names to this list.
      */
     public void list( String path, List<String> contents ) throws IOException;
 
     /**
      * Returns the size of a file with a given path, in bytes
-     * @param path A file path in normalised format, relative to the mount location. ie: "programs/myprogram"
-     * @return the size of the file, in bytes
+     *
+     * @param path A file path in normalised format, relative to the mount location. ie: "programs/myprogram".
+     * @return The size of the file, in bytes.
      */
     public long getSize( String path ) throws IOException;
-    
+
     /**
-     * Opens a file with a given path, and returns an inputstream representing it's contents.
-     * @param path A file path in normalised format, relative to the mount location. ie: "programs/myprogram"
-     * @return a stream representing the contents of the file
+     * Opens a file with a given path, and returns an {@link InputStream} representing its contents.
+     *
+     * @param path A file path in normalised format, relative to the mount location. ie: "programs/myprogram".
+     * @return A stream representing the contents of the file.
      */
-    public InputStream openForRead( String path ) throws IOException;    
+    public InputStream openForRead( String path ) throws IOException;
 }

--- a/src/main/java/dan200/computercraft/api/filesystem/IWritableMount.java
+++ b/src/main/java/dan200/computercraft/api/filesystem/IWritableMount.java
@@ -6,47 +6,62 @@
 
 package dan200.computercraft.api.filesystem;
 
+import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.peripheral.IComputerAccess;
+import net.minecraft.world.World;
+
 import java.io.IOException;
 import java.io.OutputStream;
 
 /**
- * Represents a part of a virtual filesystem that can be mounted onto a computercraft using IComputerAccess.mount() or IComputerAccess.mountWritable(), that can also be written to.
- * Ready made implementations of this interface can be created using ComputerCraftAPI.createSaveDirMount(), or you're free to implement it yourselves!
- * @see dan200.computercraft.api.ComputerCraftAPI#createSaveDirMount(World, String)
- * @see dan200.computercraft.api.peripheral.IComputerAccess#mountWritable(String, dan200.computercraft.api.filesystem.IMount)
- * @see dan200.computercraft.api.filesystem.IMount
+ * Represents a part of a virtual filesystem that can be mounted onto a computer using {@link IComputerAccess#mount(String, IMount)}
+ * or {@link IComputerAccess#mountWritable(String, IWritableMount)}, that can also be written to.
+ *
+ * Ready made implementations of this interface can be created using
+ * {@link ComputerCraftAPI#createSaveDirMount(World, String, long)}, or you're free to implement it yourselves!
+ *
+ * @see ComputerCraftAPI#createSaveDirMount(World, String, long)
+ * @see IComputerAccess#mount(String, IMount)
+ * @see IComputerAccess#mountWritable(String, IWritableMount)
+ * @see IMount
  */
 public interface IWritableMount extends IMount
 {
     /**
      * Creates a directory at a given path inside the virtual file system.
-     * @param path A file path in normalised format, relative to the mount location. ie: "programs/mynewprograms"
+     *
+     * @param path A file path in normalised format, relative to the mount location. ie: "programs/mynewprograms".
      */
     public void makeDirectory( String path ) throws IOException;
 
     /**
      * Deletes a directory at a given path inside the virtual file system.
-     * @param path A file path in normalised format, relative to the mount location. ie: "programs/myoldprograms"
+     *
+     * @param path A file path in normalised format, relative to the mount location. ie: "programs/myoldprograms".
      */
     public void delete( String path ) throws IOException;
 
     /**
-     * Opens a file with a given path, and returns an outputstream for writing to it.
-     * @param path A file path in normalised format, relative to the mount location. ie: "programs/myprogram"
+     * Opens a file with a given path, and returns an {@link OutputStream} for writing to it.
+     *
+     * @param path A file path in normalised format, relative to the mount location. ie: "programs/myprogram".
      * @return a stream for writing to
      */
     public OutputStream openForWrite( String path ) throws IOException;
 
     /**
-     * Opens a file with a given path, and returns an outputstream for appending to it.
-     * @param path A file path in normalised format, relative to the mount location. ie: "programs/myprogram"
-     * @return a stream for writing to
+     * Opens a file with a given path, and returns an {@link OutputStream} for appending to it.
+     *
+     * @param path A file path in normalised format, relative to the mount location. ie: "programs/myprogram".
+     * @return A stream for writing to.
      */
     public OutputStream openForAppend( String path ) throws IOException;
 
     /**
-     * Get the ammount of free space on the mount, in bytes. You should decrease this value as the user writes to the mount, and write operations should fail once it reaches zero.
-     * @return The ammount of free space, in bytes.
+     * Get the amount of free space on the mount, in bytes. You should decrease this value as the user writes to the
+     * mount, and write operations should fail once it reaches zero.
+     *
+     * @return The amount of free space, in bytes.
      */
     public long getRemainingSpace() throws IOException;
 }

--- a/src/main/java/dan200/computercraft/api/lua/ILuaContext.java
+++ b/src/main/java/dan200/computercraft/api/lua/ILuaContext.java
@@ -7,52 +7,84 @@
 package dan200.computercraft.api.lua;
 
 /**
- * An interface passed to peripherals and ILuaObjects' by computers or turtles, providing methods
- * that allow the peripheral call to wait for events before returning, just like in lua.
- * This is very useful if you need to signal work to be performed on the main thread, and don't want to return
- * until the work has been completed.
+ * An interface passed to peripherals and {@link ILuaObject}s by computers or turtles, providing methods
+ * that allow the peripheral call to wait for events before returning, just like in lua. This is very useful if you need
+ * to signal work to be performed on the main thread, and don't want to return until the work has been completed.
  */
 public interface ILuaContext
 {
     /**
-     * Wait for an event to occur on the computercraft, suspending the thread until it arises. This method is exactly equivalent to os.pullEvent() in lua.
-     * @param filter A specific event to wait for, or null to wait for any event
-     * @return An object array containing the name of the event that occurred, and any event parameters
-     * @throws Exception If the user presses CTRL+T to terminate the current program while pullEvent() is waiting for an event, a "Terminated" exception will be thrown here.
-     * Do not attempt to common this exception, unless you wish to prevent termination, which is not recommended.
-     * @throws InterruptedException If the user shuts down or reboots the computercraft while pullEvent() is waiting for an event, InterruptedException will be thrown. This exception must not be caught or intercepted, or the computercraft will leak memory and end up in a broken state.
+     * Wait for an event to occur on the computer, suspending the thread until it arises. This method is exactly
+     * equivalent to {@code os.pullEvent()} in lua.
+     *
+     * @param filter A specific event to wait for, or null to wait for any event.
+     * @return An object array containing the name of the event that occurred, and any event parameters.
+     * @throws LuaException         If the user presses CTRL+T to terminate the current program while pullEvent() is
+     *                              waiting for an event, a "Terminated" exception will be thrown here.
+     *
+     *                              Do not attempt to catch this exception. You should use {@link #pullEventRaw(String)}
+     *                              should you wish to disable termination.
+     * @throws InterruptedException If the user shuts down or reboots the computer while pullEvent() is waiting for an
+     *                              event, InterruptedException will be thrown. This exception must not be caught or
+     *                              intercepted, or the computer will leak memory and end up in a broken state.
      */
     public Object[] pullEvent( String filter ) throws LuaException, InterruptedException;
-    
+
     /**
-     * The same as pullEvent(), except "terminated" events are ignored. Only use this if you want to prevent program termination, which is not recommended. This method is exactly equivalent to os.pullEventRaw() in lua.
-     * @param filter A specific event to wait for, or null to wait for any event
-     * @return An object array containing the name of the event that occurred, and any event parameters
-     * @throws InterruptedException If the user shuts down or reboots the computercraft while pullEventRaw() is waiting for an event, InterruptedException will be thrown. This exception must not be caught or intercepted, or the computercraft will leak memory and end up in a broken state.
+     * The same as {@link #pullEvent(String)}, except "terminated" events are ignored. Only use this if you want to
+     * prevent program termination, which is not recommended. This method is exactly equivalent to
+     * {@code os.pullEventRaw()} in lua.
+     *
+     * @param filter A specific event to wait for, or null to wait for any event.
+     * @return An object array containing the name of the event that occurred, and any event parameters.
+     * @throws InterruptedException If the user shuts down or reboots the computer while pullEventRaw() is waiting for
+     *                              an event, InterruptedException will be thrown. This exception must not be caught or
+     *                              intercepted, or the computer will leak memory and end up in a broken state.
      * @see #pullEvent(String)
      */
     public Object[] pullEventRaw( String filter ) throws InterruptedException;
-    
+
     /**
-     * Yield the current coroutine with some arguments until it is resumed. This method is exactly equivalent to coroutine.yield() in lua. Use pullEvent() if you wish to wait for events.
+     * Yield the current coroutine with some arguments until it is resumed. This method is exactly equivalent to
+     * {@code coroutine.yield()} in lua. Use {@code pullEvent()} if you wish to wait for events.
+     *
      * @param arguments An object array containing the arguments to pass to coroutine.yield()
      * @return An object array containing the return values from coroutine.yield()
-     * @throws InterruptedException If the user shuts down or reboots the computercraft the coroutine is suspended, InterruptedException will be thrown. This exception must not be caught or intercepted, or the computercraft will leak memory and end up in a broken state.
+     * @throws InterruptedException If the user shuts down or reboots the computer the coroutine is suspended,
+     *                              InterruptedException will be thrown. This exception must not be caught or
+     *                              intercepted, or the computer will leak memory and end up in a broken state.
      * @see #pullEvent(String)
      */
     public Object[] yield( Object[] arguments ) throws InterruptedException;
 
     /**
-     * TODO: Document me
-     * @param task
-     * @return
+     * Queue a task to be executed on the main server thread at the beginning of next tick, waiting for it to complete.
+     * This should be used when you need to interact with the world in a thread-safe manner.
+     *
+     * Note that the return values of your task are handled as events, meaning more complex objects such as maps or
+     * {@link ILuaObject} will not preserve their identities.
+     *
+     * @param task The task to execute on the main thread.
+     * @return The objects returned by {@code task}.
+     * @throws LuaException         If the task could not be queued, or if the task threw an exception.
+     * @throws InterruptedException If the user shuts down or reboots the computer the coroutine is suspended,
+     *                              InterruptedException will be thrown. This exception must not be caught or
+     *                              intercepted, or the computer will leak memory and end up in a broken state.
      */
     public Object[] executeMainThreadTask( ILuaTask task ) throws LuaException, InterruptedException;
 
     /**
-     * TODO: Document me
-     * @param task
-     * @return
+     * Queue a task to be executed on the main server thread at the beginning of next tick, but do not wait for it to
+     * complete. This should be used when you need to interact with the world in a thread-safe manner but do not care
+     * about the result or you wish to run asynchronously.
+     *
+     * When the task has finished, it will enqueue a {@code task_completed} event, which takes the task id, a success
+     * value and the return values, or an error message if it failed. If you need to wait on this event, it may be
+     * better to use {@link #executeMainThreadTask(ILuaTask)}.
+     *
+     * @param task The task to execute on the main thread.
+     * @return The "id" of the task. This will be the first argument to the {@code task_completed} event.
+     * @throws LuaException If the task could not be queued.
      */
     public long issueMainThreadTask( ILuaTask task ) throws LuaException;
 }

--- a/src/main/java/dan200/computercraft/api/lua/ILuaObject.java
+++ b/src/main/java/dan200/computercraft/api/lua/ILuaObject.java
@@ -6,21 +6,35 @@
 
 package dan200.computercraft.api.lua;
 
+import dan200.computercraft.api.peripheral.IComputerAccess;
+import dan200.computercraft.api.peripheral.IPeripheral;
+
 /**
- * An interface for representing custom objects returned by IPeripheral.callMethod() calls.
+ * An interface for representing custom objects returned by {@link IPeripheral#callMethod(IComputerAccess, ILuaContext, int, Object[])}
+ * calls.
+ *
  * Return objects implementing this interface to expose objects with methods to lua.
  */
 public interface ILuaObject
 {
     /**
-     * Get the names of the methods that this object implements. This works the same as IPeripheral.getMethodNames(). See that method for detailed documentation.
-     * @see dan200.computercraft.api.peripheral.IPeripheral#getMethodNames()
+     * Get the names of the methods that this object implements. This works the same as {@link IPeripheral#getMethodNames()}.
+     * See that method for detailed documentation.
+     *
+     * @see IPeripheral#getMethodNames()
      */
     public String[] getMethodNames();
 
     /**
-     * Called when a user calls one of the methods that this object implements. This works the same as IPeripheral.callMethod(). See that method for detailed documentation.
-     * @see dan200.computercraft.api.peripheral.IPeripheral#callMethod(dan200.computercraft.api.peripheral.IComputerAccess, ILuaContext, int, Object[])
+     * Called when a user calls one of the methods that this object implements. This works the same as
+     * {@link IPeripheral#callMethod(IComputerAccess, ILuaContext, int, Object[])}}. See that method for detailed
+     * documentation.
+     *
+     * @throws LuaException         If the task could not be queued, or if the task threw an exception.
+     * @throws InterruptedException If the user shuts down or reboots the computer the coroutine is suspended,
+     *                              InterruptedException will be thrown. This exception must not be caught or
+     *                              intercepted, or the computer will leak memory and end up in a broken state.w
+     * @see IPeripheral#callMethod(IComputerAccess, ILuaContext, int, Object[])
      */
     public Object[] callMethod( ILuaContext context, int method, Object[] arguments ) throws LuaException, InterruptedException;
 }

--- a/src/main/java/dan200/computercraft/api/lua/ILuaTask.java
+++ b/src/main/java/dan200/computercraft/api/lua/ILuaTask.java
@@ -6,7 +6,24 @@
 
 package dan200.computercraft.api.lua;
 
+/**
+ * A task which can be executed via {@link ILuaContext#executeMainThreadTask(ILuaTask)} or
+ * {@link ILuaContext#issueMainThreadTask(ILuaTask)}. This will be run on the main thread, at the beginning of the
+ * next tick.
+ *
+ * @see ILuaContext#executeMainThreadTask(ILuaTask)
+ * @see ILuaContext#issueMainThreadTask(ILuaTask)
+ */
 public interface ILuaTask
 {
+    /**
+     * Execute this task.
+     *
+     * @return The arguments to add to the {@code task_completed} event. These will be returned by
+     * {@link ILuaContext#executeMainThreadTask(ILuaTask)}.
+     * @throws LuaException If you throw any exception from this function, a lua error will be raised with the
+     *                      same message as your exception. Use this to throw appropriate errors if the wrong
+     *                      arguments are supplied to your method.
+     */
     public Object[] execute() throws LuaException;
 }

--- a/src/main/java/dan200/computercraft/api/lua/LuaException.java
+++ b/src/main/java/dan200/computercraft/api/lua/LuaException.java
@@ -7,10 +7,11 @@
 package dan200.computercraft.api.lua;
 
 /**
- * An exception representing an error in Lua, like that raised by the error() function
+ * An exception representing an error in Lua, like that raised by the {@code error()} function.
  */
 public class LuaException extends Exception
 {
+    private static final long serialVersionUID = -6136063076818512651L;
     private final int m_level;
 
     public LuaException()
@@ -29,6 +30,12 @@ public class LuaException extends Exception
         m_level = level;
     }
 
+    /**
+     * The level this error is raised at. Level 1 is the function's caller, level 2 is that function's caller, and so
+     * on.
+     *
+     * @return The level to raise the error at.
+     */
     public int getLevel()
     {
         return m_level;

--- a/src/main/java/dan200/computercraft/api/media/IMedia.java
+++ b/src/main/java/dan200/computercraft/api/media/IMedia.java
@@ -18,22 +18,26 @@ import net.minecraft.world.World;
 public interface IMedia
 {
     /**
-     * Get a string representing the label of this item. Will be called vi disk.getLabel() in lua.
-     * @param stack The itemstack to inspect
-     * @return The label. ie: "Dan's Programs"
+     * Get a string representing the label of this item. Will be called via {@code disk.getLabel()} in lua.
+     *
+     * @param stack The itemstack to inspect.
+     * @return The label. ie: "Dan's Programs".
      */
     public String getLabel( ItemStack stack );
 
     /**
-     * Set a string representing the label of this item. Will be called vi disk.setLabel() in lua.
+     * Set a string representing the label of this item. Will be called vi {@code disk.setLabel()} in lua.
+     *
      * @param stack The itemstack to modify.
      * @param label The string to set the label to.
      * @return true if the label was updated, false if the label may not be modified.
      */
     public boolean setLabel( ItemStack stack, String label );
-    
+
     /**
-     * If this disk represents an item with audio (like a record), get the readable name of the audio track. ie: "Jonathon Coulton - Still Alive"
+     * If this disk represents an item with audio (like a record), get the readable name of the audio track. ie:
+     * "Jonathon Coulton - Still Alive"
+     *
      * @param stack The itemstack to inspect.
      * @return The name, or null if this item does not represent an item with audio.
      */
@@ -41,16 +45,20 @@ public interface IMedia
 
     /**
      * If this disk represents an item with audio (like a record), get the resource name of the audio track to play.
+     *
      * @param stack The itemstack to inspect.
      * @return The name, or null if this item does not represent an item with audio.
      */
     public SoundEvent getAudio( ItemStack stack );
-    
+
     /**
-     * If this disk represents an item with data (like a floppy disk), get a mount representing it's contents. This will be mounted onto the filesystem of the computercraft while the media is in the disk drive.
+     * If this disk represents an item with data (like a floppy disk), get a mount representing it's contents. This will
+     * be mounted onto the filesystem of the computer while the media is in the disk drive.
+     *
      * @param stack The itemstack to inspect.
      * @param world The world in which the item and disk drive reside.
-     * @return The mount, or null if this item does not represent an item with data. If the IMount returned also implements IWritableMount, it will mounted using mountWritable()
+     * @return The mount, or null if this item does not represent an item with data. If the mount returned also
+     * implements {@link dan200.computercraft.api.filesystem.IWritableMount}, it will mounted using mountWritable()
      * @see dan200.computercraft.api.filesystem.IMount
      * @see dan200.computercraft.api.filesystem.IWritableMount
      * @see dan200.computercraft.api.ComputerCraftAPI#createSaveDirMount(World, String, long)

--- a/src/main/java/dan200/computercraft/api/media/IMediaProvider.java
+++ b/src/main/java/dan200/computercraft/api/media/IMediaProvider.java
@@ -9,15 +9,17 @@ package dan200.computercraft.api.media;
 import net.minecraft.item.ItemStack;
 
 /**
- * This interface is used to provide IMedia implementations for ItemStack
+ * This interface is used to provide {@link IMedia} implementations for {@link ItemStack}.
+ *
  * @see dan200.computercraft.api.ComputerCraftAPI#registerMediaProvider(IMediaProvider)
  */
 public interface IMediaProvider
 {
     /**
      * Produce an IMedia implementation from an ItemStack.
-     * @see dan200.computercraft.api.ComputerCraftAPI#registerMediaProvider(IMediaProvider)
+     *
      * @return an IMedia implementation, or null if the item is not something you wish to handle
+     * @see dan200.computercraft.api.ComputerCraftAPI#registerMediaProvider(IMediaProvider)
      */
     public IMedia getMedia( ItemStack stack );
 }

--- a/src/main/java/dan200/computercraft/api/peripheral/IComputerAccess.java
+++ b/src/main/java/dan200/computercraft/api/peripheral/IComputerAccess.java
@@ -6,8 +6,10 @@
 
 package dan200.computercraft.api.peripheral;
 
+import dan200.computercraft.api.ComputerCraftAPI;
 import dan200.computercraft.api.filesystem.IMount;
 import dan200.computercraft.api.filesystem.IWritableMount;
+import net.minecraft.world.World;
 
 /**
  * The interface passed to peripherals by computers or turtles, providing methods
@@ -17,30 +19,50 @@ import dan200.computercraft.api.filesystem.IWritableMount;
 public interface IComputerAccess
 {
     /**
-     * Mount a mount onto the computers' file system in a read only mode.<br>
-     * @param desiredLocation The location on the computercraft's file system where you would like the mount to be mounted.
-     * @param mount The mount object to mount on the computercraft. These can be obtained by calling ComputerCraftAPI.createSaveDirMount(), ComputerCraftAPI.createResourceMount() or by creating your own objects that implement the IMount interface.
-     * @return The location on the computercraft's file system where you the mount mounted, or null if there was already a file in the desired location. Store this value if you wish to unmount the mount later.
-     * @see dan200.computercraft.api.ComputerCraftAPI#createSaveDirMount(World, String)
-     * @see dan200.computercraft.api.ComputerCraftAPI#createResourceMount(Class, String, String)
-     * @see #mountWritable(String, dan200.computercraft.api.filesystem.IWritableMount)
+     * Mount a mount onto the computer's file system in a read only mode.
+     *
+     * @param desiredLocation The location on the computer's file system where you would like the mount to be mounted.
+     * @param mount           The mount object to mount on the computer.
+     * @return The location on the computer's file system where you the mount mounted, or {@code null} if there was already a
+     * file in the desired location. Store this value if you wish to unmount the mount later.
+     * @throws RuntimeException If the peripheral has been detached.
+     * @see ComputerCraftAPI#createSaveDirMount(World, String, long)
+     * @see ComputerCraftAPI#createResourceMount(Class, String, String)
+     * @see #mount(String, IMount, String)
+     * @see #mountWritable(String, IWritableMount)
      * @see #unmount(String)
-     * @see dan200.computercraft.api.filesystem.IMount
+     * @see IMount
      */
     public String mount( String desiredLocation, IMount mount );
 
     /**
-     * TODO: Document me
+     * Mount a mount onto the computer's file system in a read only mode.
+     *
+     * @param desiredLocation The location on the computer's file system where you would like the mount to be mounted.
+     * @param mount           The mount object to mount on the computer.
+     * @param driveName       A custom name to give for this mount location, as returned by {@code fs.getDrive()}.
+     * @return The location on the computer's file system where you the mount mounted, or {@code null} if there was already a
+     * file in the desired location. Store this value if you wish to unmount the mount later.
+     * @throws RuntimeException If the peripheral has been detached.
+     * @see ComputerCraftAPI#createSaveDirMount(World, String, long)
+     * @see ComputerCraftAPI#createResourceMount(Class, String, String)
+     * @see #mount(String, IMount)
+     * @see #mountWritable(String, IWritableMount)
+     * @see #unmount(String)
+     * @see IMount
      */
     public String mount( String desiredLocation, IMount mount, String driveName );
 
     /**
-     * Mount a mount onto the computers' file system in a writable mode.<br>
-     * @param desiredLocation The location on the computercraft's file system where you would like the mount to be mounted.
-     * @param mount The mount object to mount on the computercraft. These can be obtained by calling ComputerCraftAPI.createSaveDirMount() or by creating your own objects that implement the IWritableMount interface.
-     * @return The location on the computercraft's file system where you the mount mounted, or null if there was already a file in the desired location. Store this value if you wish to unmount the mount later.
-     * @see dan200.computercraft.api.ComputerCraftAPI#createSaveDirMount(World, String)
-     * @see dan200.computercraft.api.ComputerCraftAPI#createResourceMount(Class, String, String)
+     * Mount a mount onto the computer's file system in a writable mode.
+     *
+     * @param desiredLocation The location on the computer's file system where you would like the mount to be mounted.
+     * @param mount           The mount object to mount on the computer.
+     * @return The location on the computer's file system where you the mount mounted, or null if there was already a
+     * file in the desired location. Store this value if you wish to unmount the mount later.
+     * @throws RuntimeException If the peripheral has been detached.
+     * @see ComputerCraftAPI#createSaveDirMount(World, String, long)
+     * @see ComputerCraftAPI#createResourceMount(Class, String, String)
      * @see #mount(String, IMount)
      * @see #unmount(String)
      * @see IMount
@@ -48,55 +70,81 @@ public interface IComputerAccess
     public String mountWritable( String desiredLocation, IWritableMount mount );
 
     /**
-     * TODO: Document me
+     * Mount a mount onto the computer's file system in a writable mode.
+     *
+     * @param desiredLocation The location on the computer's file system where you would like the mount to be mounted.
+     * @param mount           The mount object to mount on the computer.
+     * @param driveName       A custom name to give for this mount location, as returned by {@code fs.getDrive()}.
+     * @return The location on the computer's file system where you the mount mounted, or null if there was already a
+     * file in the desired location. Store this value if you wish to unmount the mount later.
+     * @throws RuntimeException If the peripheral has been detached.
+     * @see ComputerCraftAPI#createSaveDirMount(World, String, long)
+     * @see ComputerCraftAPI#createResourceMount(Class, String, String)
+     * @see #mount(String, IMount)
+     * @see #unmount(String)
+     * @see IMount
      */
     public String mountWritable( String desiredLocation, IWritableMount mount, String driveName );
 
     /**
-     * Unmounts a directory previously mounted onto the computers file system by mount() or mountWritable().<br>
-     * When a directory is unmounted, it will disappear from the computers file system, and the user will no longer be able to
-     * access it. All directories mounted by a mount or mountWritable are automatically unmounted when the peripheral
-     * is attached if they have not been explicitly unmounted.
-     * @param location    The desired location in the computers file system of the directory to unmount.
-     *                    This must be the location of a directory previously mounted by mount() or mountWritable(), as
-     *                    indicated by their return value.
-     * @see    #mount(String, IMount)
-     * @see    #mountWritable(String, IWritableMount)
+     * Unmounts a directory previously mounted onto the computers file system by {@link #mount(String, IMount)}
+     * or {@link #mountWritable(String, IWritableMount)}.
+     *
+     * When a directory is unmounted, it will disappear from the computers file system, and the user will no longer be
+     * able to access it. All directories mounted by a mount or mountWritable are automatically unmounted when the
+     * peripheral is attached if they have not been explicitly unmounted.
+     *
+     * Note that you cannot unmount another peripheral's mounts.
+     *
+     * @param location The desired location in the computers file system of the directory to unmount.
+     *                 This must be the location of a directory previously mounted by {@link #mount(String, IMount)} or
+     *                 {@link #mountWritable(String, IWritableMount)}, as indicated by their return value.
+     * @throws RuntimeException If the peripheral has been detached.
+     * @throws RuntimeException If the mount does not exist, or was mounted by another peripheral.
+     * @see #mount(String, IMount)
+     * @see #mountWritable(String, IWritableMount)
      */
     public void unmount( String location );
-    
-    /**
-     * Returns the numerical ID of this computercraft.<br>
-     * This is the same number obtained by calling os.getComputerID() or running the "id" program from lua,
-     * and is guarunteed unique. This number will be positive.
-     * @return    The identifier.
-     */
-    public int getID();    
 
     /**
-     * Causes an event to be raised on this computercraft, which the computercraft can respond to by calling
-     * os.pullEvent(). This can be used to notify the computercraft when things happen in the world or to
+     * Returns the numerical ID of this computer.
+     *
+     * This is the same number obtained by calling {@code os.getComputerID()} or running the "id" program from lua,
+     * and is guaranteed unique. This number will be positive.
+     *
+     * @return The identifier.
+     */
+    public int getID();
+
+    /**
+     * Causes an event to be raised on this computer, which the computer can respond to by calling
+     * {@code os.pullEvent()}. This can be used to notify the computer when things happen in the world or to
      * this peripheral.
-     * @param event        A string identifying the type of event that has occurred, this will be
-     *                    returned as the first value from os.pullEvent(). It is recommended that you
-     *                    you choose a name that is unique, and recognisable as originating from your 
-     *                    peripheral. eg: If your peripheral type is "button", a suitable event would be
-     *                    "button_pressed".
-     * @param arguments    In addition to a name, you may pass an array of extra arguments to the event, that will
-     *                    be supplied as extra return values to os.pullEvent(). Objects in the array will be converted
-     *                    to lua data types in the same fashion as the return values of IPeripheral.callMethod().<br>
-     *                    You may supply null to indicate that no arguments are to be supplied.
+     *
+     * @param event     A string identifying the type of event that has occurred, this will be
+     *                  returned as the first value from {@code os.pullEvent()}. It is recommended that you
+     *                  you choose a name that is unique, and recognisable as originating from your
+     *                  peripheral. eg: If your peripheral type is "button", a suitable event would be
+     *                  "button_pressed".
+     * @param arguments In addition to a name, you may pass an array of extra arguments to the event, that will
+     *                  be supplied as extra return values to os.pullEvent(). Objects in the array will be converted
+     *                  to lua data types in the same fashion as the return values of IPeripheral.callMethod().
+     *
+     *                  You may supply {@code null} to indicate that no arguments are to be supplied.
+     * @throws RuntimeException If the peripheral has been detached.
      * @see dan200.computercraft.api.peripheral.IPeripheral#callMethod
      */
     public void queueEvent( String event, Object[] arguments );
 
     /**
-     * Get a string, unique to the computercraft, by which the computercraft refers to this peripheral.
+     * Get a string, unique to the computer, by which the computer refers to this peripheral.
      * For directly attached peripherals this will be "left","right","front","back",etc, but
      * for peripherals attached remotely it will be different. It is good practice to supply
-     * this string when raising events to the computercraft, so that the computercraft knows from
+     * this string when raising events to the computer, so that the computer knows from
      * which peripheral the event came.
-     * @return A string unique to the computercraft, but not globally.
+     *
+     * @return A string unique to the computer, but not globally.
+     * @throws RuntimeException If the peripheral has been detached.
      */
     public String getAttachmentName();
 }

--- a/src/main/java/dan200/computercraft/api/peripheral/IPeripheral.java
+++ b/src/main/java/dan200/computercraft/api/peripheral/IPeripheral.java
@@ -10,89 +10,108 @@ import dan200.computercraft.api.lua.ILuaContext;
 import dan200.computercraft.api.lua.LuaException;
 
 /**
- * The interface that defines a peripheral. See IPeripheralProvider for how to associate blocks with peripherals.
+ * The interface that defines a peripheral. See {@link IPeripheralProvider} for how to associate blocks with peripherals.
  */
 public interface IPeripheral
 {
     /**
      * Should return a string that uniquely identifies this type of peripheral.
-     * This can be queried from lua by calling peripheral.getType()
-     * @return     A string identifying the type of peripheral.
+     * This can be queried from lua by calling {@code peripheral.getType()}
+     *
+     * @return A string identifying the type of peripheral.
      */
     public String getType();
-    
+
     /**
-     * Should return an array of strings that identify the methods that this 
+     * Should return an array of strings that identify the methods that this
      * peripheral exposes to Lua. This will be called once before each attachment,
      * and should not change when called multiple times.
-     * @return     An array of strings representing method names.
-     * @see     #callMethod
+     *
+     * @return An array of strings representing method names.
+     * @see #callMethod
      */
     public String[] getMethodNames();
-    
+
     /**
-     * This is called when a lua program on an attached computercraft calls peripheral.call() with
-     * one of the methods exposed by getMethodNames().<br>
-     * <br>
+     * This is called when a lua program on an attached computer calls {@code peripheral.call()} with
+     * one of the methods exposed by {@link #getMethodNames()}.
+     *
      * Be aware that this will be called from the ComputerCraft Lua thread, and must be thread-safe
-     * when interacting with minecraft objects.
-     * @param     computer    The interface to the computercraft that is making the call. Remember that multiple
-     *                        computers can be attached to a peripheral at once.
-     * @param    context        The context of the currently running lua thread. This can be used to wait for events
-     *                        or otherwise yield.
-     * @param    method        An integer identifying which of the methods from getMethodNames() the computercraft
-     *                        wishes to call. The integer indicates the index into the getMethodNames() table
-     *                        that corresponds to the string passed into peripheral.call()
-     * @param    arguments    An array of objects, representing the arguments passed into peripheral.call().<br>
-     *                        Lua values of type "string" will be represented by Object type String.<br>
-     *                        Lua values of type "number" will be represented by Object type Double.<br>
-     *                        Lua values of type "boolean" will be represented by Object type Boolean.<br>
-     *                        Lua values of any other type will be represented by a null object.<br>
-     *                        This array will be empty if no arguments are passed.
-     * @return     An array of objects, representing values you wish to return to the lua program.<br>
-     *            Integers, Doubles, Floats, Strings, Booleans and null be converted to their corresponding lua type.<br>
-     *            All other types will be converted to nil.<br>
-     *            You may return null to indicate no values should be returned.
-     * @throws    Exception    If you throw any exception from this function, a lua error will be raised with the
-     *                        same message as your exception. Use this to throw appropriate errors if the wrong
-     *                        arguments are supplied to your method.
-     * @see     #getMethodNames
+     * when interacting with Minecraft objects.
+     *
+     * @param computer  The interface to the computer that is making the call. Remember that multiple
+     *                  computers can be attached to a peripheral at once.
+     * @param context   The context of the currently running lua thread. This can be used to wait for events
+     *                  or otherwise yield.
+     * @param method    An integer identifying which of the methods from getMethodNames() the computercraft
+     *                  wishes to call. The integer indicates the index into the getMethodNames() table
+     *                  that corresponds to the string passed into peripheral.call()
+     * @param arguments An array of objects, representing the arguments passed into {@code peripheral.call()}.<br>
+     *                  Lua values of type "string" will be represented by Object type String.<br>
+     *                  Lua values of type "number" will be represented by Object type Double.<br>
+     *                  Lua values of type "boolean" will be represented by Object type Boolean.<br>
+     *                  Lua values of type "table" will be represented by Object type Map.<br>
+     *                  Lua values of any other type will be represented by a null object.<br>
+     *                  This array will be empty if no arguments are passed.
+     * @return An array of objects, representing values you wish to return to the lua program. Integers, Doubles, Floats,
+     * Strings, Booleans, Maps and ILuaObject and null be converted to their corresponding lua type. All other types
+     * will be converted to nil.
+     *
+     * You may return null to indicate no values should be returned.
+     * @throws LuaException         If you throw any exception from this function, a lua error will be raised with the
+     *                              same message as your exception. Use this to throw appropriate errors if the wrong
+     *                              arguments are supplied to your method.
+     * @throws InterruptedException If the user shuts down or reboots the computer the coroutine is suspended,
+     *                              InterruptedException will be thrown. This exception must not be caught or
+     *                              intercepted, or the computer will leak memory and end up in a broken state.
+     * @see #getMethodNames
      */
     public Object[] callMethod( IComputerAccess computer, ILuaContext context, int method, Object[] arguments ) throws LuaException, InterruptedException;
-    
+
     /**
-     * Is called when canAttachToSide has returned true, and a computercraft is attaching to the peripheral.
-     * This will occur when a peripheral is placed next to an active computercraft, when a computercraft is turned on next to a peripheral,
-     * or when a turtle travels into a square next to a peripheral.
-     * Between calls to attach() and detach(), the attached computercraft can make method calls on the peripheral using peripheral.call().
-     * This method can be used to keep track of which computers are attached to the peripheral, or to take action when attachment
-     * occurs.<br>
-     * <br>
+     * Is called when canAttachToSide has returned true, and a computer is attaching to the peripheral.
+     *
+     * This will occur when a peripheral is placed next to an active computer, when a computer is turned on next to a
+     * peripheral, or when a turtle travels into a square next to a peripheral.
+     *
+     * Between calls to attach() and detach(), the attached computer can make method calls on the peripheral using
+     * {@code peripheral.call()}. This method can be used to keep track of which computers are attached to the
+     * peripheral, or to take action when attachment occurs.
+     *
      * Be aware that this will be called from the ComputerCraft Lua thread, and must be thread-safe
-     * when interacting with minecraft objects.
-     * @param     computer        The interface to the computercraft that is being attached. Remember that multiple
-     *                            computers can be attached to a peripheral at once.
-     * @see        #detach
+     * when interacting with Minecraft objects.
+     *
+     * @param computer The interface to the computer that is being attached. Remember that multiple
+     *                 computers can be attached to a peripheral at once.
+     * @see #detach
      */
     public void attach( IComputerAccess computer );
 
     /**
-     * Is called when a computercraft is detaching from the peripheral.
-     * This will occur when a computercraft shuts down, when the peripheral is removed while attached to computers,
-     * or when a turtle moves away from a square attached to a peripheral.
-     * This method can be used to keep track of which computers are attached to the peripheral, or to take action when detachment
-     * occurs.<br>
-     * <br>
+     * Is called when a computer is detaching from the peripheral.
+     *
+     * This will occur when a computer shuts down, when the peripheral is removed while attached to computers,
+     * or when a turtle moves away from a square attached to a peripheral. This method can be used to keep track of
+     * which computers are attached to the peripheral, or to take action when detachment
+     * occurs.
+     *
      * Be aware that this will be called from the ComputerCraft Lua thread, and must be thread-safe
-     * when interacting with minecraft objects.
-     * @param     computer        The interface to the computercraft that is being detached. Remember that multiple
-     *                            computers can be attached to a peripheral at once.
-     * @see        #detach
+     * when interacting with Minecraft objects.
+     *
+     * @param computer The interface to the computer that is being detached. Remember that multiple
+     *                 computers can be attached to a peripheral at once.
+     * @see #detach
      */
     public void detach( IComputerAccess computer );
 
     /**
-     * TODO: Document me
+     * Determine whether this peripheral is equivalent to another one.
+     *
+     * The minimal example should at least check whether they are the same object. However, you may wish to check if
+     * they point to the same block or tile entity.
+     *
+     * @param other The peripheral to compare against. This may be {@code null}.
+     * @return Whether these peripherals are equivalent.
      */
     public boolean equals( IPeripheral other );
 }

--- a/src/main/java/dan200/computercraft/api/peripheral/IPeripheralProvider.java
+++ b/src/main/java/dan200/computercraft/api/peripheral/IPeripheralProvider.java
@@ -6,20 +6,22 @@
 
 package dan200.computercraft.api.peripheral;
 
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 /**
- * This interface is used to create peripheral implementations for blocks
+ * This interface is used to create peripheral implementations for blocks.
+ *
  * @see dan200.computercraft.api.ComputerCraftAPI#registerPeripheralProvider(IPeripheralProvider)
  */
 public interface IPeripheralProvider
 {
     /**
      * Produce an peripheral implementation from a block location.
+     *
+     * @return A peripheral, or {@code null} if there is not a peripheral here you'd like to handle.
      * @see dan200.computercraft.api.ComputerCraftAPI#registerPeripheralProvider(IPeripheralProvider)
-     * @return a peripheral, or null if there is not a peripheral here you'd like to handle.
      */
     public IPeripheral getPeripheral( World world, BlockPos pos, EnumFacing side );
 }

--- a/src/main/java/dan200/computercraft/api/permissions/ITurtlePermissionProvider.java
+++ b/src/main/java/dan200/computercraft/api/permissions/ITurtlePermissionProvider.java
@@ -10,11 +10,31 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 /**
- * This interface is used to restrict where turtles can move or build
+ * This interface is used to restrict where turtles can move or build.
+ *
+ * Turtles will call these methods before attempting to perform an action, allowing them to be cancelled.
+ *
  * @see dan200.computercraft.api.ComputerCraftAPI#registerPermissionProvider(ITurtlePermissionProvider)
  */
 public interface ITurtlePermissionProvider
 {
+    /**
+     * Determine whether a block can be entered by a turtle.
+     *
+     * @param world The world the block exists in
+     * @param pos   The location of the block.
+     * @return Whether the turtle can move into this block.
+     */
     public boolean isBlockEnterable( World world, BlockPos pos );
+
+    /**
+     * Determine whether a block can be modified by a turtle.
+     *
+     * This includes breaking and placing blocks.
+     *
+     * @param world The world the block exists in
+     * @param pos   The location of the block.
+     * @return Whether the turtle can modify this block.
+     */
     public boolean isBlockEditable( World world, BlockPos pos );
 }

--- a/src/main/java/dan200/computercraft/api/redstone/IBundledRedstoneProvider.java
+++ b/src/main/java/dan200/computercraft/api/redstone/IBundledRedstoneProvider.java
@@ -6,20 +6,23 @@
 
 package dan200.computercraft.api.redstone;
 
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 /**
- * This interface is used to provide bundled redstone output for blocks
+ * This interface is used to provide bundled redstone output for blocks.
+ *
  * @see dan200.computercraft.api.ComputerCraftAPI#registerBundledRedstoneProvider(IBundledRedstoneProvider)
  */
 public interface IBundledRedstoneProvider
 {
     /**
      * Produce an bundled redstone output from a block location.
+     *
+     * @return A number in the range 0-65535 to indicate this block is providing output, or -1 if you do not wish to
+     * handle this block.
      * @see dan200.computercraft.api.ComputerCraftAPI#registerBundledRedstoneProvider(IBundledRedstoneProvider)
-     * @return a number in the range 0-65535 to indicate this block is providing output, or -1 if you do not wish to handle this block
      */
     public int getBundledRedstoneOutput( World world, BlockPos pos, EnumFacing side );
 }

--- a/src/main/java/dan200/computercraft/api/turtle/ITurtleAccess.java
+++ b/src/main/java/dan200/computercraft/api/turtle/ITurtleAccess.java
@@ -11,114 +11,179 @@ import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
 /**
  * The interface passed to turtle by turtles, providing methods that they can call.
- * This should not be implemented by your classes. Do not interact with turtles except via this interface and ITurtleUpgrade.
+ *
+ * This should not be implemented by your classes. Do not interact with turtles except via this interface and
+ * {@link ITurtleUpgrade}.
  */
 public interface ITurtleAccess
 {
     /**
      * Returns the world in which the turtle resides.
+     *
      * @return the world in which the turtle resides.
      */
     public World getWorld();
 
     /**
      * Returns a vector containing the integer co-ordinates at which the turtle resides.
+     *
      * @return a vector containing the integer co-ordinates at which the turtle resides.
      */
     public BlockPos getPosition();
 
     /**
-     * TODO: Document me
+     * Attempt to move this turtle to a new position.
+     *
+     * This will preserve the turtle's internal state, such as it's inventory, computer and upgrades. It should
+     * be used before playing a movement animation using {@link #playAnimation(TurtleAnimation)}.
+     *
+     * @param world The new world to move it to
+     * @param pos   The new position to move it to.
+     * @return Whether the movement was successful. It may fail if the block was not loaded or the block placement
+     * was cancelled. Note this will not check
+     * {@link dan200.computercraft.api.permissions.ITurtlePermissionProvider#isBlockEnterable(World, BlockPos)}.
+     * @throws UnsupportedOperationException When attempting to teleport on the client side.
      */
     public boolean teleportTo( World world, BlockPos pos );
 
     /**
      * Returns a vector containing the floating point co-ordinates at which the turtle is rendered.
      * This will shift when the turtle is moving.
-     * @param f The subframe fraction
-     * @return a vector containing the floating point co-ordinates at which the turtle resides.
+     *
+     * @param f The subframe fraction.
+     * @return A vector containing the floating point co-ordinates at which the turtle resides.
+     * @see #getVisualYaw(float)
      */
     public Vec3d getVisualPosition( float f );
 
     /**
-     * TODO: Document me
+     * Returns the yaw the turtle is facing when it is rendered.
+     *
+     * @param f The subframe fraction.
+     * @return The yaw the turtle is facing.
+     * @see #getVisualPosition(float)
      */
     public float getVisualYaw( float f );
 
     /**
      * Returns the world direction the turtle is currently facing.
-     * @return the world direction the turtle is currently facing.
+     *
+     * @return The world direction the turtle is currently facing.
+     * @see #setDirection(EnumFacing)
      */
     public EnumFacing getDirection();
 
     /**
-     * TODO: Document me
+     * Set the direction the turtle is facing. Note that this will not play a rotation animation, you will also need to
+     * call {@link #playAnimation(TurtleAnimation)} to do so.
+     *
+     * @param dir The new direction to set. This should be on either the x or z axis (so north, south, east or west).
+     * @see #getDirection()
      */
     public void setDirection( EnumFacing dir );
 
     /**
-     * TODO: Document me
+     * Get the currently selected slot in the turtle's inventory.
+     *
+     * @return An integer representing the current slot.
+     * @see #getInventory()
+     * @see #setSelectedSlot(int)
      */
     public int getSelectedSlot();
 
     /**
-     * TODO: Document me
+     * Set the currently selected slot in the turtle's inventory.
+     *
+     * @param slot The slot to set. This must be greater or equal to 0 and less than the inventory size. Otherwise no
+     *             action will be taken.
+     * @throws UnsupportedOperationException When attempting to change the slot on the client side.
+     * @see #getInventory()
+     * @see #getSelectedSlot()
      */
     public void setSelectedSlot( int slot );
 
     /**
      * Sets the colour of the turtle, as if the player had dyed it with a dye item.
-     * @param dyeColour 0-15 to dye the turtle one of the 16 standard minecraft colours, or -1 to remove the dye from the turtle.
+     *
+     * @param dyeColour 0-15 to dye the turtle one of the 16 standard Minecraft colours, or -1 to remove the dye from the turtle.
+     * @see #getDyeColour()
      */
     public void setDyeColour( int dyeColour );
 
     /**
      * Gets the colour the turtle has been dyed.
-     * @return 0-15 if the turtle has been dyed one of the 16 standard minecraft colours, -1 if the turtle is clean.
+     *
+     * @return 0-15 if the turtle has been dyed one of the 16 standard Minecraft colours, -1 if the turtle is clean.
+     * @see #getDyeColour()
      */
     public int getDyeColour();
 
     /**
-     * TODO: Document me
+     * Get the inventory of this turtle
+     *
+     * @return This turtle's inventory
      */
     public IInventory getInventory();
 
     /**
-     * TODO: Document me
+     * Determine whether this turtle will require fuel when performing actions.
+     *
+     * @return Whether this turtle needs fuel.
+     * @see #getFuelLevel()
+     * @see #setFuelLevel(int)
      */
     public boolean isFuelNeeded();
 
     /**
-     * TODO: Document me
+     * Get the current fuel level of this turtle.
+     *
+     * @return The turtle's current fuel level.
+     * @see #isFuelNeeded()
+     * @see #setFuelLevel(int)
      */
     public int getFuelLevel();
 
     /**
-     * TODO: Document me
+     * Set the fuel level to a new value. It is generally preferred to use {@link #consumeFuel(int)}} or {@link #addFuel(int)}
+     * instead.
+     *
+     * @param fuel The new amount of fuel. This must be between 0 and the fuel limit.
+     * @see #getFuelLevel()
+     * @see #getFuelLimit()
+     * @see #addFuel(int)
+     * @see #consumeFuel(int)
      */
     public void setFuelLevel( int fuel );
 
     /**
-     * TODO: Document me
+     * Get the maximum amount of fuel a turtle can hold.
+     *
+     * @return The turtle's fuel limit.
      */
     public int getFuelLimit();
 
     /**
      * Removes some fuel from the turtles fuel supply. Negative numbers can be passed in to INCREASE the fuel level of the turtle.
-     * @return Whether the turtle was able to consume the ammount of fuel specified. Will return false if you supply a number
-     * greater than the current fuel level of the turtle.
+     *
+     * @param fuel The amount of fuel to consume.
+     * @return Whether the turtle was able to consume the amount of fuel specified. Will return false if you supply a number
+     * greater than the current fuel level of the turtle. No fuel will be consumed if {@code false} is returned.
+     * @throws UnsupportedOperationException When attempting to consume fuel on the client side.
      */
     public boolean consumeFuel( int fuel );
 
     /**
-     * TODO: Document me
+     * Increase the turtle's fuel level by the given amount.
+     *
+     * @param fuel The amount to refuel with.
+     * @throws UnsupportedOperationException When attempting to refuel on the client side.
      */
     public void addFuel( int fuel );
 
@@ -128,42 +193,67 @@ public interface ITurtleAccess
      * with the turtles standard movement and tool commands. An issued command will return an unique integer, which will
      * be supplied as a parameter to a "turtle_response" event issued to the turtle after the command has completed. Look at the
      * lua source code for "rom/apis/turtle" for how to build a lua wrapper around this functionality.
+     *
      * @param command an object which will execute the custom command when its point in the queue is reached
      * @return the objects the command returned when executed. you should probably return these to the player
      * unchanged if called from a peripheral method.
+     * @throws UnsupportedOperationException When attempting to execute a command on the client side.
      * @see ITurtleCommand
      */
     public Object[] executeCommand( ILuaContext context, ITurtleCommand command ) throws LuaException, InterruptedException;
 
     /**
-     * TODO: Document me
+     * Start playing a specific animation. This will prevent other turtle commands from executing until
+     * it is finished.
+     *
+     * @param animation The animation to play.
+     * @throws UnsupportedOperationException When attempting to execute play an animation on the client side.
+     * @see TurtleAnimation
      */
     public void playAnimation( TurtleAnimation animation );
 
     /**
      * Returns the turtle on the specified side of the turtle, if there is one.
-     * @return the turtle on the specified side of the turtle, if there is one.
+     *
+     * @return The upgrade on the specified side of the turtle, if there is one.
+     * @see #setUpgrade(TurtleSide, ITurtleUpgrade)
      */
     public ITurtleUpgrade getUpgrade( TurtleSide side );
 
     /**
-     * TODO: Document me
+     * Set the upgrade for a given side, resetting peripherals and clearing upgrade specific data.
+     *
+     * @param side    The side to set the upgrade on.
+     * @param upgrade The upgrade to set, may be {@code null} to clear.
+     * @see #getUpgrade(TurtleSide)
      */
     public void setUpgrade( TurtleSide side, ITurtleUpgrade upgrade );
 
     /**
      * Returns the peripheral created by the upgrade on the specified side of the turtle, if there is one.
-     * @return the peripheral created by the upgrade on the specified side of the turtle, if there is one.
+     *
+     * @return The peripheral created by the upgrade on the specified side of the turtle, {@code null} if none exists.
      */
     public IPeripheral getPeripheral( TurtleSide side );
 
     /**
-     * TODO: Document me
+     * Get an upgrade-specific NBT compound, which can be used to store arbitrary data.
+     *
+     * This will be persisted across turtle restarts and chunk loads, as well as being synced to the client. You must
+     * call {@link #updateUpgradeNBTData(TurtleSide)} after modifying it.
+     *
+     * @param side The side to get the upgrade data for.
+     * @return The upgrade-specific data.
+     * @see #updateUpgradeNBTData(TurtleSide)
      */
     public NBTTagCompound getUpgradeNBTData( TurtleSide side );
 
     /**
-     * TODO: Document me
+     * Mark the upgrade-specific data as dirty on a specific side. This is required for the data to be synced to the
+     * client and persisted.
+     *
+     * @param side The side to mark dirty.
+     * @see #updateUpgradeNBTData(TurtleSide)
      */
     public void updateUpgradeNBTData( TurtleSide side );
 }

--- a/src/main/java/dan200/computercraft/api/turtle/ITurtleCommand.java
+++ b/src/main/java/dan200/computercraft/api/turtle/ITurtleCommand.java
@@ -6,20 +6,27 @@
 
 package dan200.computercraft.api.turtle;
 
+import dan200.computercraft.api.lua.ILuaContext;
+
 /**
- * An interface for objects executing custom turtle commands, used with ITurtleAccess.issueCommand
- * @see ITurtleAccess#executeCommand(dan200.computercraft.api.lua.ILuaContext,ITurtleCommand)
+ * An interface for objects executing custom turtle commands, used with {@link ITurtleAccess#executeCommand(ILuaContext, ITurtleCommand)}.
+ *
+ * @see ITurtleAccess#executeCommand(ILuaContext, ITurtleCommand)
  */
 public interface ITurtleCommand
 {
     /**
      * Will be called by the turtle on the main thread when it is time to execute the custom command.
+     *
      * The handler should either perform the work of the command, and return success, or return
      * failure with an error message to indicate the command cannot be executed at this time.
-     * @param turtle access to the turtle for whom the command was issued
-     * @return TurtleCommandResult.success() or TurtleCommandResult.failure( errorMessage )
-     * @see ITurtleAccess#executeCommand(dan200.computercraft.api.lua.ILuaContext,ITurtleCommand)
-     * @see dan200.computercraft.api.turtle.TurtleCommandResult
+     *
+     * @param turtle Access to the turtle for whom the command was issued.
+     * @return A result, indicating whether this action succeeded or not.
+     * @see ITurtleAccess#executeCommand(ILuaContext, ITurtleCommand)
+     * @see TurtleCommandResult#success()
+     * @see TurtleCommandResult#failure(String)
+     * @see TurtleCommandResult
      */
     public TurtleCommandResult execute( ITurtleAccess turtle );
 }

--- a/src/main/java/dan200/computercraft/api/turtle/ITurtleUpgrade.java
+++ b/src/main/java/dan200/computercraft/api/turtle/ITurtleUpgrade.java
@@ -6,8 +6,10 @@
 
 package dan200.computercraft.api.turtle;
 
+import dan200.computercraft.api.ComputerCraftAPI;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import net.minecraft.client.renderer.block.model.IBakedModel;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
@@ -21,7 +23,8 @@ import javax.vecmath.Matrix4f;
 /**
  * The primary interface for defining an update for Turtles. A turtle update
  * can either be a new tool, or a new peripheral.
- * @see dan200.computercraft.api.ComputerCraftAPI#registerTurtleUpgrade( dan200.computercraft.api.turtle.ITurtleUpgrade )
+ *
+ * @see ComputerCraftAPI#registerTurtleUpgrade(ITurtleUpgrade)
  */
 public interface ITurtleUpgrade
 {
@@ -29,7 +32,8 @@ public interface ITurtleUpgrade
      * Gets a unique identifier representing this type of turtle upgrade. eg: "computercraft:wireless_modem" or "my_mod:my_upgrade".
      * You should use a unique resource domain to ensure this upgrade is uniquely identified.
      * The turtle will fail registration if an already used ID is specified.
-     * @see dan200.computercraft.api.ComputerCraftAPI#registerTurtleUpgrade( dan200.computercraft.api.turtle.ITurtleUpgrade )
+     *
+     * @see ComputerCraftAPI#registerTurtleUpgrade(ITurtleUpgrade)
      */
     public ResourceLocation getUpgradeID();
 
@@ -38,71 +42,83 @@ public interface ITurtleUpgrade
      * for backwards compatibility with pre-1.76 worlds. If your upgrade was
      * not released for older ComputerCraft versions, you can return -1 here.
      * The turtle will fail registration if an already used positive ID is specified.
-     * @see dan200.computercraft.api.ComputerCraftAPI#registerTurtleUpgrade( dan200.computercraft.api.turtle.ITurtleUpgrade )
+     *
+     * @see ComputerCraftAPI#registerTurtleUpgrade(ITurtleUpgrade)
      */
     public int getLegacyUpgradeID();
 
     /**
-     * Return a String to describe this type of turtle in turtle item names.
+     * Return an unlocalised string to describe this type of turtle in turtle item names.
+     *
      * Examples of built-in adjectives are "Wireless", "Mining" and "Crafty".
-     */    
+     */
     public String getUnlocalisedAdjective();
 
     /**
      * Return whether this turtle adds a tool or a peripheral to the turtle.
+     *
      * @see TurtleUpgradeType for the differences between the two.
-     */    
+     */
     public TurtleUpgradeType getType();
-    
+
     /**
      * Return an item stack representing the type of item that a turtle must be crafted
      * with to create a turtle which holds this upgrade. This item stack is also used
-     * to determine the upgrade given by turtle.equip()
+     * to determine the upgrade given by {@code turtle.equip()}
      */
     public ItemStack getCraftingItem();
 
     /**
-     * Will only be called for peripheral upgrades. Creates a peripheral for a turtle
-     * being placed using this upgrade. The peripheral created will be stored
-     * for the lifetime of the upgrade, will have update() called once-per-tick, and will be
-     * attached, detached and have methods called in the same manner as a Computer peripheral.
+     * Will only be called for peripheral upgrades. Creates a peripheral for a turtle being placed using this upgrade.
+     *
+     * The peripheral created will be stored for the lifetime of the upgrade and will be passed as an argument to
+     * {@link #update(ITurtleAccess, TurtleSide)}. It will be attached, detached and have methods called in the same
+     * manner as a Computer peripheral.
      *
      * @param turtle Access to the turtle that the peripheral is being created for.
-     * @param side Which side of the turtle (left or right) that the upgrade resides on.
-     * @return The newly created peripheral. You may return null if this upgrade is a Tool
+     * @param side   Which side of the turtle (left or right) that the upgrade resides on.
+     * @return The newly created peripheral. You may return {@code null} if this upgrade is a Tool
      * and this method is not expected to be called.
-     */        
+     */
     public IPeripheral createPeripheral( ITurtleAccess turtle, TurtleSide side );
 
     /**
      * Will only be called for Tool turtle. Called when turtle.dig() or turtle.attack() is called
      * by the turtle, and the tool is required to do some work.
-     * @param turtle Access to the turtle that the tool resides on.
-     * @param side Which side of the turtle (left or right) the tool resides on.
-     * @param verb Which action (dig or attack) the turtle is being called on to perform.
+     *
+     * @param turtle    Access to the turtle that the tool resides on.
+     * @param side      Which side of the turtle (left or right) the tool resides on.
+     * @param verb      Which action (dig or attack) the turtle is being called on to perform.
      * @param direction Which world direction the action should be performed in, relative to the turtles
-     * position. This will either be up, down, or the direction the turtle is facing, depending on
-     * whether dig, digUp or digDown was called.
-     * @return Whether the turtle was able to perform the action, and hence whether the turtle.dig()
-     * or turtle.attack() lua method should return true. If true is returned, the tool will perform
-     * a swinging animation. You may return null if this turtle is a Peripheral
-     * and this method is not expected to be called.
+     *                  position. This will either be up, down, or the direction the turtle is facing, depending on
+     *                  whether dig, digUp or digDown was called.
+     * @return Whether the turtle was able to perform the action, and hence whether the {@code turtle.dig()}
+     * or {@code turtle.attack()} lua method should return true. If true is returned, the tool will perform
+     * a swinging animation. You may return {@code null} if this turtle is a Peripheral  and this method is not expected
+     * to be called.
      */
     public TurtleCommandResult useTool( ITurtleAccess turtle, TurtleSide side, TurtleVerb verb, EnumFacing direction );
 
     /**
      * Called to obtain the model to be used when rendering a turtle peripheral.
+     *
+     * This can be obtained from {@link net.minecraft.client.renderer.ItemModelMesher#getItemModel(ItemStack)},
+     * {@link net.minecraft.client.renderer.block.model.ModelManager#getModel(ModelResourceLocation)} or any other
+     * source.
+     *
      * @param turtle Access to the turtle that the upgrade resides on. This will be null when getting item models!
-     * @param side Which side of the turtle (left or right) the upgrade resides on.
-     * @return The model that you wish to be used to render your upgrade, and a transformation to apply to it. Returning a transformation of null has the same effect as the identify matrix.
+     * @param side   Which side of the turtle (left or right) the upgrade resides on.
+     * @return The model that you wish to be used to render your upgrade, and a transformation to apply to it. Returning
+     * a transformation of {@code null} has the same effect as the identify matrix.
      */
-    @SideOnly( Side.CLIENT )
+    @SideOnly(Side.CLIENT)
     public Pair<IBakedModel, Matrix4f> getModel( ITurtleAccess turtle, TurtleSide side );
 
     /**
      * Called once per tick for each turtle which has the upgrade equipped.
+     *
      * @param turtle Access to the turtle that the upgrade resides on.
-     * @param side Which side of the turtle (left or right) the upgrade resides on.
+     * @param side   Which side of the turtle (left or right) the upgrade resides on.
      */
     public void update( ITurtleAccess turtle, TurtleSide side );
 }

--- a/src/main/java/dan200/computercraft/api/turtle/TurtleAnimation.java
+++ b/src/main/java/dan200/computercraft/api/turtle/TurtleAnimation.java
@@ -6,17 +6,82 @@
 
 package dan200.computercraft.api.turtle;
 
+/**
+ * An animation a turtle will play between executing commands.
+ *
+ * Each animation takes 8 ticks to complete unless otherwise specified.
+ *
+ * @see ITurtleAccess#playAnimation(TurtleAnimation)
+ */
 public enum TurtleAnimation
 {
+    /**
+     * An animation which does nothing. This takes no time to complete.
+     *
+     * @see #Wait
+     * @see #ShortWait
+     */
     None,
+
+    /**
+     * Make the turtle move forward. Note that the animation starts from the block <em>behind</em> it, and
+     * moves into this one.
+     */
     MoveForward,
+
+    /**
+     * Make the turtle move backwards. Note that the animation starts from the block <em>in front</em> it, and
+     * moves into this one.
+     */
     MoveBack,
+
+    /**
+     * Make the turtle move backwards. Note that the animation starts from the block <em>above</em> it, and
+     * moves into this one.
+     */
     MoveUp,
+
+    /**
+     * Make the turtle move backwards. Note that the animation starts from the block <em>below</em> it, and
+     * moves into this one.
+     */
     MoveDown,
+
+    /**
+     * Turn the turtle to the left. Note that the animation starts with the turtle facing <em>right</em>, and
+     * the turtle turns to face in the current direction.
+     */
     TurnLeft,
+
+    /**
+     * Turn the turtle to the left. Note that the animation starts with the turtle facing <em>right</em>, and
+     * the turtle turns to face in the current direction.
+     */
     TurnRight,
+
+    /**
+     * Swing the tool on the left.
+     */
     SwingLeftTool,
+
+    /**
+     * Swing the tool on the right.
+     */
     SwingRightTool,
+
+    /**
+     * Wait until the animation has finished, performing no movement.
+     *
+     * @see #ShortWait
+     * @see #None
+     */
     Wait,
+
+    /**
+     * Wait until the animation has finished, performing no movement. This takes 4 ticks to complete.
+     *
+     * @see #Wait
+     * @see #None
+     */
     ShortWait,
 }

--- a/src/main/java/dan200/computercraft/api/turtle/TurtleCommandResult.java
+++ b/src/main/java/dan200/computercraft/api/turtle/TurtleCommandResult.java
@@ -6,16 +6,35 @@
 
 package dan200.computercraft.api.turtle;
 
+import net.minecraft.util.EnumFacing;
+
+/**
+ * Used to indicate the result of executing a turtle command.
+ *
+ * @see ITurtleCommand#execute(ITurtleAccess)
+ * @see ITurtleUpgrade#useTool(ITurtleAccess, TurtleSide, TurtleVerb, EnumFacing)
+ */
 public final class TurtleCommandResult
 {
     private static final TurtleCommandResult s_success = new TurtleCommandResult( true, null, null );
     private static final TurtleCommandResult s_emptyFailure = new TurtleCommandResult( false, null, null );
 
+    /**
+     * Create a successful command result with no result.
+     *
+     * @return A successful command result with no values.
+     */
     public static TurtleCommandResult success()
     {
         return success( null );
     }
 
+    /**
+     * Create a successful command result with the given result values.
+     *
+     * @param results The results of executing this command.
+     * @return A successful command result with the given values.
+     */
     public static TurtleCommandResult success( Object[] results )
     {
         if( results == null || results.length == 0 )
@@ -28,11 +47,22 @@ public final class TurtleCommandResult
         }
     }
 
+    /**
+     * Create a failed command result with no error message.
+     *
+     * @return A failed command result with no message.
+     */
     public static TurtleCommandResult failure()
     {
         return failure( null );
     }
 
+    /**
+     * Create a failed command result with an error message.
+     *
+     * @param errorMessage The error message to provide.
+     * @return A failed command result with a message.
+     */
     public static TurtleCommandResult failure( String errorMessage )
     {
         if( errorMessage == null )
@@ -56,16 +86,31 @@ public final class TurtleCommandResult
         m_results = results;
     }
 
+    /**
+     * Determine whether the command executed successfully.
+     *
+     * @return If the command was successful.
+     */
     public boolean isSuccess()
     {
         return m_success;
     }
 
+    /**
+     * Get the error message of this command result.
+     *
+     * @return The command's error message, or {@code null} if it was a success.
+     */
     public String getErrorMessage()
     {
         return m_errorMessage;
     }
 
+    /**
+     * Get the resulting values of this command result.
+     *
+     * @return The command's result, or {@code null} if it was a failure.
+     */
     public Object[] getResults()
     {
         return m_results;

--- a/src/main/java/dan200/computercraft/api/turtle/TurtleSide.java
+++ b/src/main/java/dan200/computercraft/api/turtle/TurtleSide.java
@@ -12,12 +12,12 @@ package dan200.computercraft.api.turtle;
 public enum TurtleSide
 {
     /**
-     * The turtles left side (where the pickaxe usually is on a Wireless Mining Turtle)
+     * The turtle's left side (where the pickaxe usually is on a Wireless Mining Turtle)
      */
     Left,
 
     /**
-     * The turtles right side (where the modem usually is on a Wireless Mining Turtle)
+     * The turtle's right side (where the modem usually is on a Wireless Mining Turtle)
      */
     Right,
 }

--- a/src/main/java/dan200/computercraft/api/turtle/TurtleUpgradeType.java
+++ b/src/main/java/dan200/computercraft/api/turtle/TurtleUpgradeType.java
@@ -7,21 +7,21 @@
 package dan200.computercraft.api.turtle;
 
 /**
- * An enum representing the two different types of turtle that an ITurtleUpgrade
- * implementation can add to a turtle.
- * @see ITurtleUpgrade
+ * An enum representing the different types of turtle that an {@link ITurtleUpgrade} implementation can add to a turtle.
+ *
+ * @see ITurtleUpgrade#getType()
  */
 public enum TurtleUpgradeType
 {
     /**
-     * A tool is rendered as an item on the side of the turtle, and responds to the turtle.dig()
-     * and turtle.attack() methods (Such as pickaxe or sword on Mining and Melee turtles).
+     * A tool is rendered as an item on the side of the turtle, and responds to the {@code turtle.dig()}
+     * and {@code turtle.attack()} methods (Such as pickaxe or sword on Mining and Melee turtles).
      */
     Tool,
-    
+
     /**
      * A peripheral adds a special peripheral which is attached to the side of the turtle,
-     * and can be interacted with the peripheral API (Such as the modem on Wireless Turtles).
+     * and can be interacted with the {@code peripheral} API (Such as the modem on Wireless Turtles).
      */
     Peripheral,
 
@@ -30,8 +30,7 @@ public enum TurtleUpgradeType
      * your upgrade to also provide methods. For example, a pickaxe could provide methods
      * determining whether it can break the given block or not.
      */
-    Both,
-    ;
+    Both,;
 
     public boolean isTool()
     {

--- a/src/main/java/dan200/computercraft/api/turtle/TurtleVerb.java
+++ b/src/main/java/dan200/computercraft/api/turtle/TurtleVerb.java
@@ -6,21 +6,24 @@
 
 package dan200.computercraft.api.turtle;
 
+import net.minecraft.util.EnumFacing;
+
 /**
- * An enum representing the two different actions that an ITurtleUpgrade of type
- * Tool may be called on to perform by a turtle.
- * @see ITurtleUpgrade
- * @see ITurtleUpgrade#useTool
+ * An enum representing the different actions that an {@link ITurtleUpgrade} of type Tool may be called on to perform by
+ * a turtle.
+ *
+ * @see ITurtleUpgrade#getType()
+ * @see ITurtleUpgrade#useTool(ITurtleAccess, TurtleSide, TurtleVerb, EnumFacing)
  */
 public enum TurtleVerb
 {
     /**
-     * The turtle called turtle.dig(), turtle.digUp() or turtle.digDown()
+     * The turtle called {@code turtle.dig()}, {@code turtle.digUp()} or {@code turtle.digDown()}
      */
     Dig,
-    
+
     /**
-     * The turtle called turtle.attack(), turtle.attackUp() or turtle.attackDown()
+     * The turtle called {@code turtle.attack()}, {@code turtle.attackUp()} or {@code turtle.attackDown()}
      */
     Attack,
 }


### PR DESCRIPTION
 - Add documentation for all undocumented methods and enums.
 - Use `@code`, `@link` and `@see` where appropriate.
 - Fix spelling in a couple of cases.

I'm open to any other improvements/comments people have - I'm sure I've made a couple of grammatical boo-boos.

One thing I think is worth considering is adding `@Nullable`/`@NonNull` annotations to the API - while they do clutter method declarations a little, they do help to make it clear what values are allowed, as well as providing useful hints for your IDE.