### PR TITLE
Fixes speakers playing incorrect sounds on the server

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
@@ -238,7 +238,7 @@ public class SpeakerPeripheral implements IPeripheral {
                     @Nullable
                     @Override
                     public Object[] execute() throws LuaException {
-                        world.playSound(null, pos, new SoundEvent(resource), SoundCategory.RECORDS, vol, soundPitch);
+                        world.playSound( null, pos, SoundEvent.REGISTRY.getObject( resource ), SoundCategory.RECORDS, vol, soundPitch );
                         return null;
                     }
 


### PR DESCRIPTION
As a new `SoundEvent` was being created each time, the actual sound was not in the registry, resulting in the sound -> id mapping yielding incorrect values.