### PR TITLE
Update os.version()

### DIFF
--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -166,8 +166,12 @@ if string.find( _HOST, "ComputerCraft" ) == 1 then
 end
 
 -- Install lua parts of the os api
-function os.version()
-    return "CraftOS 1.8"
+function os.version(isnumber)
+    if isnumber == true then
+        return 1.8
+    else
+        return "CraftOS 1.8"
+    end
 end
 
 function os.pullEventRaw( sFilter )


### PR DESCRIPTION
If you now run os.version(true), you get a number and not a string. Example Code:
```
if os.version(true) < 1.8  then
    print("This Program need features that has been added in 1.8")
    return
end
```