### PR TITLE
Set CraftOS version to 1.8

### DIFF
--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -167,7 +167,7 @@ end
 
 -- Install lua parts of the os api
 function os.version()
-    return "CraftOS 1.7"
+    return "CraftOS 1.8"
 end
 
 function os.pullEventRaw( sFilter )


### PR DESCRIPTION
Since this is release 1.80 being worked on, following the usual pattern, we should be at CraftOS 1.8. I've changed `os.version()`'s return value in `bios.lua`, if anything else needs to be adjusted for this, let me know and I'll change it.