### PR TITLE
Add /bin to Shellpath

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/autorun/shellpath
+++ b/src/main/resources/assets/computercraft/lua/rom/autorun/shellpath
@@ -1,0 +1,3 @@
+if fs.isDir("/bin") then
+	shell.setPath(shell.path()..":/bin")
+end


### PR DESCRIPTION
This Script checks, if /bin exists and a folder. If true, it will add it to the path. Program authors can just say to her installer "Place this file in /bin" and her program can be run from every folder on the computer. You don't need to edit startup.