### PR TITLE
Fix several crashes caused by incorrect NonNull annotations.

### DIFF
--- a/src/main/java/dan200/computercraft/client/render/TurtleSmartItemModel.java
+++ b/src/main/java/dan200/computercraft/client/render/TurtleSmartItemModel.java
@@ -29,6 +29,7 @@ import net.minecraft.world.World;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.vecmath.Matrix4f;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -103,7 +104,7 @@ public class TurtleSmartItemModel implements IBakedModel, IResourceManagerReload
         {
             @Nonnull
             @Override
-            public IBakedModel handleItemState( @Nonnull IBakedModel originalModel, ItemStack stack, @Nonnull World world, @Nonnull EntityLivingBase entity)
+            public IBakedModel handleItemState( @Nonnull IBakedModel originalModel, ItemStack stack, @Nullable World world, @Nullable EntityLivingBase entity)
             {
                 ItemTurtleBase turtle = (ItemTurtleBase) stack.getItem();
                 ComputerFamily family = turtle.getFamily( stack );

--- a/src/main/java/dan200/computercraft/shared/computer/items/ItemCommandComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/items/ItemCommandComputer.java
@@ -15,6 +15,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
 public class ItemCommandComputer extends ItemComputer
@@ -52,7 +53,7 @@ public class ItemCommandComputer extends ItemComputer
     }
 
     @Override
-    public void getSubItems( @Nonnull Item itemID, @Nonnull CreativeTabs tabs, @Nonnull List<ItemStack> list )
+    public void getSubItems( @Nonnull Item itemID, @Nullable CreativeTabs tabs, @Nonnull List<ItemStack> list )
     {
         list.add( ComputerItemFactory.create( -1, null, ComputerFamily.Command ) );
     }

--- a/src/main/java/dan200/computercraft/shared/computer/items/ItemComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/items/ItemComputer.java
@@ -22,6 +22,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
 public class ItemComputer extends ItemComputerBase
@@ -72,7 +73,7 @@ public class ItemComputer extends ItemComputerBase
     }
 
     @Override
-    public void getSubItems( @Nonnull Item itemID, @Nonnull CreativeTabs tabs, @Nonnull List<ItemStack> list )
+    public void getSubItems( @Nonnull Item itemID, @Nullable CreativeTabs tabs, @Nonnull List<ItemStack> list )
     {
         list.add( ComputerItemFactory.create( -1, null, ComputerFamily.Normal ) );
         list.add( ComputerItemFactory.create( -1, null, ComputerFamily.Advanced ) );

--- a/src/main/java/dan200/computercraft/shared/peripheral/common/ItemAdvancedModem.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/common/ItemAdvancedModem.java
@@ -14,6 +14,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
 public class ItemAdvancedModem extends ItemPeripheralBase
@@ -49,7 +50,7 @@ public class ItemAdvancedModem extends ItemPeripheralBase
     }
 
     @Override
-    public void getSubItems( @Nonnull Item itemID, @Nonnull CreativeTabs tabs, @Nonnull List<ItemStack> list )
+    public void getSubItems( @Nonnull Item itemID, @Nullable CreativeTabs tabs, @Nonnull List<ItemStack> list )
     {
         list.add( PeripheralItemFactory.create( PeripheralType.AdvancedModem, null, 1 ) );
     }

--- a/src/main/java/dan200/computercraft/shared/peripheral/common/ItemCable.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/common/ItemCable.java
@@ -24,6 +24,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
 public class ItemCable extends ItemPeripheralBase
@@ -63,7 +64,7 @@ public class ItemCable extends ItemPeripheralBase
     }
 
     @Override
-    public void getSubItems( @Nonnull Item itemID, @Nonnull CreativeTabs tabs, @Nonnull List<ItemStack> list )
+    public void getSubItems( @Nonnull Item itemID, @Nullable CreativeTabs tabs, @Nonnull List<ItemStack> list )
     {
         list.add( PeripheralItemFactory.create( PeripheralType.WiredModem, null, 1 ) );
         list.add( PeripheralItemFactory.create( PeripheralType.Cable, null, 1 ) );

--- a/src/main/java/dan200/computercraft/shared/peripheral/common/ItemPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/common/ItemPeripheral.java
@@ -14,6 +14,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
 public class ItemPeripheral extends ItemPeripheralBase
@@ -69,7 +70,7 @@ public class ItemPeripheral extends ItemPeripheralBase
     }
 
     @Override
-    public void getSubItems( @Nonnull Item itemID, @Nonnull CreativeTabs tabs, @Nonnull List<ItemStack> list )
+    public void getSubItems( @Nonnull Item itemID, @Nullable CreativeTabs tabs, @Nonnull List<ItemStack> list )
     {
         list.add( PeripheralItemFactory.create( PeripheralType.DiskDrive, null, 1 ) );
         list.add( PeripheralItemFactory.create( PeripheralType.Printer, null, 1 ) );

--- a/src/main/java/dan200/computercraft/shared/turtle/items/ItemTurtleBase.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/items/ItemTurtleBase.java
@@ -28,6 +28,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,7 +44,7 @@ public abstract class ItemTurtleBase extends ItemComputerBase implements ITurtle
     public abstract ItemStack create( int id, String label, Colour colour, ITurtleUpgrade leftUpgrade, ITurtleUpgrade rightUpgrade, int fuelLevel, ResourceLocation overlay );
 
     @Override
-    public void getSubItems( @Nonnull Item itemID, @Nonnull CreativeTabs tabs, @Nonnull List<ItemStack> list )
+    public void getSubItems( @Nonnull Item itemID, @Nullable CreativeTabs tabs, @Nonnull List<ItemStack> list )
     {
         List<ItemStack> all = new ArrayList<ItemStack>();
         ComputerCraft.addAllUpgradedTurtles( all );


### PR DESCRIPTION
Awfully sorry about this. It appears that Minecraft's annotations are occasionally wrong. IntelliJ will automatically add "not-null" checks on these annotations, resulting in crashes when they are actually null.

Whilst this can be fixed by disabling IntelliJ's checks, incorrect annotations are misleading for the developer too, so I have changed them where appropriate. Sorry about this.