### PR TITLE
Add shell.parse()

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/shell.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/shell.lua
@@ -421,6 +421,31 @@ if multishell then
     end
 end
 
+function shell.parse(...)
+local params = {...}
+local args = {}
+local options = {}
+for key,data in ipairs(params) do
+  if data:find("--",1,true) == 1 then
+    data = data:sub(3,-1)
+    local head,body = data:match("([^=]+)=([^=]+)")
+    if body ~= nil then
+      options[head] = body
+    else
+      options[data] = true
+    end
+  elseif data:find("-") == 1 then
+    data = data:sub(2,-1)
+    for i=1,#data do
+      options[data:sub(i,i)] = true
+    end
+  else
+    table.insert(args,data)
+  end
+end
+return args,options
+end
+
 local tArgs = { ... }
 if #tArgs > 0 then
     -- "shell x y z"


### PR DESCRIPTION
I added the function shell.parse.  This function allows you to parse arguments. Here's a few examples:
```
args,options = shell.parse("-abc,"example")
args is {"example"}
options is {a=true,b=true,c=true}
shell.parse("-gh","--hello=World","example","123")
args is {"example","123"}
options is {g=true,h=true,hello="World"}
shell.parse("--foo","bar")
args is {"bar"}
options is {foo=true}
```

Why I want to add this function to Computercarft?
I think many people would use this function and I'm planing to make a PR for list, that use this function.