### PR TITLE
Do not insert empty or duplicate entries into shell history

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/lua
@@ -44,7 +44,9 @@ while bRunning do
 		end
         return nil
 	end )
-	table.insert( tCommandHistory, s )
+	if s:match("%S") and tCommandHistory[#tCommandHistory] ~= s then
+		table.insert( tCommandHistory, s )
+	end
 	
 	local nForcePrint = 0
 	local func, e = load( s, "lua", "t", tEnv )

--- a/src/main/resources/assets/computercraft/lua/rom/programs/shell
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/shell
@@ -363,7 +363,9 @@ else
         else
             sLine = read( nil, tCommandHistory )
         end
-        table.insert( tCommandHistory, sLine )
+        if sLine:match("%S") and tCommandHistory[#tCommandHistory] ~= sLine then
+            table.insert( tCommandHistory, sLine )
+        end
         shell.run( sLine )
     end
 end


### PR DESCRIPTION
If a string is empty or the same as the previous command then it will not be inserted into history. This makes history slightly easier to navigate as you don't have to go over several duplicate entries or empty lines.