### PR TITLE
Replace reflection with access transformers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,12 @@ dependencies {
 
 }
 
+jar {
+    manifest {
+        attributes('FMLAT': 'computercraft_at.cfg')
+    }
+}
+
 processResources
 {
     // this will ensure that this task is redone when the versions change.

--- a/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
+++ b/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
@@ -134,7 +134,7 @@ public abstract class BlockGeneric extends Block implements
     }
 
     @Override
-    protected final ItemStack createStackedBlock( @Nonnull IBlockState state )
+    public final ItemStack createStackedBlock( @Nonnull IBlockState state )
     {
         return null;
     }

--- a/src/main/java/dan200/computercraft/shared/media/items/RecordMedia.java
+++ b/src/main/java/dan200/computercraft/shared/media/items/RecordMedia.java
@@ -13,7 +13,6 @@ import net.minecraft.item.ItemRecord;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 
 import javax.annotation.Nonnull;
 
@@ -46,7 +45,7 @@ public class RecordMedia implements IMedia
     public SoundEvent getAudio( @Nonnull ItemStack stack )
     {
         ItemRecord itemRecord = (ItemRecord)stack.getItem();
-        return ObfuscationReflectionHelper.getPrivateValue(ItemRecord.class, itemRecord, "field_185076_b");
+        return itemRecord.sound;
     }
     
     @Override

--- a/src/main/java/dan200/computercraft/shared/proxy/CCTurtleProxyCommon.java
+++ b/src/main/java/dan200/computercraft/shared/proxy/CCTurtleProxyCommon.java
@@ -38,7 +38,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.event.FMLMissingMappingsEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
@@ -180,26 +179,12 @@ public abstract class CCTurtleProxyCommon implements ICCTurtleProxy
     {
         if( !m_dropConsumers.containsKey( entity ) )
         {
-            boolean captured = ObfuscationReflectionHelper.<Boolean, Entity>getPrivateValue(
-                Entity.class,
-                entity,
-                "captureDrops"
-            );
+            boolean captured = entity.captureDrops;
             
             if( !captured )
             {
-                ObfuscationReflectionHelper.setPrivateValue(
-                    Entity.class,
-                    entity,
-                    Boolean.TRUE,
-                    "captureDrops"
-                );
-                
-                ArrayList<EntityItem> items = ObfuscationReflectionHelper.getPrivateValue(
-                    Entity.class,
-                    entity,
-                    "capturedDrops"
-                );
+                entity.captureDrops = true;
+                ArrayList<EntityItem> items = entity.capturedDrops;
                 
                 if( items == null || items.size() == 0 )
                 {
@@ -214,26 +199,12 @@ public abstract class CCTurtleProxyCommon implements ICCTurtleProxy
     {
         if( m_dropConsumers.containsKey( entity ) )
         {
-            boolean captured = ObfuscationReflectionHelper.<Boolean, Entity>getPrivateValue(
-                    Entity.class,
-                    entity,
-                    "captureDrops"
-            );
+            boolean captured = entity.captureDrops;
             
             if( captured )
             {
-                ObfuscationReflectionHelper.setPrivateValue(
-                    Entity.class,
-                    entity,
-                    Boolean.FALSE,
-                    "captureDrops"
-                );
-                
-                ArrayList<EntityItem> items = ObfuscationReflectionHelper.getPrivateValue(
-                    Entity.class,
-                    entity,
-                    "capturedDrops"
-                );
+                entity.captureDrops = false;
+                ArrayList<EntityItem> items = entity.capturedDrops;
                 
                 if( items != null )
                 {

--- a/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
+++ b/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
@@ -73,7 +73,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.event.FMLMissingMappingsEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
@@ -130,8 +129,7 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
         if (item instanceof ItemRecord)
         {
             ItemRecord record = (ItemRecord) item;
-            String key = ObfuscationReflectionHelper.getPrivateValue( ItemRecord.class, record, "field_185077_c" );
-            return StringUtil.translateToLocal( key );
+            return StringUtil.translateToLocal( record.displayName );
         }
         return null;
     }

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleCompareCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleCompareCommand.java
@@ -17,10 +17,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.relauncher.ReflectionHelper;
 
 import javax.annotation.Nonnull;
-import java.lang.reflect.Method;
 
 public class TurtleCompareCommand implements ITurtleCommand
 {
@@ -58,22 +56,7 @@ public class TurtleCompareCommand implements ITurtleCommand
                     // Try createStackedBlock first
                     if( !lookAtBlock.hasTileEntity( lookAtState ) )
                     {
-                        try
-                        {
-                            Method method = ReflectionHelper.findMethod(
-                                Block.class, lookAtBlock,
-                                new String[]{ "func_149644_j", "j", "createStackedBlock" },
-                                IBlockState.class
-                            );
-                            if( method != null )
-                            {
-                                lookAtStack = (ItemStack)method.invoke( lookAtBlock, lookAtState );
-                            }
-                        }
-                        catch( Exception e )
-                        {
-                            // ???
-                        }
+                        lookAtStack = lookAtBlock.createStackedBlock( lookAtState );
                     }
 
                     // See if the block drops anything with the same ID as itself

--- a/src/main/resources/META-INF/computercraft_at.cfg
+++ b/src/main/resources/META-INF/computercraft_at.cfg
@@ -1,0 +1,6 @@
+# RecordMedia (and related methods)
+public net.minecraft.item.ItemRecord field_185076_b # sound
+public net.minecraft.item.ItemRecord field_185077_c # displayName
+
+# TurtleCompareCommand
+public net.minecraft.block.Block func_180643_i(Lnet/minecraft/block/state/IBlockState;)Lnet/minecraft/item/ItemStack; # createStackedBlock


### PR DESCRIPTION
This makes the code slightly neater and allows us to catch places where the variable/function has been renamed between Minecraft versions (such as `createStackedBlock`).

Worth noting that people may have to run `./setup.sh` again, as some IDEs won't pick up on the changes.