### PR TITLE
Use IBlockState instead of Block methods

### DIFF
--- a/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
+++ b/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
@@ -412,7 +412,6 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
     private void registerForgeHandlers()
     {
         ForgeHandlers handlers = new ForgeHandlers();
-        FMLCommonHandler.instance().bus().register( handlers );
         MinecraftForge.EVENT_BUS.register( handlers );
     }
 

--- a/src/main/java/dan200/computercraft/shared/computer/apis/CommandAPI.java
+++ b/src/main/java/dan200/computercraft/shared/computer/apis/CommandAPI.java
@@ -119,7 +119,7 @@ public class CommandAPI implements ILuaAPI
         table.put( "metadata", metadata );
 
         Map<Object, Object> stateTable = new HashMap<Object, Object>();
-        for( Object o : block.getActualState( state, world, pos ).getProperties().entrySet() )
+        for( Object o : state.getActualState( world, pos ).getProperties().entrySet() )
         {
             ImmutableMap.Entry<IProperty, Object> entry = (ImmutableMap.Entry<IProperty, Object>)o;
             String propertyName = entry.getKey().getName();

--- a/src/main/java/dan200/computercraft/shared/pocket/items/ItemPocketComputer.java
+++ b/src/main/java/dan200/computercraft/shared/pocket/items/ItemPocketComputer.java
@@ -18,6 +18,7 @@ import dan200.computercraft.shared.computer.core.ServerComputer;
 import dan200.computercraft.shared.computer.items.IComputerItem;
 import dan200.computercraft.shared.pocket.apis.PocketAPI;
 import dan200.computercraft.shared.pocket.peripherals.PocketModemPeripheral;
+import dan200.computercraft.shared.util.StringUtil;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -30,7 +31,6 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundEvent;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
 
 import java.util.List;
@@ -200,14 +200,14 @@ public class ItemPocketComputer extends Item implements IComputerItem, IMedia
         boolean modem = getHasModem( stack );
         if( modem )
         {
-            return I18n.translateToLocalFormatted(
+            return StringUtil.translateToLocalFormatted(
                 baseString + ".upgraded.name",
-                I18n.translateToLocal( "upgrade.computercraft:wireless_modem.adjective" )
+                StringUtil.translateToLocal( "upgrade.computercraft:wireless_modem.adjective" )
             );
         }
         else
         {
-            return I18n.translateToLocal( baseString + ".name" );
+            return StringUtil.translateToLocal( baseString + ".name" );
         }
     }
 

--- a/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
+++ b/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
@@ -48,10 +48,7 @@ import dan200.computercraft.shared.pocket.items.PocketComputerItemFactory;
 import dan200.computercraft.shared.pocket.recipes.PocketComputerUpgradeRecipe;
 import dan200.computercraft.shared.turtle.blocks.TileTurtle;
 import dan200.computercraft.shared.turtle.inventory.ContainerTurtle;
-import dan200.computercraft.shared.util.Colour;
-import dan200.computercraft.shared.util.CreativeTabMain;
-import dan200.computercraft.shared.util.ImpostorRecipe;
-import dan200.computercraft.shared.util.ImpostorShapelessRecipe;
+import dan200.computercraft.shared.util.*;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -68,7 +65,6 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.IThreadListener;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.world.WorldEvent;
@@ -130,7 +126,7 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
         {
             ItemRecord record = (ItemRecord) item;
             String key = ObfuscationReflectionHelper.getPrivateValue( ItemRecord.class, record, "field_185077_c" );
-            return I18n.translateToLocal( key );
+            return StringUtil.translateToLocal( key );
         }
         return null;
     }

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleInspectCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleInspectCommand.java
@@ -57,7 +57,7 @@ public class TurtleInspectCommand implements ITurtleCommand
                 table.put( "metadata", metadata );
 
                 Map<Object, Object> stateTable = new HashMap<Object, Object>();
-                for( Object o : block.getActualState( state, world, newPosition ).getProperties().entrySet() )
+                for( Object o : state.getActualState( world, newPosition ).getProperties().entrySet() )
                 {
                     ImmutableMap.Entry<IProperty, Object> entry = (ImmutableMap.Entry<IProperty, Object>)o;
                     String propertyName = entry.getKey().getName();

--- a/src/main/java/dan200/computercraft/shared/turtle/items/ItemTurtleBase.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/items/ItemTurtleBase.java
@@ -14,6 +14,7 @@ import dan200.computercraft.shared.computer.items.ItemComputerBase;
 import dan200.computercraft.shared.turtle.blocks.ITurtleTile;
 import dan200.computercraft.shared.turtle.core.TurtleBrain;
 import dan200.computercraft.shared.util.Colour;
+import dan200.computercraft.shared.util.StringUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
@@ -21,10 +22,9 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.text.translation.I18n;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import java.util.ArrayList;
@@ -142,29 +142,29 @@ public abstract class ItemTurtleBase extends ItemComputerBase implements ITurtle
         ITurtleUpgrade right = getUpgrade( stack, TurtleSide.Right );
         if( left != null && right != null )
         {
-            return I18n.translateToLocalFormatted(
+            return StringUtil.translateToLocalFormatted(
                 baseString + ".upgraded_twice.name",
-                I18n.translateToLocal( right.getUnlocalisedAdjective() ),
-                I18n.translateToLocal( left.getUnlocalisedAdjective() )
+                StringUtil.translateToLocal( right.getUnlocalisedAdjective() ),
+                StringUtil.translateToLocal( left.getUnlocalisedAdjective() )
             );
         }
         else if( left != null )
         {
-            return I18n.translateToLocalFormatted(
+            return StringUtil.translateToLocalFormatted(
                 baseString + ".upgraded.name",
-                I18n.translateToLocal( left.getUnlocalisedAdjective() )
+                StringUtil.translateToLocal( left.getUnlocalisedAdjective() )
             );
         }
         else if( right != null )
         {
-            return I18n.translateToLocalFormatted(
+            return StringUtil.translateToLocalFormatted(
                 baseString + ".upgraded.name",
-                I18n.translateToLocal( right.getUnlocalisedAdjective() )
+                StringUtil.translateToLocal( right.getUnlocalisedAdjective() )
             );
         }
         else
         {
-            return I18n.translateToLocal( baseString + ".name" );
+            return StringUtil.translateToLocal( baseString + ".name" );
         }
     }
 

--- a/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleHoe.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleHoe.java
@@ -34,8 +34,7 @@ public class TurtleHoe extends TurtleTool
         if( super.canBreakBlock( world, pos ) )
         {
             IBlockState state = world.getBlockState( pos );
-            Block block = state.getBlock();
-            Material material = block.getMaterial( state );
+            Material material = state.getMaterial( );
             return
                 material == Material.PLANTS ||
                 material == Material.CACTUS ||

--- a/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleShovel.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleShovel.java
@@ -26,8 +26,7 @@ public class TurtleShovel extends TurtleTool
         if( super.canBreakBlock( world, pos ) )
         {
             IBlockState state = world.getBlockState( pos );
-            Block block = state.getBlock();
-            Material material = block.getMaterial( state );
+            Material material = state.getMaterial( );
             return
                     material == Material.GROUND ||
                     material == Material.SAND ||

--- a/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleSword.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleSword.java
@@ -26,8 +26,7 @@ public class TurtleSword extends TurtleTool
         if( super.canBreakBlock( world, pos ) )
         {
             IBlockState state = world.getBlockState( pos );
-            Block block = state.getBlock();
-            Material material = block.getMaterial( state );
+            Material material = state.getMaterial( );
             return
                     material == Material.PLANTS ||
                     material == Material.LEAVES ||

--- a/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleTool.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleTool.java
@@ -136,7 +136,7 @@ public class TurtleTool implements ITurtleUpgrade
     {
         IBlockState state = world.getBlockState( pos );
         Block block = state.getBlock();
-        if( block.isAir( state, world, pos ) || block == Blocks.BEDROCK || block.getBlockHardness( state, world, pos ) <= -1.0F )
+        if( block.isAir( state, world, pos ) || block == Blocks.BEDROCK || state.getBlockHardness( world, pos ) <= -1.0F )
         {
             return false;
         }

--- a/src/main/java/dan200/computercraft/shared/util/RedstoneUtil.java
+++ b/src/main/java/dan200/computercraft/shared/util/RedstoneUtil.java
@@ -11,43 +11,33 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockRedstoneWire;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.world.IBlockAccess;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 public class RedstoneUtil
 {
-    private static Block getBlock( IBlockAccess world, BlockPos pos )
-    {
-        if( pos.getY() >= 0 )
-        {
-            return world.getBlockState( pos ).getBlock();
-        }
-        return null;
-    }
-
     public static int getRedstoneOutput( World world, BlockPos pos, EnumFacing side )
     {
         int power = 0;
-        Block block = getBlock( world, pos );
-        if( block != null && block != Blocks.AIR )
+        IBlockState state = world.getBlockState( pos );
+        Block block =   state.getBlock();
+        if( block != Blocks.AIR )
         {
-            IBlockState state = world.getBlockState( pos );
             if( block == Blocks.REDSTONE_WIRE )
             {
                 if( side != EnumFacing.UP )
                 {
-                    power = ((Integer)state.getValue( BlockRedstoneWire.POWER )).intValue();
+                    power = state.getValue( BlockRedstoneWire.POWER );
                 }
                 else
                 {
                     power = 0;
                 }
             }
-            else if( block.canProvidePower( state ) )
+            else if( state.canProvidePower( ) )
             {
-                power = block.getWeakPower( state, world, pos, side.getOpposite() );
+                power = state.getWeakPower( world, pos, side.getOpposite() );
             }
             if( block.isNormalCube( state, world, pos ) )
             {
@@ -56,10 +46,10 @@ public class RedstoneUtil
                     if( testSide != side )
                     {
                         BlockPos testPos = pos.offset( testSide );
-                        Block neighbour = getBlock( world, testPos );
-                        if( neighbour != null && neighbour.canProvidePower( state ) )
+                        IBlockState neighbour = world.getBlockState( testPos );
+                        if( neighbour.canProvidePower( ) )
                         {
-                            power = Math.max( power, neighbour.getStrongPower( state, world, testPos, testSide.getOpposite() ) );
+                            power = Math.max( power, neighbour.getStrongPower( world, testPos, testSide.getOpposite() ) );
                         }
                     }
                 }
@@ -81,15 +71,15 @@ public class RedstoneUtil
     public static void propogateRedstoneOutput( World world, BlockPos pos, EnumFacing side )
     {
         // Propogate ordinary output
-        Block block = getBlock( world, pos );
+        IBlockState block = world.getBlockState( pos );
         BlockPos neighbourPos = pos.offset( side );
-        Block neighbour = getBlock( world, neighbourPos );
-        if( neighbour != null && neighbour != Blocks.AIR )
+        IBlockState neighbour = world.getBlockState( neighbourPos );
+        if( neighbour.getBlock() != Blocks.AIR )
         {
-            world.notifyBlockOfStateChange( neighbourPos, block );
-            if( neighbour.isNormalCube( world.getBlockState( neighbourPos ), world, neighbourPos ) )
+            world.notifyBlockOfStateChange( neighbourPos, block.getBlock() );
+            if( neighbour.getBlock().isNormalCube( neighbour, world, neighbourPos ) )
             {
-                world.notifyNeighborsOfStateExcept( neighbourPos, neighbour, side.getOpposite() );
+                world.notifyNeighborsOfStateExcept( neighbourPos, neighbour.getBlock(), side.getOpposite() );
             }
         }
     }

--- a/src/main/java/dan200/computercraft/shared/util/StringUtil.java
+++ b/src/main/java/dan200/computercraft/shared/util/StringUtil.java
@@ -23,4 +23,22 @@ public class StringUtil
 
         return builder.toString();
     }
+
+    /**
+     * Translates a Stat name
+     */
+    @SuppressWarnings("deprecation")
+    public static String translateToLocal( String key )
+    {
+        return net.minecraft.util.text.translation.I18n.translateToLocal( key );
+    }
+
+    /**
+     * Translates a Stat name with format args
+     */
+    @SuppressWarnings("deprecation")
+    public static String translateToLocalFormatted( String key, Object... format )
+    {
+        return net.minecraft.util.text.translation.I18n.translateToLocalFormatted( key, format );
+    }
 }

--- a/src/main/java/dan200/computercraft/shared/util/WorldUtil.java
+++ b/src/main/java/dan200/computercraft/shared/util/WorldUtil.java
@@ -27,16 +27,7 @@ public class WorldUtil
 
     public static boolean isLiquidBlock( World world, BlockPos pos )
     {
-        if( isBlockInWorld( world, pos ) )
-        {
-            IBlockState state = world.getBlockState( pos );
-            Block block = state.getBlock();
-            if( block != null )
-            {
-                return block.getMaterial( state ).isLiquid();
-            }
-        }
-        return false;
+        return isBlockInWorld( world, pos ) && world.getBlockState( pos ).getMaterial().isLiquid();
     }
 
     public static BlockPos moveCoords( BlockPos pos, EnumFacing dir )


### PR DESCRIPTION
Sorry. I saw this patch when putting together #154 and couldn't see the difference to the original. Better late than never I guess.

---

There was a crash in `RedstoneUtil` when redstone state was changing next to a full block due to the incorrect state being passed. By using `IBlockState` methods we ensure that this cannot happen again.

The old `IBlockState` methods were also deprecated, so this reduces the warning count a little. I've also moved string translation into `StringUtils`, to reduce the number of deprecation warnings elsewhere in the code.

**Note:** There are a couple of other "clean up" changes I'd like to make, which don't actually end up fixing any bugs. I'm wondering about the chances of them being accepted, especially due to:

> It does not add unneccessary stylistic changes to the code, especially where functionality is not being changed.