### PR TITLE
Add virtual peripherals

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/help/peripheral.txt
+++ b/src/main/resources/assets/computercraft/lua/rom/help/peripheral.txt
@@ -8,6 +8,8 @@ peripheral.getMethods( name )
 peripheral.call( name, methodName, param1, param2, etc )
 peripheral.wrap( name )
 peripheral.find( type, [fnFilter] )
+peripheral.create( type, env, [side] )
+peripheral.remove( side )
 
 Events fired by the peripheral API:
 "peripheral" when a new peripheral is attached. Argument is the name.


### PR DESCRIPTION
I had add virtual peripherals. Examples for Usage:
-Use peripherals over remote
-Make a virtual speaker for a command computer, that use the command API
-Read the screen with a virtual monitor, without overwrite the term API
That just 3 examples. Maybe you have more.