### PR TITLE
Fix selection boxes not being shown

### DIFF
--- a/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
+++ b/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
@@ -219,6 +219,12 @@ public abstract class BlockGeneric extends Block implements
     }
 
     @Override
+    public AxisAlignedBB getSelectedBoundingBox( IBlockState state, World worldIn, BlockPos pos )
+    {
+        return getBoundingBox( state, worldIn, pos ).offset( pos );
+    }
+
+    @Override
     public final AxisAlignedBB getCollisionBoundingBox( IBlockState state, World world, BlockPos pos )
     {
         TileEntity tile = world.getTileEntity( pos );

--- a/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
+++ b/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
@@ -219,12 +219,6 @@ public abstract class BlockGeneric extends Block implements
     }
 
     @Override
-    public final AxisAlignedBB getSelectedBoundingBox( IBlockState state, World world, BlockPos pos )
-    {
-        return getBoundingBox( state, world, pos );
-    }
-
-    @Override
     public final AxisAlignedBB getCollisionBoundingBox( IBlockState state, World world, BlockPos pos )
     {
         TileEntity tile = world.getTileEntity( pos );

--- a/src/main/java/dan200/computercraft/shared/peripheral/modem/TileCable.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/modem/TileCable.java
@@ -37,6 +37,19 @@ import java.util.*;
 public class TileCable extends TileModemBase
     implements INetwork
 {
+    private static final double MIN = 0.375;
+    private static final double MAX = 1 - MIN;
+
+    private static final AxisAlignedBB BOX_CENTRE = new AxisAlignedBB( MIN, MIN, MIN, MAX, MAX, MAX );
+    private static final AxisAlignedBB[] BOXES = new AxisAlignedBB[]{
+        new AxisAlignedBB( MIN, 0, MIN, MAX, MIN, MAX ),   // Down
+        new AxisAlignedBB( MIN, MAX, MIN, MAX, 1, MAX ),   // Up
+        new AxisAlignedBB( MIN, MIN, 0, MAX, MAX, MIN ),   // North
+        new AxisAlignedBB( MIN, MIN, MAX, MAX, MAX, 1 ),   // South
+        new AxisAlignedBB( 0, MIN, MIN, MIN, MAX, MAX ),   // West
+        new AxisAlignedBB( MAX, MIN, MIN, 1, MAX, MAX ),   // East
+    };
+
     // Statics
 
     private static class Peripheral extends ModemPeripheral
@@ -415,14 +428,7 @@ public class TileCable extends TileModemBase
             {
                 AxisAlignedBB modem = getModemBounds();
                 AxisAlignedBB cable = getCableBounds();
-                return new AxisAlignedBB(
-                    Math.min( modem.minX, cable.minX ),
-                    Math.min( modem.minY, cable.minY ),
-                    Math.min( modem.minZ, cable.minZ ),
-                    Math.max( modem.maxX, cable.maxX ),
-                    Math.max( modem.maxY, cable.maxY ),
-                    Math.max( modem.maxZ, cable.maxZ )
-                );
+                return modem.union( cable );
             }
         }
     }
@@ -437,7 +443,15 @@ public class TileCable extends TileModemBase
         }
         if( type == PeripheralType.Cable || type == PeripheralType.WiredModemWithCable )
         {
-            bounds.add( getCableBounds() );
+            bounds.add( BOX_CENTRE );
+            BlockPos pos = getPos();
+            for (EnumFacing facing : EnumFacing.VALUES)
+            {
+                if( BlockCable.isCable( worldObj, pos.offset( facing ) ) )
+                {
+                    bounds.add( BOXES[ facing.ordinal() ] );
+                }
+            }
         }
     }
 

--- a/src/main/java/dan200/computercraft/shared/peripheral/modem/TileModemBase.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/modem/TileModemBase.java
@@ -9,12 +9,22 @@ package dan200.computercraft.shared.peripheral.modem;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.shared.common.BlockGeneric;
 import dan200.computercraft.shared.peripheral.common.TilePeripheralBase;
+import net.minecraft.block.Block;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.AxisAlignedBB;
 
 public abstract class TileModemBase extends TilePeripheralBase
 {
+    private static final AxisAlignedBB[] BOXES = new AxisAlignedBB[] {
+        new AxisAlignedBB( 0.125, 0.0, 0.125, 0.875, 0.1875, 0.875 ), // Down
+        new AxisAlignedBB( 0.125, 0.8125, 0.125, 0.875, 1.0, 0.875 ), // Up
+        new AxisAlignedBB( 0.125, 0.125, 0.0, 0.875, 0.875, 0.1875 ), // North
+        new AxisAlignedBB( 0.125, 0.125, 0.8125, 0.875, 0.875, 1.0 ), // South
+        new AxisAlignedBB( 0.0, 0.125, 0.125, 0.1875, 0.875, 0.875 ), // West
+        new AxisAlignedBB( 0.8125, 0.125, 0.125, 1.0, 0.875, 0.875 ), // East
+    };
+
     protected ModemPeripheral m_modem;
 
     protected TileModemBase()
@@ -58,34 +68,8 @@ public abstract class TileModemBase extends TilePeripheralBase
     @Override
     public AxisAlignedBB getBounds()
     {
-        switch( getDirection() )
-        {
-            case UP:
-            default:
-            {
-                return new AxisAlignedBB( 0.125, 0.8125, 0.125, 0.875, 1.0, 0.875 );
-            }
-            case DOWN:
-            {
-                return new AxisAlignedBB( 0.125, 0.0, 0.125, 0.875, 0.1875, 0.875 );
-            }
-            case NORTH:
-            {
-                return new AxisAlignedBB( 0.125, 0.125, 0.0, 0.875, 0.875, 0.1875 );
-            }
-            case SOUTH:
-            {
-                return new AxisAlignedBB( 0.125, 0.125, 0.8125, 0.875, 0.875, 1.0 );
-            }
-            case WEST:
-            {
-                return new AxisAlignedBB( 0.0, 0.125, 0.125, 0.1875, 0.875, 0.875 );
-            }
-            case EAST:
-            {
-                return new AxisAlignedBB( 0.8125, 0.125, 0.125, 1.0, 0.875, 0.875 );
-            }
-        }
+        int direction = getDirection().ordinal();
+        return direction >= 0 && direction < BOXES.length ? BOXES[ direction ] : Block.FULL_BLOCK_AABB;
     }
 
     @Override


### PR DESCRIPTION
I really should have spotted this earlier. Sorry.

`Block.getSelectedBoundingBox` expects a bounding box relative to (0, 0, 0) but we were returning one relative to the current block. Instead we allow the default behaviour to continue, which will call `BlockGeneric.getBoundingBox` and offset it.

---

I'm looking at the implementations here and wonder if we really need to access the `TileEntity` at all here? The only implementation which requires the TE, rather than being able to use the block state is turtles. Perhaps it would be better to hoist some, if not all, of this code into the appropriate sub classes.

Also @dan200, would you be OK with me changing `TileCable`'s `getCollisionBounds` to handle each cable segment separately? This way you get nicer entity collisions with the cables.