### PR TITLE
Add readline keybindings to read function

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/fun/adventure
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/fun/adventure
@@ -1325,6 +1325,7 @@ while bRunning do
 	term.setTextColour( colours.white )
 		
     local sRawLine = read( nil, tCommandHistory )
+    if not sRawLine then break end
     table.insert( tCommandHistory, sRawLine )
     
     local sLine = nil

--- a/src/main/resources/assets/computercraft/lua/rom/programs/lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/lua
@@ -44,6 +44,7 @@ while bRunning do
 		end
         return nil
 	end )
+	if not s then break end
 	table.insert( tCommandHistory, s )
 	
 	local nForcePrint = 0

--- a/src/main/resources/assets/computercraft/lua/rom/programs/rednet/chat
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/rednet/chat
@@ -392,7 +392,7 @@ elseif sCommand == "join" then
                 promptWindow.setTextColor( textColour )
 
                 local sChat = read( nil, tSendHistory )
-                if string.match( sChat, "^/logout" ) then
+                if not sChat or string.match( sChat, "^/logout" ) then
                     break
                 else
                     rednet.send( nHostID, {

--- a/src/main/resources/assets/computercraft/lua/rom/programs/shell
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/shell
@@ -363,6 +363,9 @@ else
         else
             sLine = read( nil, tCommandHistory )
         end
+        
+        if not sLine then break end
+        
         table.insert( tCommandHistory, sLine )
         shell.run( sLine )
     end


### PR DESCRIPTION
This adds a selection of keybindings to the `read` function which mirror those provided by readline (shell command prompts, several REPLs, etc...). I'm not entirely sure whether this should actually be included - it does bloat the already large `bios.lua`. However it does make inputting long text (especially in the `lua` program) slightly easier. I guess you can make up your mind for yourself 😄.

## Keybindings
This provides the most basic keybindings as given [here](https://tiswww.case.edu/php/chet/readline/rluserman.html#SEC3).

 - <kbd>C-a</kbd> / <kbd>C-e</kbd> to jump to beginning/end of line
 - <kbd>C-d</kbd> to exit read without inputting anything. This could cause problems as `read` can now return `nil`. However, it does mean you can exit `lua` and `shell` without having to type an explicit "exit".
 - <kbd>C-b</kbd> / <kbd>C-f</kbd> to move left/right one character
 - <kbd>M-b</kbd> / <kbd>M-f</kbd> to move left/right one word.
 - <kbd>C-p</kbd> / <kbd>C-n</kbd> to move backwards/forwards in history or completions.
 - <kbd>C-u</kbd> / <kbd>C-k</kbd> to delete to the beginning/end of line.
 - <kbd>C-w</kbd> / <kbd>M-d</kbd> to delete to the beginning of the previous word/end of next    word. (Note, the docs say it should be <kbd>M-DEL</kbd> rather than <kbd>C-w</kbd>. However, most of the things I've experimented with use the latter).

This doesn't define any of the more complex command like undo, transpose, yanking, etc... I'm happy to add them if people *really* want them, but it feels rather overkill.

## Implementation
I'm currently listening to `key_down`/`key_up` events to track the status of control/alt keys. This is fine most of the time, though could cause problems with multiple users or people exiting the GUI with keys down. A couple of changes which could be made elsewhere to fix this:

 - Trigger `key_up` events when the terminal is closed.
 - Include modifier keys in the `key` event. I'm not a fan of this as it seems too "friendly" for the user, but it is the most fool-proof way.

## Possible extensions
It might be nice to add similar shortcuts to `edit`. A similar system could also be added to the pager described in #212. I'd be happy to add them if people want.