### PR TITLE
Include standard Lua libraries in package.loaded

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/shell.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/shell.lua
@@ -21,7 +21,15 @@ local function createShellEnv( sDir )
     tEnv[ "multishell" ] = multishell
 
     local package = {}
-    package.loaded = {}
+    package.loaded = {
+        _G = _G,
+        bit32 = bit32,
+        coroutine = coroutine,
+        math = math,
+        package = package,
+        string = string,
+        table = table,
+    }
     package.path = "?;?.lua;?/init.lua"
     package.preload = {}
     package.loaders = {


### PR DESCRIPTION
I realise `_G` being there is slightly weird, but PUC Lua does it so I'm sticking with it. I'm not including `os` or `io` as they aren't quite the same as PUC Lua's.