### PR TITLE
Do not reset redstone inputs when adding peripherals

### DIFF
--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
@@ -977,15 +977,11 @@ public class TurtleBrain implements ITurtleAccess
                 if( !m_peripherals.containsKey( side ) )
                 {
                     serverComputer.setPeripheral( dir, peripheral );
-                    serverComputer.setRedstoneInput( dir, 0 );
-                    serverComputer.setBundledRedstoneInput( dir, 0 );
                     m_peripherals.put( side, peripheral );
                 }
                 else if( !m_peripherals.get( side ).equals( peripheral ) )
                 {
                     serverComputer.setPeripheral( dir, peripheral );
-                    serverComputer.setRedstoneInput( dir, 0 );
-                    serverComputer.setBundledRedstoneInput( dir, 0 );
                     m_peripherals.remove( side );
                     m_peripherals.put( side, peripheral );
                 }


### PR DESCRIPTION
As of 8abff95441b87df733df839eca6c373513e0487b, peripherals no longer blocked redstone input. As this is no longer the case, redstone levels no longer need to be reset.

[See this comment here](https://github.com/dan200/ComputerCraft/commit/8abff95441b87df733df839eca6c373513e0487b#commitcomment-22033607) for more details.