### PR TITLE
Modifiable terminal colour palette

### DIFF
--- a/src/main/java/dan200/computercraft/client/gui/FixedWidthFontRenderer.java
+++ b/src/main/java/dan200/computercraft/client/gui/FixedWidthFontRenderer.java
@@ -8,6 +8,7 @@ package dan200.computercraft.client.gui;
 
 import dan200.computercraft.core.terminal.TextBuffer;
 import dan200.computercraft.shared.util.Colour;
+import dan200.computercraft.shared.util.Palette;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.VertexBuffer;
@@ -31,28 +32,37 @@ public class FixedWidthFontRenderer
         m_textureManager = textureManager;
     }
 
-    private void drawChar( VertexBuffer renderer, double x, double y, int index, int color )
+    private void drawChar( VertexBuffer renderer, double x, double y, int index, int color, Palette p )
     {
         int column = index % 16;
         int row = index / 16;
-        Colour colour = Colour.values()[ 15 - color ];
-        renderer.pos( x, y, 0.0 ).tex( (double) (column * FONT_WIDTH) / 256.0, (double) (row * FONT_HEIGHT ) / 256.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-        renderer.pos( x, y + FONT_HEIGHT, 0.0 ).tex( (double) (column * FONT_WIDTH) / 256.0, (double) ((row + 1) * FONT_HEIGHT) / 256.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-        renderer.pos( x + FONT_WIDTH, y, 0.0 ).tex( (double) ((column + 1) * FONT_WIDTH) / 256.0, (double) (row * FONT_HEIGHT) / 256.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-        renderer.pos( x + FONT_WIDTH, y, 0.0 ).tex( (double) ((column + 1) * FONT_WIDTH) / 256.0, (double) (row * FONT_HEIGHT) / 256.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-        renderer.pos( x, y + FONT_HEIGHT, 0.0 ).tex( (double) (column * FONT_WIDTH) / 256.0, (double) ((row + 1) * FONT_HEIGHT) / 256.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-        renderer.pos( x + FONT_WIDTH, y + FONT_HEIGHT, 0.0 ).tex( (double) ((column + 1) * FONT_WIDTH) / 256.0, (double) ((row + 1) * FONT_HEIGHT) / 256.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+
+        float[] colour = p.getColour( 15 - color );
+        float r = colour[0];
+        float g = colour[1];
+        float b = colour[2];
+
+        renderer.pos( x, y, 0.0 ).tex( (double) (column * FONT_WIDTH) / 256.0, (double) (row * FONT_HEIGHT ) / 256.0 ).color( r, g, b, 1.0f ).endVertex();
+        renderer.pos( x, y + FONT_HEIGHT, 0.0 ).tex( (double) (column * FONT_WIDTH) / 256.0, (double) ((row + 1) * FONT_HEIGHT) / 256.0 ).color( r, g, b, 1.0f ).endVertex();
+        renderer.pos( x + FONT_WIDTH, y, 0.0 ).tex( (double) ((column + 1) * FONT_WIDTH) / 256.0, (double) (row * FONT_HEIGHT) / 256.0 ).color( r, g, b, 1.0f ).endVertex();
+        renderer.pos( x + FONT_WIDTH, y, 0.0 ).tex( (double) ((column + 1) * FONT_WIDTH) / 256.0, (double) (row * FONT_HEIGHT) / 256.0 ).color( r, g, b, 1.0f ).endVertex();
+        renderer.pos( x, y + FONT_HEIGHT, 0.0 ).tex( (double) (column * FONT_WIDTH) / 256.0, (double) ((row + 1) * FONT_HEIGHT) / 256.0 ).color( r, g, b, 1.0f ).endVertex();
+        renderer.pos( x + FONT_WIDTH, y + FONT_HEIGHT, 0.0 ).tex( (double) ((column + 1) * FONT_WIDTH) / 256.0, (double) ((row + 1) * FONT_HEIGHT) / 256.0 ).color( r, g, b, 1.0f ).endVertex();
     }
 
-    private void drawQuad( VertexBuffer renderer, double x, double y, int color, double width )
+    private void drawQuad( VertexBuffer renderer, double x, double y, int color, double width, Palette p )
     {
-        Colour colour = Colour.values()[ 15 - color ];
-        renderer.pos( x, y, 0.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-        renderer.pos( x, y + FONT_HEIGHT, 0.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-        renderer.pos( x + width, y, 0.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-        renderer.pos( x + width, y, 0.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-        renderer.pos( x, y + FONT_HEIGHT, 0.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
-        renderer.pos( x + width, y + FONT_HEIGHT, 0.0 ).color( colour.getR(), colour.getG(), colour.getB(), 1.0f ).endVertex();
+        float[] colour = p.getColour( 15 - color );
+        float r = colour[0];
+        float g = colour[1];
+        float b = colour[2];
+
+        renderer.pos( x, y, 0.0 ).color( r, g, b, 1.0f ).endVertex();
+        renderer.pos( x, y + FONT_HEIGHT, 0.0 ).color( r, g, b, 1.0f ).endVertex();
+        renderer.pos( x + width, y, 0.0 ).color( r, g, b, 1.0f ).endVertex();
+        renderer.pos( x + width, y, 0.0 ).color( r, g, b, 1.0f ).endVertex();
+        renderer.pos( x, y + FONT_HEIGHT, 0.0 ).color( r, g, b, 1.0f ).endVertex();
+        renderer.pos( x + width, y + FONT_HEIGHT, 0.0 ).color( r, g, b, 1.0f ).endVertex();
     }
 
     private boolean isGreyScale( int colour )
@@ -60,7 +70,7 @@ public class FixedWidthFontRenderer
         return (colour == 0 || colour == 15 || colour == 7 || colour == 8);
     }
 
-    public void drawStringBackgroundPart( int x, int y, TextBuffer backgroundColour, double leftMarginSize, double rightMarginSize, boolean greyScale )
+    public void drawStringBackgroundPart( int x, int y, TextBuffer backgroundColour, double leftMarginSize, double rightMarginSize, boolean greyScale, Palette p )
     {
         // Draw the quads
         Tessellator tessellator = Tessellator.getInstance();
@@ -73,7 +83,7 @@ public class FixedWidthFontRenderer
             {
                 colour1 = 15;
             }
-            drawQuad( renderer, x - leftMarginSize, y, colour1, leftMarginSize );
+            drawQuad( renderer, x - leftMarginSize, y, colour1, leftMarginSize, p );
         }
         if( rightMarginSize > 0.0 )
         {
@@ -82,7 +92,7 @@ public class FixedWidthFontRenderer
             {
                 colour2 = 15;
             }
-            drawQuad( renderer, x + backgroundColour.length() * FONT_WIDTH, y, colour2, rightMarginSize );
+            drawQuad( renderer, x + backgroundColour.length() * FONT_WIDTH, y, colour2, rightMarginSize, p );
         }
         for( int i = 0; i < backgroundColour.length(); i++ )
         {
@@ -91,14 +101,14 @@ public class FixedWidthFontRenderer
             {
                 colour = 15;
             }
-            drawQuad( renderer, x + i * FONT_WIDTH, y, colour, FONT_WIDTH );
+            drawQuad( renderer, x + i * FONT_WIDTH, y, colour, FONT_WIDTH, p );
         }
         GlStateManager.disableTexture2D();
         tessellator.draw();
         GlStateManager.enableTexture2D();
     }
 
-    public void drawStringTextPart( int x, int y, TextBuffer s, TextBuffer textColour, boolean greyScale )
+    public void drawStringTextPart( int x, int y, TextBuffer s, TextBuffer textColour, boolean greyScale, Palette p )
     {
         // Draw the quads
         Tessellator tessellator = Tessellator.getInstance();
@@ -119,12 +129,12 @@ public class FixedWidthFontRenderer
             {
                 index = (int)'?';
             }
-            drawChar( renderer, x + i * FONT_WIDTH, y, index, colour );
+            drawChar( renderer, x + i * FONT_WIDTH, y, index, colour, p );
         }
         tessellator.draw();
     }
 
-    public void drawString( TextBuffer s, int x, int y, TextBuffer textColour, TextBuffer backgroundColour, double leftMarginSize, double rightMarginSize, boolean greyScale )
+    public void drawString( TextBuffer s, int x, int y, TextBuffer textColour, TextBuffer backgroundColour, double leftMarginSize, double rightMarginSize, boolean greyScale, Palette p )
     {
         // Draw background
         if( backgroundColour != null )
@@ -133,7 +143,7 @@ public class FixedWidthFontRenderer
             m_textureManager.bindTexture( background );
 
             // Draw the quads
-            drawStringBackgroundPart( x, y, backgroundColour, leftMarginSize, rightMarginSize, greyScale );
+            drawStringBackgroundPart( x, y, backgroundColour, leftMarginSize, rightMarginSize, greyScale, p );
         }
     
         // Draw text
@@ -143,7 +153,7 @@ public class FixedWidthFontRenderer
             m_textureManager.bindTexture( font );
             
             // Draw the quads
-            drawStringTextPart( x, y, s, textColour, greyScale );
+            drawStringTextPart( x, y, s, textColour, greyScale, p );
         }
     }
 

--- a/src/main/java/dan200/computercraft/client/gui/FixedWidthFontRenderer.java
+++ b/src/main/java/dan200/computercraft/client/gui/FixedWidthFontRenderer.java
@@ -7,7 +7,6 @@
 package dan200.computercraft.client.gui;
 
 import dan200.computercraft.core.terminal.TextBuffer;
-import dan200.computercraft.shared.util.Colour;
 import dan200.computercraft.shared.util.Palette;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
@@ -16,6 +15,8 @@ import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.opengl.GL11;
+
+import java.util.Arrays;
 
 public class FixedWidthFontRenderer
 {
@@ -32,12 +33,21 @@ public class FixedWidthFontRenderer
         m_textureManager = textureManager;
     }
 
-    private void drawChar( VertexBuffer renderer, double x, double y, int index, int color, Palette p )
+    private static void greyscaleify( float[] rgb )
+    {
+        Arrays.fill(rgb, ( rgb[0] + rgb[1] + rgb[2] ) / 3.0f);
+    }
+
+    private void drawChar( VertexBuffer renderer, double x, double y, int index, int color, Palette p, boolean greyscale )
     {
         int column = index % 16;
         int row = index / 16;
 
         float[] colour = p.getColour( 15 - color );
+        if(greyscale)
+        {
+            greyscaleify( colour );
+        }
         float r = colour[0];
         float g = colour[1];
         float b = colour[2];
@@ -50,9 +60,13 @@ public class FixedWidthFontRenderer
         renderer.pos( x + FONT_WIDTH, y + FONT_HEIGHT, 0.0 ).tex( (double) ((column + 1) * FONT_WIDTH) / 256.0, (double) ((row + 1) * FONT_HEIGHT) / 256.0 ).color( r, g, b, 1.0f ).endVertex();
     }
 
-    private void drawQuad( VertexBuffer renderer, double x, double y, int color, double width, Palette p )
+    private void drawQuad( VertexBuffer renderer, double x, double y, int color, double width, Palette p, boolean greyscale )
     {
         float[] colour = p.getColour( 15 - color );
+        if(greyscale)
+        {
+            greyscaleify( colour );
+        }
         float r = colour[0];
         float g = colour[1];
         float b = colour[2];
@@ -83,7 +97,7 @@ public class FixedWidthFontRenderer
             {
                 colour1 = 15;
             }
-            drawQuad( renderer, x - leftMarginSize, y, colour1, leftMarginSize, p );
+            drawQuad( renderer, x - leftMarginSize, y, colour1, leftMarginSize, p, greyScale );
         }
         if( rightMarginSize > 0.0 )
         {
@@ -92,7 +106,7 @@ public class FixedWidthFontRenderer
             {
                 colour2 = 15;
             }
-            drawQuad( renderer, x + backgroundColour.length() * FONT_WIDTH, y, colour2, rightMarginSize, p );
+            drawQuad( renderer, x + backgroundColour.length() * FONT_WIDTH, y, colour2, rightMarginSize, p, greyScale );
         }
         for( int i = 0; i < backgroundColour.length(); i++ )
         {
@@ -101,7 +115,7 @@ public class FixedWidthFontRenderer
             {
                 colour = 15;
             }
-            drawQuad( renderer, x + i * FONT_WIDTH, y, colour, FONT_WIDTH, p );
+            drawQuad( renderer, x + i * FONT_WIDTH, y, colour, FONT_WIDTH, p, greyScale );
         }
         GlStateManager.disableTexture2D();
         tessellator.draw();
@@ -129,7 +143,7 @@ public class FixedWidthFontRenderer
             {
                 index = (int)'?';
             }
-            drawChar( renderer, x + i * FONT_WIDTH, y, index, colour, p );
+            drawChar( renderer, x + i * FONT_WIDTH, y, index, colour, p, greyScale );
         }
         tessellator.draw();
     }

--- a/src/main/java/dan200/computercraft/client/gui/FixedWidthFontRenderer.java
+++ b/src/main/java/dan200/computercraft/client/gui/FixedWidthFontRenderer.java
@@ -35,7 +35,7 @@ public class FixedWidthFontRenderer
 
     private static void greyscaleify( float[] rgb )
     {
-        Arrays.fill(rgb, ( rgb[0] + rgb[1] + rgb[2] ) / 3.0f);
+        Arrays.fill( rgb, ( rgb[0] + rgb[1] + rgb[2] ) / 3.0f );
     }
 
     private void drawChar( VertexBuffer renderer, double x, double y, int index, int color, Palette p, boolean greyscale )

--- a/src/main/java/dan200/computercraft/client/gui/GuiPrintout.java
+++ b/src/main/java/dan200/computercraft/client/gui/GuiPrintout.java
@@ -205,7 +205,7 @@ public class GuiPrintout extends GuiContainer
             int lineIdx = ItemPrintout.LINES_PER_PAGE * m_page + line;
             if( lineIdx >= 0 && lineIdx < m_text.length )
             {
-                fontRenderer.drawString( m_text[lineIdx], x, y, m_colours[lineIdx], null, 0, 0, false, new Palette() );
+                fontRenderer.drawString( m_text[lineIdx], x, y, m_colours[lineIdx], null, 0, 0, false, Palette.DEFAULT );
             }
             y = y + FixedWidthFontRenderer.FONT_HEIGHT;
         }

--- a/src/main/java/dan200/computercraft/client/gui/GuiPrintout.java
+++ b/src/main/java/dan200/computercraft/client/gui/GuiPrintout.java
@@ -10,6 +10,7 @@ import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.core.terminal.TextBuffer;
 import dan200.computercraft.shared.media.inventory.ContainerHeldItem;
 import dan200.computercraft.shared.media.items.ItemPrintout;
+import dan200.computercraft.shared.util.Palette;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.ResourceLocation;
@@ -204,7 +205,7 @@ public class GuiPrintout extends GuiContainer
             int lineIdx = ItemPrintout.LINES_PER_PAGE * m_page + line;
             if( lineIdx >= 0 && lineIdx < m_text.length )
             {
-                fontRenderer.drawString( m_text[lineIdx], x, y, m_colours[lineIdx], null, 0, 0, false );
+                fontRenderer.drawString( m_text[lineIdx], x, y, m_colours[lineIdx], null, 0, 0, false, new Palette() );
             }
             y = y + FixedWidthFontRenderer.FONT_HEIGHT;
         }

--- a/src/main/java/dan200/computercraft/client/gui/widgets/WidgetTerminal.java
+++ b/src/main/java/dan200/computercraft/client/gui/widgets/WidgetTerminal.java
@@ -29,7 +29,7 @@ public class WidgetTerminal extends Widget
     private static final ResourceLocation background = new ResourceLocation( "computercraft", "textures/gui/termBackground.png" );
     private static float TERMINATE_TIME = 0.5f;
 
-    private IComputerContainer m_computer;
+    private final IComputerContainer m_computer;
 
     private float m_terminateTimer;
     private float m_rebootTimer;
@@ -369,26 +369,27 @@ public class WidgetTerminal extends Widget
         int startX = xOrigin + getXPosition();
         int startY = yOrigin + getYPosition();
 
-        // Draw the screen contents
-        IComputer computer = m_computer.getComputer();
-        Terminal terminal = (computer != null) ? computer.getTerminal() : null;
-        if( terminal != null )
+        synchronized( m_computer )
         {
-            // Draw the terminal
-            boolean greyscale = !computer.isColour();
-            synchronized( terminal )
+            // Draw the screen contents
+            IComputer computer = m_computer.getComputer();
+            Terminal terminal = ( computer != null ) ? computer.getTerminal() : null;
+            if( terminal != null )
             {
+                // Draw the terminal
+                boolean greyscale = !computer.isColour();
+
                 Palette palette = terminal.getPalette();
 
                 // Get the data from the terminal first
                 // Unfortunately we have to keep the lock for the whole of drawing, so the text doesn't change under us.
-                FixedWidthFontRenderer fontRenderer = (FixedWidthFontRenderer)ComputerCraft.getFixedWidthFontRenderer();
+                FixedWidthFontRenderer fontRenderer = (FixedWidthFontRenderer) ComputerCraft.getFixedWidthFontRenderer();
                 boolean tblink = m_focus && terminal.getCursorBlink() && ComputerCraft.getGlobalCursorBlink();
                 int tw = terminal.getWidth();
                 int th = terminal.getHeight();
                 int tx = terminal.getCursorX();
                 int ty = terminal.getCursorY();
-                
+
                 int x = startX + m_leftMargin;
                 int y = startY + m_topMargin;
 
@@ -404,9 +405,9 @@ public class WidgetTerminal extends Widget
                 }
 
                 // Draw lines
-                for( int line=0; line<th; ++line )
+                for( int line = 0; line < th; ++line )
                 {
-                    TextBuffer text = terminal.getLine(line);
+                    TextBuffer text = terminal.getLine( line );
                     TextBuffer colour = terminal.getTextColourLine( line );
                     TextBuffer backgroundColour = terminal.getBackgroundColourLine( line );
                     fontRenderer.drawString( text, x, y, colour, backgroundColour, m_leftMargin, m_rightMargin, greyscale, palette );
@@ -428,21 +429,19 @@ public class WidgetTerminal extends Widget
                             palette
                     );
                 }
-            }
-        }
-        else
-        {
-            // Draw a black background
-            mc.getTextureManager().bindTexture( background );
-            Colour black = Colour.Black;
-            GlStateManager.color( black.getR(), black.getG(), black.getB(), 1.0f );
-            try
+            } else
             {
-                drawTexturedModalRect( startX, startY, 0, 0, getWidth(), getHeight() );
-            }
-            finally
-            {
-                GlStateManager.color( 1.0f, 1.0f, 1.0f, 1.0f );
+                // Draw a black background
+                mc.getTextureManager().bindTexture( background );
+                Colour black = Colour.Black;
+                GlStateManager.color( black.getR(), black.getG(), black.getB(), 1.0f );
+                try
+                {
+                    drawTexturedModalRect( startX, startY, 0, 0, getWidth(), getHeight() );
+                } finally
+                {
+                    GlStateManager.color( 1.0f, 1.0f, 1.0f, 1.0f );
+                }
             }
         }
     }

--- a/src/main/java/dan200/computercraft/client/gui/widgets/WidgetTerminal.java
+++ b/src/main/java/dan200/computercraft/client/gui/widgets/WidgetTerminal.java
@@ -13,6 +13,7 @@ import dan200.computercraft.core.terminal.TextBuffer;
 import dan200.computercraft.shared.computer.core.IComputer;
 import dan200.computercraft.shared.computer.core.IComputerContainer;
 import dan200.computercraft.shared.util.Colour;
+import dan200.computercraft.shared.util.Palette;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.GlStateManager;
@@ -377,6 +378,8 @@ public class WidgetTerminal extends Widget
             boolean greyscale = !computer.isColour();
             synchronized( terminal )
             {
+                Palette palette = terminal.getPalette();
+
                 // Get the data from the terminal first
                 // Unfortunately we have to keep the lock for the whole of drawing, so the text doesn't change under us.
                 FixedWidthFontRenderer fontRenderer = (FixedWidthFontRenderer)ComputerCraft.getFixedWidthFontRenderer();
@@ -393,11 +396,11 @@ public class WidgetTerminal extends Widget
                 TextBuffer emptyLine = new TextBuffer( ' ', tw );
                 if( m_topMargin > 0 )
                 {
-                    fontRenderer.drawString( emptyLine, x, startY, terminal.getTextColourLine( 0 ), terminal.getBackgroundColourLine( 0 ), m_leftMargin, m_rightMargin, greyscale );
+                    fontRenderer.drawString( emptyLine, x, startY, terminal.getTextColourLine( 0 ), terminal.getBackgroundColourLine( 0 ), m_leftMargin, m_rightMargin, greyscale, palette );
                 }
                 if( m_bottomMargin > 0 )
                 {
-                    fontRenderer.drawString( emptyLine, x, startY + 2 * m_bottomMargin + ( th - 1 ) * FixedWidthFontRenderer.FONT_HEIGHT, terminal.getTextColourLine( th - 1 ), terminal.getBackgroundColourLine( th - 1 ), m_leftMargin, m_rightMargin, greyscale );
+                    fontRenderer.drawString( emptyLine, x, startY + 2 * m_bottomMargin + ( th - 1 ) * FixedWidthFontRenderer.FONT_HEIGHT, terminal.getTextColourLine( th - 1 ), terminal.getBackgroundColourLine( th - 1 ), m_leftMargin, m_rightMargin, greyscale, palette );
                 }
 
                 // Draw lines
@@ -406,7 +409,7 @@ public class WidgetTerminal extends Widget
                     TextBuffer text = terminal.getLine(line);
                     TextBuffer colour = terminal.getTextColourLine( line );
                     TextBuffer backgroundColour = terminal.getBackgroundColourLine( line );
-                    fontRenderer.drawString( text, x, y, colour, backgroundColour, m_leftMargin, m_rightMargin, greyscale );
+                    fontRenderer.drawString( text, x, y, colour, backgroundColour, m_leftMargin, m_rightMargin, greyscale, palette );
                     y += FixedWidthFontRenderer.FONT_HEIGHT;
                 }
 
@@ -421,7 +424,8 @@ public class WidgetTerminal extends Widget
                             startY + m_topMargin + FixedWidthFontRenderer.FONT_HEIGHT * ty,
                             cursorColour, null,
                             0, 0,
-                            greyscale
+                            greyscale,
+                            palette
                     );
                 }
             }

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -49,8 +49,6 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
             return;
         }
 
-        Palette palette = origin.getTerminal().getTerminal().getPalette();
-
         // Ensure each monitor is rendered only once
         long renderFrame = ComputerCraft.getRenderFrame();
         if( origin.m_lastRenderFrame == renderFrame )
@@ -107,6 +105,8 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
             {
                 if( terminal != null )
                 {
+                    Palette palette = terminal.getPalette();
+
                     // Allocate display lists
                     if( origin.m_renderDisplayList < 0 )
                     {

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -14,6 +14,7 @@ import dan200.computercraft.shared.common.ClientTerminal;
 import dan200.computercraft.shared.peripheral.monitor.TileMonitor;
 import dan200.computercraft.shared.util.Colour;
 import dan200.computercraft.shared.util.DirectionUtil;
+import dan200.computercraft.shared.util.Palette;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
@@ -47,6 +48,8 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
         {
             return;
         }
+
+        Palette palette = origin.getTerminal().getTerminal().getPalette();
 
         // Ensure each monitor is rendered only once
         long renderFrame = ComputerCraft.getRenderFrame();
@@ -144,9 +147,9 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
                                 {
                                     GlStateManager.scale( 1.0, marginSquash, 1.0 );
                                     GlStateManager.translate( 0.0, -marginYSize / marginSquash, 0.0 );
-                                    fontRenderer.drawStringBackgroundPart( 0, 0, terminal.getBackgroundColourLine( 0 ), marginXSize, marginXSize, greyscale );
+                                    fontRenderer.drawStringBackgroundPart( 0, 0, terminal.getBackgroundColourLine( 0 ), marginXSize, marginXSize, greyscale, palette );
                                     GlStateManager.translate( 0.0, ( marginYSize + height * FixedWidthFontRenderer.FONT_HEIGHT ) / marginSquash, 0.0 );
-                                    fontRenderer.drawStringBackgroundPart( 0, 0, terminal.getBackgroundColourLine( height - 1 ), marginXSize, marginXSize, greyscale );
+                                    fontRenderer.drawStringBackgroundPart( 0, 0, terminal.getBackgroundColourLine( height - 1 ), marginXSize, marginXSize, greyscale, palette );
                                 }
                                 finally
                                 {
@@ -160,7 +163,8 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
                                             0, FixedWidthFontRenderer.FONT_HEIGHT * y,
                                             terminal.getBackgroundColourLine( y ),
                                             marginXSize, marginXSize,
-                                            greyscale
+                                            greyscale,
+                                            palette
                                     );
                                 }
                             }
@@ -186,7 +190,8 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
                                             0, FixedWidthFontRenderer.FONT_HEIGHT * y,
                                             terminal.getLine( y ),
                                             terminal.getTextColourLine( y ),
-                                            greyscale
+                                            greyscale,
+                                            palette
                                     );
                                 }
                             }
@@ -216,7 +221,8 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
                                             FixedWidthFontRenderer.FONT_HEIGHT * cursorY,
                                             cursorColour, null,
                                             0, 0,
-                                            greyscale
+                                            greyscale,
+                                            palette
                                     );
                                 }
                             }

--- a/src/main/java/dan200/computercraft/core/apis/TermAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/TermAPI.java
@@ -74,10 +74,10 @@ public class TermAPI implements ILuaAPI
             "getBackgroundColour",
             "getBackgroundColor",
             "blit",
-            "setColour",
-            "setColor",
-            "getColour",
-            "getColor"
+            "setPaletteColour",
+            "setPaletteColor",
+            "getPaletteColour",
+            "getPaletteColor"
         };
     }
     

--- a/src/main/java/dan200/computercraft/core/apis/TermAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/TermAPI.java
@@ -120,50 +120,6 @@ public class TermAPI implements ILuaAPI
         }
     }
 
-    public static void setColour( Terminal terminal, HashMap<Object, Object> colours) throws LuaException
-    {
-        final double lg2 = Math.log( 2 );
-
-        for(Map.Entry<Object, Object> e : colours.entrySet())
-        {
-            if(e.getKey() instanceof Double)
-            {
-                int index = 15 - (int)( Math.log( (Double)e.getKey() ) / lg2 );
-
-                try
-                {
-                    if (e.getValue() instanceof HashMap)
-                    {
-                        @SuppressWarnings({ "unchecked" }) // There isn't really a nice way around this :(
-                        HashMap<Object, Object> colour = (HashMap<Object, Object>) e.getValue();
-
-                        setColour(
-                                terminal,
-                                index,
-                                ( (Double)colour.get( 1.0 ) ).floatValue(),
-                                ( (Double)colour.get( 2.0 ) ).floatValue(),
-                                ( (Double)colour.get( 3.0 ) ).floatValue()
-                        );
-                    }
-                    else if (e.getValue() instanceof Double)
-                    {
-                        float[] rgb = Palette.decodeRGB8( ((Double)e.getValue()).intValue() );
-
-                        setColour(
-                                terminal,
-                                index,
-                                rgb[0], rgb[1], rgb[2]
-                        );
-                    }
-                }
-                catch(ClassCastException cce)
-                {
-                    throw new LuaException( "Malformed colour table " + cce.getMessage() );
-                }
-            }
-        }
-    }
-
     @Override
     public Object[] callMethod( ILuaContext context, int method, Object[] args ) throws LuaException
     {
@@ -337,14 +293,6 @@ public class TermAPI implements ILuaAPI
             case 20:
             {
                 // setPaletteColour/setPaletteColor
-                if(args.length >= 1 && args[0] instanceof HashMap)
-                {
-                    @SuppressWarnings( { "unchecked" } ) // There isn't really a nice way around this :(
-                    HashMap<Object, Object> colourTbl = (HashMap<Object, Object>)args[0];
-                    setColour( m_terminal, colourTbl );
-                    return null;
-                }
-
                 if(args.length == 2 && args[0] instanceof Double && args[1] instanceof Double)
                 {
                     int colour = 15 - parseColour( args, true );
@@ -364,7 +312,7 @@ public class TermAPI implements ILuaAPI
                     return null;
                 }
 
-                throw new LuaException( "Expected table or number, number or number, number, number, number" );
+                throw new LuaException( "Expected number, number or number, number, number, number" );
             }
             case 21:
             case 22:

--- a/src/main/java/dan200/computercraft/core/apis/TermAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/TermAPI.java
@@ -279,12 +279,12 @@ public class TermAPI implements ILuaAPI
             case 20:
             {
                 // setColour/setColor
-                if ( args.length < 4 || !(args[0] instanceof Double) || !(args[1] instanceof Double) || !(args[2] instanceof Double) || !(args[3] instanceof Double) ) // toil and trouble
+                if( args.length < 4 || !(args[0] instanceof Double) || !(args[1] instanceof Double) || !(args[2] instanceof Double) || !(args[3] instanceof Double) ) // toil and trouble
                 {
                     throw new LuaException( "Expected number, number, number, number" );
                 }
 
-                if ( !m_environment.isColour() )
+                if( !m_environment.isColour() )
                 {
                     // Make sure you can't circumvent greyscale terminals with this function.
                     throw new LuaException( "Colour not supported" );
@@ -320,7 +320,7 @@ public class TermAPI implements ILuaAPI
                 {
                     if ( m_terminal.getPalette() != null )
                     {
-                        return ArrayUtils.toObject( m_terminal.getPalette().getColour64( colour ) );
+                        return ArrayUtils.toObject( m_terminal.getPalette().getColour( colour ) );
                     }
                 }
                 return null;

--- a/src/main/java/dan200/computercraft/core/apis/TermAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/TermAPI.java
@@ -336,7 +336,7 @@ public class TermAPI implements ILuaAPI
             case 19:
             case 20:
             {
-                // setColour/setColor
+                // setPaletteColour/setPaletteColor
                 if( !m_environment.isColour() )
                 {
                     // Make sure you can't circumvent greyscale terminals with this function.
@@ -375,8 +375,8 @@ public class TermAPI implements ILuaAPI
             case 21:
             case 22:
             {
-                // getColour/getColor
-                if (args.length < 1 || !(args[0] instanceof Double))
+                // getPaletteColour/getPaletteColor
+                if(args.length < 1 || !(args[0] instanceof Double))
                 {
                     throw new LuaException( "Expected number" );
                 }

--- a/src/main/java/dan200/computercraft/core/apis/TermAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/TermAPI.java
@@ -337,12 +337,6 @@ public class TermAPI implements ILuaAPI
             case 20:
             {
                 // setPaletteColour/setPaletteColor
-                if( !m_environment.isColour() )
-                {
-                    // Make sure you can't circumvent greyscale terminals with this function.
-                    throw new LuaException( "Colour not supported" );
-                }
-
                 if(args.length >= 1 && args[0] instanceof HashMap)
                 {
                     @SuppressWarnings( { "unchecked" } ) // There isn't really a nice way around this :(
@@ -353,7 +347,7 @@ public class TermAPI implements ILuaAPI
 
                 if(args.length == 2 && args[0] instanceof Double && args[1] instanceof Double)
                 {
-                    int colour = 15 - parseColour( args, m_environment.isColour() );
+                    int colour = 15 - parseColour( args, true );
                     int hex = ((Double)args[1]).intValue();
                     float[] rgb = Palette.decodeRGB8( hex );
                     setColour( m_terminal, colour, rgb[0], rgb[1], rgb[2] );
@@ -362,7 +356,7 @@ public class TermAPI implements ILuaAPI
 
                 if(args.length >= 4 && args[0] instanceof Double && args[1] instanceof Double && args[2] instanceof Double && args[3] instanceof Double)
                 {
-                    int colour = 15 - parseColour( args, m_environment.isColour() );
+                    int colour = 15 - parseColour( args, true );
                     float r = ((Double)args[1]).floatValue();
                     float g = ((Double)args[2]).floatValue();
                     float b = ((Double)args[3]).floatValue();

--- a/src/main/java/dan200/computercraft/core/apis/TermAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/TermAPI.java
@@ -81,7 +81,7 @@ public class TermAPI implements ILuaAPI
         };
     }
     
-    public static int parseColour( Object[] args, boolean _enableColours ) throws LuaException
+    public static int parseColour( Object[] args ) throws LuaException
     {
         if( args.length < 1 || args[0] == null || !(args[0] instanceof Double) )
         {
@@ -96,10 +96,6 @@ public class TermAPI implements ILuaAPI
         if( colour < 0 || colour > 15 )
         {
             throw new LuaException( "Colour out of range" );
-        }
-        if( !_enableColours && (colour != 0 && colour != 15 && colour != 7 && colour != 8) )
-        {
-            throw new LuaException( "Colour not supported" );
         }
         return colour;
     }
@@ -230,7 +226,7 @@ public class TermAPI implements ILuaAPI
             case 9:
             {
                 // setTextColour/setTextColor
-                int colour = parseColour( args, m_environment.isColour() );
+                int colour = parseColour( args );
                 synchronized( m_terminal )
                 {
                     m_terminal.setTextColour( colour );
@@ -241,7 +237,7 @@ public class TermAPI implements ILuaAPI
             case 11:
             {
                 // setBackgroundColour/setBackgroundColor
-                int colour = parseColour( args, m_environment.isColour() );
+                int colour = parseColour( args );
                 synchronized( m_terminal )
                 {
                     m_terminal.setBackgroundColour( colour );
@@ -295,7 +291,7 @@ public class TermAPI implements ILuaAPI
                 // setPaletteColour/setPaletteColor
                 if(args.length == 2 && args[0] instanceof Double && args[1] instanceof Double)
                 {
-                    int colour = 15 - parseColour( args, true );
+                    int colour = 15 - parseColour( args );
                     int hex = ((Double)args[1]).intValue();
                     float[] rgb = Palette.decodeRGB8( hex );
                     setColour( m_terminal, colour, rgb[0], rgb[1], rgb[2] );
@@ -304,7 +300,7 @@ public class TermAPI implements ILuaAPI
 
                 if(args.length >= 4 && args[0] instanceof Double && args[1] instanceof Double && args[2] instanceof Double && args[3] instanceof Double)
                 {
-                    int colour = 15 - parseColour( args, true );
+                    int colour = 15 - parseColour( args );
                     float r = ((Double)args[1]).floatValue();
                     float g = ((Double)args[2]).floatValue();
                     float b = ((Double)args[3]).floatValue();
@@ -323,8 +319,7 @@ public class TermAPI implements ILuaAPI
                     throw new LuaException( "Expected number" );
                 }
 
-                int colour = 15 - parseColour( args, m_environment.isColour() );
-
+                int colour = 15 - parseColour( args );
                 synchronized( m_terminal )
                 {
                     if ( m_terminal.getPalette() != null )

--- a/src/main/java/dan200/computercraft/core/apis/TermAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/TermAPI.java
@@ -72,9 +72,7 @@ public class TermAPI implements ILuaAPI
             "setColour",
             "setColor",
             "getColour",
-            "getColor",
-            "resetColour",
-            "resetColor"
+            "getColor"
         };
     }
     
@@ -302,6 +300,7 @@ public class TermAPI implements ILuaAPI
                     if( m_terminal.getPalette() != null )
                     {
                         m_terminal.getPalette().setColour( colour, r, g, b );
+                        m_terminal.setChanged();
                     }
                 }
                 return null;

--- a/src/main/java/dan200/computercraft/core/terminal/Terminal.java
+++ b/src/main/java/dan200/computercraft/core/terminal/Terminal.java
@@ -307,7 +307,12 @@ public class Terminal
     {
         return m_changed;
     }
-    
+
+    public void setChanged()
+    {
+        m_changed = true;
+    }
+
     public void clearChanged()
     {
         m_changed = false;
@@ -325,6 +330,10 @@ public class Terminal
             nbttagcompound.setString( "term_text_" + n, m_text[n].toString() );
             nbttagcompound.setString( "term_textColour_" + n, m_textColour[n].toString() );
             nbttagcompound.setString( "term_textBgColour_" + n, m_backgroundColour[ n ].toString() );
+        }
+        if(m_palette != null)
+        {
+            m_palette.writeToNBT( nbttagcompound );
         }
         return nbttagcompound;
     }
@@ -354,6 +363,10 @@ public class Terminal
             {
                 m_backgroundColour[n].write( nbttagcompound.getString( "term_textBgColour_" + n ) );
             }
+        }
+        if (m_palette != null)
+        {
+            m_palette.readFromNBT( nbttagcompound );
         }
         m_changed = true;
     }

--- a/src/main/java/dan200/computercraft/core/terminal/Terminal.java
+++ b/src/main/java/dan200/computercraft/core/terminal/Terminal.java
@@ -5,6 +5,7 @@
  */
 
 package dan200.computercraft.core.terminal;
+import dan200.computercraft.shared.util.Palette;
 import net.minecraft.nbt.NBTTagCompound;
 
 public class Terminal
@@ -23,6 +24,8 @@ public class Terminal
     private TextBuffer m_text[];
     private TextBuffer m_textColour[];
     private TextBuffer m_backgroundColour[];
+
+    private Palette m_palette;
 
     private boolean m_changed;
 
@@ -49,6 +52,8 @@ public class Terminal
         m_cursorBlink = false;
         
         m_changed = false;
+
+        m_palette = new Palette();
     }
 
     public void reset()
@@ -60,6 +65,7 @@ public class Terminal
         m_cursorBlink = false;
         clear();
         m_changed = true;
+        m_palette.resetColours();
     }
     
     public int getWidth() {
@@ -176,6 +182,11 @@ public class Terminal
     public int getBackgroundColour()
     {
         return m_cursorBackgroundColour;
+    }
+
+    public Palette getPalette()
+    {
+        return m_palette;
     }
 
     public void blit( String text, String textColour, String backgroundColour )

--- a/src/main/java/dan200/computercraft/core/terminal/Terminal.java
+++ b/src/main/java/dan200/computercraft/core/terminal/Terminal.java
@@ -25,7 +25,7 @@ public class Terminal
     private TextBuffer m_textColour[];
     private TextBuffer m_backgroundColour[];
 
-    private Palette m_palette;
+    private final Palette m_palette;
 
     private boolean m_changed;
 

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
@@ -229,7 +229,7 @@ public class MonitorPeripheral implements IPeripheral
             case 20:
             case 21:
             {
-                // setColour/setColor
+                // setPaletteColour/setPaletteColor
                 Terminal terminal = m_monitor.getTerminal().getTerminal();
                 boolean isColour = m_monitor.getTerminal().isColour();
 
@@ -270,7 +270,7 @@ public class MonitorPeripheral implements IPeripheral
             case 22:
             case 23:
             {
-                // getColour/getColor
+                // getPaletteColour/getPaletteColor
                 Terminal terminal = m_monitor.getTerminal().getTerminal();
                 Palette palette = terminal.getPalette();
 

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
@@ -232,14 +232,6 @@ public class MonitorPeripheral implements IPeripheral
                 // setPaletteColour/setPaletteColor
                 Terminal terminal = m_monitor.getTerminal().getTerminal();
 
-                if(args.length >= 1 && args[0] instanceof HashMap )
-                {
-                    @SuppressWarnings( { "unchecked" } ) // There isn't really a nice way around this :(
-                    HashMap<Object, Object> colourTbl = (HashMap<Object, Object>)args[0];
-                    dan200.computercraft.core.apis.TermAPI.setColour( terminal, colourTbl );
-                    return null;
-                }
-
                 if(args.length == 2 && args[0] instanceof Double && args[1] instanceof Double)
                 {
                     int colour = 15 - dan200.computercraft.core.apis.TermAPI.parseColour( args, true );
@@ -259,7 +251,7 @@ public class MonitorPeripheral implements IPeripheral
                     return null;
                 }
 
-                throw new LuaException( "Expected table or number, number, number, number" );
+                throw new LuaException( "Expected number, number or number, number, number, number" );
             }
             case 22:
             case 23:

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
@@ -14,6 +14,8 @@ import dan200.computercraft.core.terminal.Terminal;
 import dan200.computercraft.shared.util.Palette;
 import org.apache.commons.lang3.ArrayUtils;
 
+import java.util.HashMap;
+
 public class MonitorPeripheral implements IPeripheral
 {
     private final TileMonitor m_monitor;
@@ -229,14 +231,6 @@ public class MonitorPeripheral implements IPeripheral
             {
                 // setColour/setColor
                 Terminal terminal = m_monitor.getTerminal().getTerminal();
-                Palette palette = terminal.getPalette();
-
-                // setColour/setColor
-                if( args.length < 4 || !(args[0] instanceof Double) || !(args[1] instanceof Double) || !(args[2] instanceof Double) || !(args[3] instanceof Double) )
-                {
-                    throw new LuaException( "Expected number, number, number, number" );
-                }
-
                 boolean isColour = m_monitor.getTerminal().isColour();
 
                 if( !isColour )
@@ -244,15 +238,25 @@ public class MonitorPeripheral implements IPeripheral
                     throw new LuaException( "Colour not supported" );
                 }
 
-                int colour = 15 - dan200.computercraft.core.apis.TermAPI.parseColour( args, true );
-                float r = ((Double)args[1]).floatValue();
-                float g = ((Double)args[2]).floatValue();
-                float b = ((Double)args[3]).floatValue();
-
-                if( palette != null )
+                if(args.length >= 1 && args[0] instanceof HashMap )
                 {
-                    palette.setColour( colour, r, g, b );
+                    @SuppressWarnings( { "unchecked" } ) // There isn't really a nice way around this :(
+                    HashMap<Object, Object> colourTbl = (HashMap<Object, Object>)args[0];
+                    dan200.computercraft.core.apis.TermAPI.setColour( terminal, colourTbl );
                 }
+                else if (args.length >= 4 && args[0] instanceof Double && args[1] instanceof Double && args[2] instanceof Double && args[3] instanceof Double)
+                {
+                    int colour = 15 - dan200.computercraft.core.apis.TermAPI.parseColour( args, true );
+                    float r = ((Double)args[1]).floatValue();
+                    float g = ((Double)args[2]).floatValue();
+                    float b = ((Double)args[3]).floatValue();
+                    dan200.computercraft.core.apis.TermAPI.setColour( terminal, colour, r, g, b );
+                }
+                else
+                {
+                    throw new LuaException( "Expected table or number, number, number, number" );
+                }
+
                 return null;
             }
             case 22:

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
@@ -169,7 +169,7 @@ public class MonitorPeripheral implements IPeripheral
             case 10:
             {
                 // setTextColour/setTextColor
-                int colour = dan200.computercraft.core.apis.TermAPI.parseColour( args, m_monitor.getTerminal().isColour() );
+                int colour = dan200.computercraft.core.apis.TermAPI.parseColour( args );
                 Terminal terminal = m_monitor.getTerminal().getTerminal();
                 terminal.setTextColour( colour );
                 return null;
@@ -178,7 +178,7 @@ public class MonitorPeripheral implements IPeripheral
             case 12:
             {
                 // setBackgroundColour/setBackgroundColor
-                int colour = dan200.computercraft.core.apis.TermAPI.parseColour( args, m_monitor.getTerminal().isColour() );
+                int colour = dan200.computercraft.core.apis.TermAPI.parseColour( args );
                 Terminal terminal = m_monitor.getTerminal().getTerminal();
                 terminal.setBackgroundColour( colour );
                 return null;
@@ -234,7 +234,7 @@ public class MonitorPeripheral implements IPeripheral
 
                 if(args.length == 2 && args[0] instanceof Double && args[1] instanceof Double)
                 {
-                    int colour = 15 - dan200.computercraft.core.apis.TermAPI.parseColour( args, true );
+                    int colour = 15 - dan200.computercraft.core.apis.TermAPI.parseColour( args );
                     int hex = ((Double)args[1]).intValue();
                     float[] rgb = Palette.decodeRGB8( hex );
                     dan200.computercraft.core.apis.TermAPI.setColour( terminal, colour, rgb[0], rgb[1], rgb[2] );
@@ -243,7 +243,7 @@ public class MonitorPeripheral implements IPeripheral
 
                 if (args.length >= 4 && args[0] instanceof Double && args[1] instanceof Double && args[2] instanceof Double && args[3] instanceof Double)
                 {
-                    int colour = 15 - dan200.computercraft.core.apis.TermAPI.parseColour( args, true );
+                    int colour = 15 - dan200.computercraft.core.apis.TermAPI.parseColour( args );
                     float r = ((Double)args[1]).floatValue();
                     float g = ((Double)args[2]).floatValue();
                     float b = ((Double)args[3]).floatValue();
@@ -251,7 +251,7 @@ public class MonitorPeripheral implements IPeripheral
                     return null;
                 }
 
-                throw new LuaException( "Expected number, number or number, number, number, number" );
+                throw new LuaException( "Expected number, number, number, number" );
             }
             case 22:
             case 23:
@@ -260,7 +260,7 @@ public class MonitorPeripheral implements IPeripheral
                 Terminal terminal = m_monitor.getTerminal().getTerminal();
                 Palette palette = terminal.getPalette();
 
-                int colour = 15 - dan200.computercraft.core.apis.TermAPI.parseColour( args, m_monitor.getTerminal().isColour() );
+                int colour = 15 - dan200.computercraft.core.apis.TermAPI.parseColour( args );
 
                 if( palette != null )
                 {

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
@@ -57,10 +57,10 @@ public class MonitorPeripheral implements IPeripheral
             "getBackgroundColour",
             "getBackgroundColor",
             "blit",
-            "setColour",
-            "setColor",
-            "getColour",
-            "getColor"
+            "setPaletteColour",
+            "setPaletteColor",
+            "getPaletteColour",
+            "getPaletteColor"
         };
     }
 

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
@@ -231,12 +231,6 @@ public class MonitorPeripheral implements IPeripheral
             {
                 // setPaletteColour/setPaletteColor
                 Terminal terminal = m_monitor.getTerminal().getTerminal();
-                boolean isColour = m_monitor.getTerminal().isColour();
-
-                if( !isColour )
-                {
-                    throw new LuaException( "Colour not supported" );
-                }
 
                 if(args.length >= 1 && args[0] instanceof HashMap )
                 {

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
@@ -243,21 +243,29 @@ public class MonitorPeripheral implements IPeripheral
                     @SuppressWarnings( { "unchecked" } ) // There isn't really a nice way around this :(
                     HashMap<Object, Object> colourTbl = (HashMap<Object, Object>)args[0];
                     dan200.computercraft.core.apis.TermAPI.setColour( terminal, colourTbl );
+                    return null;
                 }
-                else if (args.length >= 4 && args[0] instanceof Double && args[1] instanceof Double && args[2] instanceof Double && args[3] instanceof Double)
+
+                if(args.length == 2 && args[0] instanceof Double && args[1] instanceof Double)
+                {
+                    int colour = 15 - dan200.computercraft.core.apis.TermAPI.parseColour( args, true );
+                    int hex = ((Double)args[1]).intValue();
+                    float[] rgb = Palette.decodeRGB8( hex );
+                    dan200.computercraft.core.apis.TermAPI.setColour( terminal, colour, rgb[0], rgb[1], rgb[2] );
+                    return null;
+                }
+
+                if (args.length >= 4 && args[0] instanceof Double && args[1] instanceof Double && args[2] instanceof Double && args[3] instanceof Double)
                 {
                     int colour = 15 - dan200.computercraft.core.apis.TermAPI.parseColour( args, true );
                     float r = ((Double)args[1]).floatValue();
                     float g = ((Double)args[2]).floatValue();
                     float b = ((Double)args[3]).floatValue();
                     dan200.computercraft.core.apis.TermAPI.setColour( terminal, colour, r, g, b );
-                }
-                else
-                {
-                    throw new LuaException( "Expected table or number, number, number, number" );
+                    return null;
                 }
 
-                return null;
+                throw new LuaException( "Expected table or number, number, number, number" );
             }
             case 22:
             case 23:

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
@@ -11,6 +11,8 @@ import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.core.terminal.Terminal;
+import dan200.computercraft.shared.util.Palette;
+import org.apache.commons.lang3.ArrayUtils;
 
 public class MonitorPeripheral implements IPeripheral
 {
@@ -52,7 +54,11 @@ public class MonitorPeripheral implements IPeripheral
             "getTextColor",
             "getBackgroundColour",
             "getBackgroundColor",
-            "blit"
+            "blit",
+            "setColour",
+            "setColor",
+            "getColour",
+            "getColor"
         };
     }
 
@@ -216,6 +222,52 @@ public class MonitorPeripheral implements IPeripheral
                 Terminal terminal = m_monitor.getTerminal().getTerminal();
                 terminal.blit( text, textColour, backgroundColour );
                 terminal.setCursorPos( terminal.getCursorX() + text.length(), terminal.getCursorY() );
+                return null;
+            }
+            case 20:
+            case 21:
+            {
+                // setColour/setColor
+                Terminal terminal = m_monitor.getTerminal().getTerminal();
+                Palette palette = terminal.getPalette();
+
+                // setColour/setColor
+                if( args.length < 4 || !(args[0] instanceof Double) || !(args[1] instanceof Double) || !(args[2] instanceof Double) || !(args[3] instanceof Double) )
+                {
+                    throw new LuaException( "Expected number, number, number, number" );
+                }
+
+                boolean isColour = m_monitor.getTerminal().isColour();
+
+                if( !isColour )
+                {
+                    throw new LuaException( "Colour not supported" );
+                }
+
+                int colour = 15 - dan200.computercraft.core.apis.TermAPI.parseColour( args, true );
+                float r = ((Double)args[1]).floatValue();
+                float g = ((Double)args[2]).floatValue();
+                float b = ((Double)args[3]).floatValue();
+
+                if( palette != null )
+                {
+                    palette.setColour( colour, r, g, b );
+                }
+                return null;
+            }
+            case 22:
+            case 23:
+            {
+                // getColour/getColor
+                Terminal terminal = m_monitor.getTerminal().getTerminal();
+                Palette palette = terminal.getPalette();
+
+                int colour = 15 - dan200.computercraft.core.apis.TermAPI.parseColour( args, m_monitor.getTerminal().isColour() );
+
+                if( palette != null )
+                {
+                    return ArrayUtils.toObject( palette.getColour( colour ) );
+                }
                 return null;
             }
         }

--- a/src/main/java/dan200/computercraft/shared/util/Palette.java
+++ b/src/main/java/dan200/computercraft/shared/util/Palette.java
@@ -1,5 +1,7 @@
 package dan200.computercraft.shared.util;
 
+import net.minecraft.nbt.NBTTagCompound;
+
 public class Palette
 {
     private static class PaletteColour
@@ -91,6 +93,30 @@ public class Palette
         for(int i = 0; i < Colour.values().length; ++i)
         {
             resetColour( i );
+        }
+    }
+
+    public NBTTagCompound writeToNBT( NBTTagCompound nbt )
+    {
+        for(int i = 0; i < colours.length; ++i)
+        {
+            PaletteColour c = colours[i];
+            String prefix = "term_palette_colour_" + i;
+            nbt.setFloat( prefix + "_r", c.m_r );
+            nbt.setFloat( prefix + "_g", c.m_g );
+            nbt.setFloat( prefix + "_b", c.m_b );
+        }
+        return nbt;
+    }
+
+    public void readFromNBT( NBTTagCompound nbt )
+    {
+        for(int i = 0; i < colours.length; ++i)
+        {
+            String prefix = "term_palette_colour_" + i;
+            colours[i].m_r = nbt.getFloat( prefix + "_r" );
+            colours[i].m_g = nbt.getFloat( prefix + "_g" );
+            colours[i].m_b = nbt.getFloat( prefix + "_b" );
         }
     }
 }

--- a/src/main/java/dan200/computercraft/shared/util/Palette.java
+++ b/src/main/java/dan200/computercraft/shared/util/Palette.java
@@ -70,16 +70,6 @@ public class Palette
         return null;
     }
 
-    public double[] getColour64( int i )
-    {
-        if( i >= 0 && i < colours.length )
-        {
-            PaletteColour c = colours[ i ];
-            return new double[] { (double)c.m_r, (double)c.m_g, (double)c.m_b };
-        }
-        return null;
-    }
-
     public void resetColour( int i )
     {
         if(i >= 0 && i < colours.length )

--- a/src/main/java/dan200/computercraft/shared/util/Palette.java
+++ b/src/main/java/dan200/computercraft/shared/util/Palette.java
@@ -7,6 +7,8 @@ public class Palette
     private static final int PALETTE_SIZE = 16;
     private final float[][] colours = new float[PALETTE_SIZE][3];
 
+    public static final Palette DEFAULT = new Palette();
+
     public Palette()
     {
         // Get the default palette

--- a/src/main/java/dan200/computercraft/shared/util/Palette.java
+++ b/src/main/java/dan200/computercraft/shared/util/Palette.java
@@ -68,12 +68,30 @@ public class Palette
         return null;
     }
 
+    public double[] getColour64( int i )
+    {
+        if( i >= 0 && i < colours.length )
+        {
+            PaletteColour c = colours[ i ];
+            return new double[] { (double)c.m_r, (double)c.m_g, (double)c.m_b };
+        }
+        return null;
+    }
+
+    public void resetColour( int i )
+    {
+        if(i >= 0 && i < colours.length )
+        {
+            Colour c = Colour.values()[ i ];
+            colours[i] = new PaletteColour( c.getR(), c.getG(), c.getB() );
+        }
+    }
+
     public void resetColours()
     {
         for(int i = 0; i < Colour.values().length; ++i)
         {
-            Colour c = Colour.values()[ i ];
-            colours[i] = new PaletteColour( c.getR(), c.getG(), c.getB() );
+            resetColour( i );
         }
     }
 }

--- a/src/main/java/dan200/computercraft/shared/util/Palette.java
+++ b/src/main/java/dan200/computercraft/shared/util/Palette.java
@@ -53,7 +53,7 @@ public class Palette
         }
     }
 
-    private static int encodeRGB8( float[] rgb )
+    public static int encodeRGB8( float[] rgb )
     {
         int r = (int)( rgb[0] * 255 ) & 0xFF;
         int g = (int)( rgb[1] * 255 ) & 0xFF;
@@ -62,7 +62,7 @@ public class Palette
         return ( r << 16 ) | ( g << 8 ) | b;
     }
 
-    private static float[] decodeRGB8( int rgb )
+    public static float[] decodeRGB8( int rgb )
     {
         return new float[]
         {

--- a/src/main/java/dan200/computercraft/shared/util/Palette.java
+++ b/src/main/java/dan200/computercraft/shared/util/Palette.java
@@ -82,8 +82,7 @@ public class Palette
     {
         if(i >= 0 && i < colours.length )
         {
-            Colour c = Colour.values()[ i ];
-            colours[i] = new PaletteColour( c.getR(), c.getG(), c.getB() );
+            setColour( i, Colour.values()[ i ] );
         }
     }
 

--- a/src/main/java/dan200/computercraft/shared/util/Palette.java
+++ b/src/main/java/dan200/computercraft/shared/util/Palette.java
@@ -4,42 +4,8 @@ import net.minecraft.nbt.NBTTagCompound;
 
 public class Palette
 {
-    private static class PaletteColour
-    {
-        private float m_r, m_g, m_b;
-
-        public PaletteColour(float r, float g, float b)
-        {
-            m_r = r;
-            m_g = g;
-            m_b = b;
-        }
-
-        @Override
-        public boolean equals(Object o)
-        {
-            if(this == o) return true;
-            if(o == null || getClass() != o.getClass()) return false;
-
-            PaletteColour that = (PaletteColour) o;
-
-            if(Float.compare( that.m_r, m_r ) != 0) return false;
-            if(Float.compare( that.m_g, m_g ) != 0) return false;
-            return Float.compare( that.m_b, m_b ) == 0;
-        }
-
-        @Override
-        public int hashCode()
-        {
-            int result = (m_r != +0.0f ? Float.floatToIntBits( m_r ) : 0);
-            result = 31 * result + (m_g != +0.0f ? Float.floatToIntBits( m_g ) : 0);
-            result = 31 * result + (m_b != +0.0f ? Float.floatToIntBits( m_b ) : 0);
-            return result;
-        }
-    }
-
     private static final int PALETTE_SIZE = 16;
-    private final PaletteColour[] colours = new PaletteColour[ PALETTE_SIZE ];
+    private final float[][] colours = new float[PALETTE_SIZE][3];
 
     public Palette()
     {
@@ -51,7 +17,9 @@ public class Palette
     {
         if( i >= 0 && i < colours.length )
         {
-            colours[ i ] = new PaletteColour( r, g, b );
+            colours[i][0] = r;
+            colours[i][1] = g;
+            colours[i][2] = b;
         }
     }
 
@@ -64,17 +32,16 @@ public class Palette
     {
         if( i >= 0 && i < colours.length )
         {
-            PaletteColour c = colours[ i ];
-            return new float[] { c.m_r, c.m_g, c.m_b };
+            return colours[i];
         }
         return null;
     }
 
     public void resetColour( int i )
     {
-        if(i >= 0 && i < colours.length )
+        if( i >= 0 && i < colours.length )
         {
-            setColour( i, Colour.values()[ i ] );
+            setColour( i, Colour.values()[i] );
         }
     }
 
@@ -90,11 +57,10 @@ public class Palette
     {
         for(int i = 0; i < colours.length; ++i)
         {
-            PaletteColour c = colours[i];
             String prefix = "term_palette_colour_" + i;
-            nbt.setFloat( prefix + "_r", c.m_r );
-            nbt.setFloat( prefix + "_g", c.m_g );
-            nbt.setFloat( prefix + "_b", c.m_b );
+            nbt.setFloat( prefix + "_r", colours[i][0] );
+            nbt.setFloat( prefix + "_g", colours[i][1] );
+            nbt.setFloat( prefix + "_b", colours[i][2] );
         }
         return nbt;
     }
@@ -104,9 +70,9 @@ public class Palette
         for(int i = 0; i < colours.length; ++i)
         {
             String prefix = "term_palette_colour_" + i;
-            colours[i].m_r = nbt.getFloat( prefix + "_r" );
-            colours[i].m_g = nbt.getFloat( prefix + "_g" );
-            colours[i].m_b = nbt.getFloat( prefix + "_b" );
+            colours[i][0] = nbt.getFloat( prefix + "_r" );
+            colours[i][1] = nbt.getFloat( prefix + "_g" );
+            colours[i][2] = nbt.getFloat( prefix + "_b" );
         }
     }
 }

--- a/src/main/java/dan200/computercraft/shared/util/Palette.java
+++ b/src/main/java/dan200/computercraft/shared/util/Palette.java
@@ -1,0 +1,79 @@
+package dan200.computercraft.shared.util;
+
+public class Palette
+{
+    private static class PaletteColour
+    {
+        private float m_r, m_g, m_b;
+
+        public PaletteColour(float r, float g, float b)
+        {
+            m_r = r;
+            m_g = g;
+            m_b = b;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if(this == o) return true;
+            if(o == null || getClass() != o.getClass()) return false;
+
+            PaletteColour that = (PaletteColour) o;
+
+            if(Float.compare( that.m_r, m_r ) != 0) return false;
+            if(Float.compare( that.m_g, m_g ) != 0) return false;
+            return Float.compare( that.m_b, m_b ) == 0;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = (m_r != +0.0f ? Float.floatToIntBits( m_r ) : 0);
+            result = 31 * result + (m_g != +0.0f ? Float.floatToIntBits( m_g ) : 0);
+            result = 31 * result + (m_b != +0.0f ? Float.floatToIntBits( m_b ) : 0);
+            return result;
+        }
+    }
+
+    private static final int PALETTE_SIZE = 16;
+    private final PaletteColour[] colours = new PaletteColour[ PALETTE_SIZE ];
+
+    public Palette()
+    {
+        // Get the default palette
+        resetColours();
+    }
+
+    public void setColour(int i, float r, float g, float b)
+    {
+        if( i >= 0 && i < colours.length )
+        {
+            colours[ i ] = new PaletteColour( r, g, b );
+        }
+    }
+
+    public void setColour(int i, Colour colour)
+    {
+        setColour( i, colour.getR(), colour.getG(), colour.getB() );
+    }
+
+    public float[] getColour( int i )
+    {
+        if( i >= 0 && i < colours.length )
+        {
+            PaletteColour c = colours[ i ];
+            return new float[] { c.m_r, c.m_g, c.m_b };
+        }
+        return null;
+    }
+
+    public void resetColours()
+    {
+        for(int i = 0; i < Colour.values().length; ++i)
+        {
+            Colour c = Colour.values()[ i ];
+            colours[i] = new PaletteColour( c.getR(), c.getG(), c.getB() );
+        }
+    }
+}

--- a/src/main/java/dan200/computercraft/shared/util/Palette.java
+++ b/src/main/java/dan200/computercraft/shared/util/Palette.java
@@ -53,26 +53,45 @@ public class Palette
         }
     }
 
+    private static int encodeRGB8( float[] rgb )
+    {
+        int r = (int)( rgb[0] * 255 ) & 0xFF;
+        int g = (int)( rgb[1] * 255 ) & 0xFF;
+        int b = (int)( rgb[2] * 255 ) & 0xFF;
+
+        return ( r << 16 ) | ( g << 8 ) | b;
+    }
+
+    private static float[] decodeRGB8( int rgb )
+    {
+        return new float[]
+        {
+            (( rgb >> 16 ) & 0xFF) / 255.0f,
+            (( rgb >> 8 ) & 0xFF) / 255.0f,
+            ( rgb & 0xFF ) / 255.0f
+        };
+    }
+
     public NBTTagCompound writeToNBT( NBTTagCompound nbt )
     {
+        int[] rgb8 = new int[colours.length];
+
         for(int i = 0; i < colours.length; ++i)
         {
-            String prefix = "term_palette_colour_" + i;
-            nbt.setFloat( prefix + "_r", colours[i][0] );
-            nbt.setFloat( prefix + "_g", colours[i][1] );
-            nbt.setFloat( prefix + "_b", colours[i][2] );
+            rgb8[i] = encodeRGB8( colours[i] );
         }
+
+        nbt.setIntArray( "term_palette", rgb8 );
         return nbt;
     }
 
     public void readFromNBT( NBTTagCompound nbt )
     {
+        int[] rgb8 = nbt.getIntArray( "term_palette" );
+
         for(int i = 0; i < colours.length; ++i)
         {
-            String prefix = "term_palette_colour_" + i;
-            colours[i][0] = nbt.getFloat( prefix + "_r" );
-            colours[i][1] = nbt.getFloat( prefix + "_g" );
-            colours[i][2] = nbt.getFloat( prefix + "_b" );
+            colours[i] = decodeRGB8( rgb8[i] );
         }
     }
 }

--- a/src/main/resources/assets/computercraft/lua/rom/apis/colors
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/colors
@@ -40,8 +40,11 @@ function rgb8( r, g, b )
     if type(r) == "number" and g == nil and b == nil then
         return bit32.band( bit32.rshift( r, 16 ), 0xFF ) / 255, bit32.band( bit32.rshift( r, 8 ), 0xFF ) / 255, bit32.band( r, 0xFF ) / 255
     elseif type(r) == "number" and type(g) == "number" and type(b) == "number" then
-        return r / 255, g / 255, b / 255
+        return 
+            bit32.lshift( bit32.band(r * 255, 0xFF), 16 ) +
+            bit32.lshift( bit32.band(g * 255, 0xFF), 8 ) +
+            bit32.band(b * 255 0xFF)
     else
-        return nil
+        error( "Expected 1 or 3 numbers" )
     end
 end

--- a/src/main/resources/assets/computercraft/lua/rom/apis/colors
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/colors
@@ -25,13 +25,23 @@ function combine( ... )
 end
 
 function subtract( colors, ... )
-	local r = colors
-	for n,c in ipairs( { ... } ) do
-		r = bit32.band(r, bit32.bnot(c))
-	end
-	return r
+    local r = colors
+    for n,c in ipairs( { ... } ) do
+        r = bit32.band(r, bit32.bnot(c))
+    end
+    return r
 end
 
 function test( colors, color )
     return ((bit32.band(colors, color)) == color)
+end
+
+function rgb8( r, g, b )
+    if type(r) == "number" and g == nil and b == nil then
+        return bit32.band( bit32.rshift( r, 16 ), 0xFF ) / 255, bit32.band( bit32.rshift( r, 8 ), 0xFF ) / 255, bit32.band( r, 0xFF ) / 255
+    elseif type(r) == "number" and type(g) == "number" and type(b) == "number" then
+        return r / 255, g / 255, b / 255
+    else
+        return nil
+    end
 end

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window
@@ -72,7 +72,7 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
 
         for i=0,15 do
             local c = 2 ^ i
-            tPalette[c] = table.pack( parent.getColour( c ) )
+            tPalette[c] = { parent.getColour( c ) }
         end
     end
 
@@ -291,7 +291,9 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
             for k,v in pairs(colour) do
                 tPalette[k] = v
             end
-        else
+        elseif type(colour) == "number" and type(r) == "number" and g == nil and b == nil then
+            tPalette[ colour ] = { colours.rgb8( r ) }
+        elseif type(colour) == "number" and type(r) == "number" and type(g) == "number" and type(b) == "number" then
             local tCol = tPalette[ colour ]
             tCol[1] = r
             tCol[2] = g

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window
@@ -289,8 +289,16 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     function window.setPaletteColour( colour, r, g, b )
         if type(colour) == "table" then
             for k,v in pairs(colour) do
-                tPalette[k] = v
+                if type(v) == "number" then
+                    local vr, vg, vb = colours.rgb8( v )
+                    tPalette[k] = { vr, vg, vb }
+                    parent.setPaletteColour( k, vr, vg, vb )
+                elseif type(v) == "table" then
+                    tPalette[k] = v
+                    parent.setPaletteColour( k, table.unpack( v ) )
+                end
             end
+            return
         elseif type(colour) == "number" and type(r) == "number" and g == nil and b == nil then
             tPalette[ colour ] = { colours.rgb8( r ) }
         elseif type(colour) == "number" and type(r) == "number" and type(g) == "number" and type(b) == "number" then
@@ -301,7 +309,7 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
         end
 
         if bVisible then
-            return updatePalette()
+            return parent.setPaletteColour( colour, tPalette[ colour ] )
         end
     end
 

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window
@@ -94,12 +94,6 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
         parent.setTextColor( nTextColor )
     end
 
-    local function updatePalette()
-        for k,v in pairs(tPalette) do
-            parent.setColour( k, table.unpack( v ) )
-        end
-    end
-    
     local function redrawLine( n )
         local tLine = tLines[ n ]
         parent.setCursorPos( nX, nY + n - 1 )
@@ -109,6 +103,12 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     local function redraw()
         for n=1,nHeight do
             redrawLine( n )
+        end
+    end
+
+    local function updatePalette()
+        for k,v in pairs(tPalette) do
+            parent.setColour( k, table.unpack( v ) )
         end
     end
 
@@ -293,6 +293,10 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
         tCol[1] = r
         tCol[2] = g
         tCol[3] = b
+
+        if bVisible then
+            return updatePalette()
+        end
     end
 
     window.setColor = window.setColour
@@ -380,10 +384,10 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     function window.redraw()
         if bVisible then
             redraw()
+            updatePalette()
             updateCursorBlink()
             updateCursorColor()
             updateCursorPos()
-            updatePalette()
         end
     end
 

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window
@@ -20,6 +20,7 @@ local tHex = {
 
 local string_rep = string.rep
 local string_sub = string.sub
+local table_unpack = table.unpack
 
 function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
 
@@ -108,7 +109,7 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
 
     local function updatePalette()
         for k,v in pairs( tPalette ) do
-            parent.setPaletteColour( k, table.unpack( v ) )
+            parent.setPaletteColour( k, v[1], v[2], v[3] )
         end
     end
 
@@ -269,11 +270,6 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     end
 
     local function setTextColor( color )
-        if not parent.isColor() then
-            if color ~= colors.white and color ~= colors.black and color ~= colors.gray and color ~= colors.lightGray then
-                error( "Color not supported", 3 )
-            end
-        end
         nTextColor = color
         if bVisible then
             updateCursorColor()
@@ -289,34 +285,33 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     end
 
     function window.setPaletteColour( colour, r, g, b )
+        local tCol
         if type(colour) == "number" and type(r) == "number" and g == nil and b == nil then
-            tPalette[ colour ] = { colours.rgb8( r ) }
+            tCol = { colours.rgb8( r ) }
         elseif type(colour) == "number" and type(r) == "number" and type(g) == "number" and type(b) == "number" then
-            local tCol = tPalette[ colour ]
+            tCol = tPalette[ colour ]
             tCol[1] = r
             tCol[2] = g
             tCol[3] = b
+        else
+            error("Expected number, number, number, number")
         end
 
         if bVisible then
-            return parent.setPaletteColour( colour, table.unpack( tPalette[ colour ] ) )
+            return parent.setPaletteColour( colour, tCol[1], tCol[2], tCol[3] ) )
         end
     end
 
     window.setPaletteColor = window.setPaletteColour
 
     function window.getPaletteColour( colour )
-        return table.unpack( tPalette[ colour ] )
+        local tCol = tPalette[ colour ]
+        return tCol[1], tCol[2], tCol[3]
     end
 
     window.getPaletteColor = window.getPaletteColour
 
     local function setBackgroundColor( color )
-        if not parent.isColor() then
-            if color ~= colors.white and color ~= colors.black and color ~= colors.gray and color ~= colors.lightGray then
-                error( "Color not supported", 3 )
-            end
-        end
         nBackgroundColor = color
     end
 

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window
@@ -72,7 +72,7 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
 
         for i=0,15 do
             local c = 2 ^ i
-            tPalette[c] = { parent.getColour( c ) }
+            tPalette[c] = { parent.getPaletteColour( c ) }
         end
     end
 
@@ -107,7 +107,7 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     end
 
     local function updatePalette()
-        return parent.setColour( tPalette )
+        return parent.setPaletteColour( tPalette )
     end
 
     local function internalBlit( sText, sTextColor, sBackgroundColor )
@@ -286,7 +286,7 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
         setTextColor( color )
     end
 
-    function window.setColour( colour, r, g, b )
+    function window.setPaletteColour( colour, r, g, b )
         if type(colour) == "table" then
             for k,v in pairs(colour) do
                 tPalette[k] = v
@@ -305,13 +305,13 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
         end
     end
 
-    window.setColor = window.setColour
+    window.setPaletteColor = window.setPaletteColour
 
-    function window.getColour( colour )
+    function window.getPaletteColour( colour )
         return table.unpack( tPalette[ colour ] )
     end
 
-    window.getColor = window.getColour
+    window.getPaletteColor = window.getPaletteColour
 
     local function setBackgroundColor( color )
         if not parent.isColor() then

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window
@@ -107,9 +107,7 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     end
 
     local function updatePalette()
-        for k,v in pairs(tPalette) do
-            parent.setColour( k, table.unpack( v ) )
-        end
+        return parent.setColour( tPalette )
     end
 
     local function internalBlit( sText, sTextColor, sBackgroundColor )
@@ -289,10 +287,16 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     end
 
     function window.setColour( colour, r, g, b )
-        local tCol = tPalette[ colour ]
-        tCol[1] = r
-        tCol[2] = g
-        tCol[3] = b
+        if type(colour) == "table" then
+            for k,v in pairs(colour) do
+                tPalette[k] = v
+            end
+        else
+            local tCol = tPalette[ colour ]
+            tCol[1] = r
+            tCol[2] = g
+            tCol[3] = b
+        end
 
         if bVisible then
             return updatePalette()

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window
@@ -383,6 +383,7 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
             updateCursorBlink()
             updateCursorColor()
             updateCursorPos()
+            updatePalette()
         end
     end
 

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window
@@ -309,7 +309,7 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
         end
 
         if bVisible then
-            return parent.setPaletteColour( colour, tPalette[ colour ] )
+            return parent.setPaletteColour( colour, table.unpack( tPalette[ colour ] ) )
         end
     end
 

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window
@@ -57,6 +57,7 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     local nTextColor = colors.white
     local nBackgroundColor = colors.black
     local tLines = {}
+    local tPalette = {}
     do
         local sEmptyText = sEmptySpaceLine
         local sEmptyTextColor = tEmptyColorLines[ nTextColor ]
@@ -67,6 +68,11 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
                 textColor = sEmptyTextColor,
                 backgroundColor = sEmptyBackgroundColor,
             }
+        end
+
+        for i=0,15 do
+            local c = 2 ^ i
+            tPalette[c] = table.pack( parent.getColour( c ) )
         end
     end
 
@@ -86,6 +92,12 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     
     local function updateCursorColor()
         parent.setTextColor( nTextColor )
+    end
+
+    local function updatePalette()
+        for k,v in pairs(tPalette) do
+            parent.setColour( k, table.unpack( v ) )
+        end
     end
     
     local function redrawLine( n )
@@ -275,6 +287,21 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     function window.setTextColour( color )
         setTextColor( color )
     end
+
+    function window.setColour( colour, r, g, b )
+        local tCol = tPalette[ colour ]
+        tCol[1] = r
+        tCol[2] = g
+        tCol[3] = b
+    end
+
+    window.setColor = window.setColour
+
+    function window.getColour( colour )
+        return table.unpack( tPalette[ colour ] )
+    end
+
+    window.getColor = window.getColour
 
     local function setBackgroundColor( color )
         if not parent.isColor() then

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window
@@ -107,7 +107,9 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     end
 
     local function updatePalette()
-        return parent.setPaletteColour( tPalette )
+        for k,v in pairs( tPalette ) do
+            parent.setPaletteColour( k, table.unpack( v ) )
+        end
     end
 
     local function internalBlit( sText, sTextColor, sBackgroundColor )
@@ -287,19 +289,7 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     end
 
     function window.setPaletteColour( colour, r, g, b )
-        if type(colour) == "table" then
-            for k,v in pairs(colour) do
-                if type(v) == "number" then
-                    local vr, vg, vb = colours.rgb8( v )
-                    tPalette[k] = { vr, vg, vb }
-                    parent.setPaletteColour( k, vr, vg, vb )
-                elseif type(v) == "table" then
-                    tPalette[k] = v
-                    parent.setPaletteColour( k, table.unpack( v ) )
-                end
-            end
-            return
-        elseif type(colour) == "number" and type(r) == "number" and g == nil and b == nil then
+        if type(colour) == "number" and type(r) == "number" and g == nil and b == nil then
             tPalette[ colour ] = { colours.rgb8( r ) }
         elseif type(colour) == "number" and type(r) == "number" and type(g) == "number" and type(b) == "number" then
             local tCol = tPalette[ colour ]


### PR DESCRIPTION
As discussed in #193.
![](https://shitty.download/H4pA.png)

This adds the following terminal functions:
- `setColour(colour, r, g, b)` - Sets the RGB of a colour. `colour` is the colour from the `colours` API, `r`, `g` and `b` are specified as numbers in the range 0-1. Will (should) error when used on a greyscale computer.
- `getColour(colour)` - Gets the RGB of a colour.