### PR TITLE
Replace WeakHashMap for open files with a weak set

### DIFF
--- a/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
+++ b/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
@@ -11,7 +11,6 @@ import dan200.computercraft.api.filesystem.IMount;
 import dan200.computercraft.api.filesystem.IWritableMount;
 
 import java.io.*;
-import java.lang.ref.WeakReference;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -292,7 +291,7 @@ public class FileSystem
     }
 
     private final Map<String, MountWrapper> m_mounts = new HashMap<String, MountWrapper>();
-    private final WeakHashMap<IMountedFile, Object> m_openFiles = new WeakHashMap<IMountedFile, Object>();
+    private final Set<IMountedFile> m_openFiles = Collections.newSetFromMap( new WeakHashMap<IMountedFile, Boolean>() );
     
     public FileSystem( String rootLabel, IMount rootMount ) throws FileSystemException
     {
@@ -309,7 +308,7 @@ public class FileSystem
         // Close all dangling open files
         synchronized( m_openFiles )
         {
-            for(IMountedFile file : m_openFiles.keySet())
+            for(IMountedFile file : m_openFiles)
             {
                 try {
                     file.close();

--- a/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
+++ b/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
@@ -666,7 +666,7 @@ public class FileSystem
                 throw new FileSystemException("Too many files already open");
             }
 
-            m_openFiles.put( file, null );
+            m_openFiles.add( file );
             return file;
         }
     }


### PR DESCRIPTION
While weak sets don't exist in Java, you can use [`Collections.newSetFromMap`](https://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#newSetFromMap(java.util.Map)) to create one artifically.

This doesn't change anything in terms of functionality, it just makes the code a little prettier.