### PR TITLE
Speaker max hearable range limit

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
@@ -168,7 +168,7 @@ public class SpeakerPeripheral implements IPeripheral {
         }
 
         // If the resource location for note block notes changes, this method call will need to be updated
-        Object[] returnValue = playSound(new Object[] {"block.note." + arguments[0], volume, Math.pow(2d, (pitch - 12) / 12d)}, context, true);
+        Object[] returnValue = playSound(new Object[] {"block.note." + arguments[0], Math.min(volume,3f) , Math.pow(2d, (pitch - 12) / 12d)}, context, true);
 
         if (returnValue[0] instanceof Boolean && (Boolean) returnValue[0])
         {
@@ -238,7 +238,7 @@ public class SpeakerPeripheral implements IPeripheral {
                     @Nullable
                     @Override
                     public Object[] execute() throws LuaException {
-                        world.playSound( null, pos, SoundEvent.REGISTRY.getObject( resource ), SoundCategory.RECORDS, vol, soundPitch );
+                        world.playSound( null, pos, SoundEvent.REGISTRY.getObject( resource ), SoundCategory.RECORDS, Math.min(vol,3f), soundPitch );
                         return null;
                     }
 


### PR DESCRIPTION
Limits max volume of speaker to volume of normal note block.

Due to way volume in playsound is implemented values that are multiple of 1 are extending range source can be heard from. Without this limit with value of 10000 speaker can be heard from 160000 blocks away. This would allow someone to spam whole server with noises.

This limits it to 48 blocks max (3) that is standard for note block.

I am unsure if this should be hard coded or a setting but i think hard coded in this case.