### PR TITLE
Fix files not writing data when closed

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/handles/EncodedInputHandle.java
+++ b/src/main/java/dan200/computercraft/core/apis/handles/EncodedInputHandle.java
@@ -23,7 +23,11 @@ public class EncodedInputHandle extends HandleGeneric
 
     public EncodedInputHandle( InputStream stream, String encoding )
     {
-        super( stream );
+        this( makeReader( stream, encoding ) );
+    }
+
+    private static BufferedReader makeReader( InputStream stream, String encoding )
+    {
         if( encoding == null ) encoding = "UTF-8";
         InputStreamReader streamReader;
         try
@@ -34,7 +38,7 @@ public class EncodedInputHandle extends HandleGeneric
         {
             streamReader = new InputStreamReader( stream );
         }
-        this.m_reader = new BufferedReader( streamReader );
+        return new BufferedReader( streamReader );
     }
 
     @Nonnull

--- a/src/main/java/dan200/computercraft/core/apis/handles/EncodedOutputHandle.java
+++ b/src/main/java/dan200/computercraft/core/apis/handles/EncodedOutputHandle.java
@@ -23,7 +23,11 @@ public class EncodedOutputHandle extends HandleGeneric
 
     public EncodedOutputHandle( OutputStream stream, String encoding )
     {
-        super( stream );
+        this( makeWriter( stream, encoding ) );
+    }
+
+    private static BufferedWriter makeWriter( OutputStream stream, String encoding )
+    {
         if( encoding == null ) encoding = "UTF-8";
         OutputStreamWriter streamWriter;
         try
@@ -34,7 +38,7 @@ public class EncodedOutputHandle extends HandleGeneric
         {
             streamWriter = new OutputStreamWriter( stream );
         }
-        this.m_writer = new BufferedWriter( streamWriter );
+        return new BufferedWriter( streamWriter );
     }
 
     @Nonnull


### PR DESCRIPTION
As the raw stream was being provided to the parent class, buffered data was not written, resulting in empty files. This ensures the buffered reader/writer is the one which is closed.

In response to [this comment](https://github.com/dan200/ComputerCraft/pull/238#issuecomment-302175615)