### PR TITLE
Fix Bug with term.setCursorPos

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
@@ -243,6 +243,12 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     end
 
     function window.setCursorPos( x, y )
+        if type( x ) ~= "number" or type( y ) ~= "number" then
+            error( "Expected number, number", 2 )
+        end
+        if x < 1 or y < 1 then
+            error( "Position out of range", 2 )
+        end
         nCursorX = math.floor( x )
         nCursorY = math.floor( y )
         if bVisible then

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
@@ -246,9 +246,6 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
         if type( x ) ~= "number" or type( y ) ~= "number" then
             error( "Expected number, number", 2 )
         end
-        if x < 1 or y < 1 then
-            error( "Position out of range", 2 )
-        end
         nCursorX = math.floor( x )
         nCursorY = math.floor( y )
         if bVisible then


### PR DESCRIPTION
I fixed 2 Bugs:
1. If you call this function, without 2 numbers, you get a error in the window API and not in your Program
2. If you call, this function with 2 numbers lower then 1 (e.g. term.setCursorPos(0,0) ), CraftOS will hang forever and need to press Ctrl+R or rejoin the world.