### PR TITLE
Add some sanity checks to Palette.readFromNBT

### DIFF
--- a/src/main/java/dan200/computercraft/shared/util/Palette.java
+++ b/src/main/java/dan200/computercraft/shared/util/Palette.java
@@ -89,7 +89,10 @@ public class Palette
 
     public void readFromNBT( NBTTagCompound nbt )
     {
+        if( !nbt.hasKey( "term_palette" ) ) return;
         int[] rgb8 = nbt.getIntArray( "term_palette" );
+
+        if( rgb8.length != colours.length ) return;
 
         for(int i = 0; i < colours.length; ++i)
         {


### PR DESCRIPTION
Printers use a `Terminal` to store the page currently being printed. Printers saved in an older version of ComputerCraft would be missing the `term_palette` field, resulting in an out of bounds exception when loading the tile.