### PR TITLE
Remove rightAlt from edit

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/edit.lua
@@ -679,7 +679,7 @@ while bRunning do
 
             end
 
-        elseif param == keys.leftCtrl or param == keys.rightCtrl or param == keys.rightAlt then
+        elseif param == keys.leftCtrl or param == keys.rightCtrl then
             -- Menu toggle
             bMenu = not bMenu
             if bMenu then


### PR DESCRIPTION
This is a fix for German user. If you want to write {,[,] or }, which is often needed in LUA, on a German Keyboard, you have to hold rightAlt, which open the menu. So it's not easy to write these Chars. I think, the two Ctrl Keys are enough. Why we need a 3rd Key?