### PR TITLE
Remove AT for Block.createStackedBlock

### DIFF
--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleCompareCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleCompareCommand.java
@@ -14,11 +14,13 @@ import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
 
 import javax.annotation.Nonnull;
+import java.lang.reflect.Method;
 
 public class TurtleCompareCommand implements ITurtleCommand
 {
@@ -56,7 +58,18 @@ public class TurtleCompareCommand implements ITurtleCommand
                     // Try createStackedBlock first
                     if( !lookAtBlock.hasTileEntity( lookAtState ) )
                     {
-                        lookAtStack = lookAtBlock.createStackedBlock( lookAtState );
+                        try
+                        {
+                            Method method = ReflectionHelper.findMethod(
+                                Block.class, lookAtBlock,
+                                new String[] { "func_180643_i", "createStackedBlock" },
+                                IBlockState.class
+                            );
+                            lookAtStack = (ItemStack) method.invoke( lookAtBlock, lookAtState );
+                        }
+                        catch( Exception e )
+                        {
+                        }
                     }
 
                     // See if the block drops anything with the same ID as itself

--- a/src/main/resources/META-INF/computercraft_at.cfg
+++ b/src/main/resources/META-INF/computercraft_at.cfg
@@ -1,6 +1,3 @@
 # RecordMedia (and related methods)
 public net.minecraft.item.ItemRecord field_185076_b # sound
 public net.minecraft.item.ItemRecord field_185077_c # displayName
-
-# TurtleCompareCommand
-public net.minecraft.block.Block func_180643_i(Lnet/minecraft/block/state/IBlockState;)Lnet/minecraft/item/ItemStack; # createStackedBlock


### PR DESCRIPTION
Reverts parts of #243, allowing decompilation again. Sorry.