### PR TITLE
Make shell.resolveProgram pick up on *.lua files

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/shell
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/shell
@@ -111,6 +111,16 @@ function shell.resolve( _sPath )
 	end
 end
 
+local function pathWithExtension( _sPath, _sExt )
+    local nLen = #sPath
+    local sEndChar = string.sub( _sPath, nLen, nLen )
+    -- Remove any trailing slashes so we can add an extension to the path safely
+    if sEndChar == "/" or sEndChar == "\\" then
+        _sPath = string.sub( _sPath, 1, nLen - 1 )
+    end
+    return _sPath .. "." .. _sExt
+end
+
 function shell.resolveProgram( _sCommand )
 	-- Substitute aliases firsts
 	if tAliases[ _sCommand ] ~= nil then
@@ -123,7 +133,12 @@ function shell.resolveProgram( _sCommand )
     	local sPath = fs.combine( "", _sCommand )
     	if fs.exists( sPath ) and not fs.isDir( sPath ) then
 			return sPath
-    	end
+    	else
+            local sPathLua = pathWithExtension( sPath, "lua" )
+            if fs.exists( sPathLua ) and not fs.isDir( sPathLua ) then
+                return sPathLua
+            end
+        end
 		return nil
     end
     
@@ -132,7 +147,12 @@ function shell.resolveProgram( _sCommand )
     	sPath = fs.combine( shell.resolve( sPath ), _sCommand )
     	if fs.exists( sPath ) and not fs.isDir( sPath ) then
 			return sPath
-    	end
+    	else
+            local sPathLua = pathWithExtension( sPath, "lua" )
+            if fs.exists( sPathLua ) and not fs.isDir( sPathLua ) then
+                return sPathLua
+            end
+        end
     end
 	
 	-- Not found


### PR DESCRIPTION
This is a fairly simple pull request. Since many people prefer their programs with a .lua extension, with this change, these files will be picked up by `shell.resolveProgram`, without specifying the extension explicitly.

For example, assuming there is a `test.lua` file in `/`, running a lua prompt in `/`:
```Lua
> shell.resolveProgram("test")
test.lua
```
It will always prefer exact matches, so if there is a `test` file as well, it will choose that one instead.

The main purpose of this is to allow running .lua files without specifying the extension:
```
> test
Hello World!
```

Before merging: Should autocomplete handle this? Currently, it behaves like before and will only autocomplete the full filename. 