### PR TITLE
Allows placement of wired modem on any block that has peripheral.

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/common/ItemCable.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/common/ItemCable.java
@@ -9,6 +9,7 @@ package dan200.computercraft.shared.peripheral.common;
 import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.shared.peripheral.PeripheralType;
 import dan200.computercraft.shared.peripheral.modem.TileCable;
+import dan200.computercraft.shared.util.PeripheralUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
@@ -107,7 +108,7 @@ public class ItemCable extends ItemPeripheralBase
         }
 
         // Try to add on the side of something
-        if( !existing.isAir( existingState, world, pos ) && (type == PeripheralType.Cable || existing.isSideSolid( existingState, world, pos, side )) )
+        if( !existing.isAir( existingState, world, pos ) && (type == PeripheralType.Cable || existing.isSideSolid( existingState, world, pos, side ) || PeripheralUtil.getPeripheral( world, pos, side ) != null ) )
         {
             BlockPos offset = pos.offset( side );
             Block offsetExisting = world.getBlockState( offset ).getBlock();

--- a/src/main/java/dan200/computercraft/shared/peripheral/common/ItemPeripheralBase.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/common/ItemPeripheralBase.java
@@ -7,6 +7,7 @@
 package dan200.computercraft.shared.peripheral.common;
 
 import dan200.computercraft.shared.peripheral.PeripheralType;
+import dan200.computercraft.shared.util.PeripheralUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBlock;
@@ -40,8 +41,11 @@ public abstract class ItemPeripheralBase extends ItemBlock implements IPeriphera
         PeripheralType type = getPeripheralType( stack );
         switch( type )
         {
+            case WiredModem: // Client don't know peripherals so its always true. On server side we allow only on peripherals or full blocks. 
+            {
+                return ( world.isRemote || ( world.isSideSolid( pos, side ) || PeripheralUtil.getPeripheral( world, pos, side ) != null ) );
+            }
             case WirelessModem:
-            case WiredModem:
             case AdvancedModem:
             {
                 return world.isSideSolid( pos, side );

--- a/src/main/java/dan200/computercraft/shared/peripheral/modem/TileCable.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/modem/TileCable.java
@@ -349,10 +349,10 @@ public class TileCable extends TileModemBase
         {
            
             EnumFacing dir = getDirection();
-            if( !worldObj.isSideSolid(
+            if( worldObj.isAirBlock(getPos().offset( dir )) || ( !worldObj.isSideSolid(
             getPos().offset( dir ),
             dir.getOpposite()
-            ) && PeripheralUtil.getPeripheral( worldObj, getPos().offset( dir ), dir.getOpposite() ) == null
+            ) && PeripheralUtil.getPeripheral( worldObj, getPos().offset( dir ), dir.getOpposite() ) == null )
             )
             {
                 switch( getPeripheralType() )
@@ -366,6 +366,12 @@ public class TileCable extends TileModemBase
                     }
                     case WiredModemWithCable:
                     {
+                        if( m_peripheralAccessAllowed == true ) //Make sure to disconnect peripheral when breaking
+                        {
+                            m_peripheralAccessAllowed = false;
+                            updateAnim(); 
+                            networkChanged();
+                        }
                         // Drop the modem and convert to cable
                         ((BlockGeneric)getBlockType()).dropItem( worldObj, getPos(), PeripheralItemFactory.create( PeripheralType.WiredModem, getLabel(), 1 ) );
                         setLabel( null );

--- a/src/main/java/dan200/computercraft/shared/peripheral/modem/TileCable.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/modem/TileCable.java
@@ -343,29 +343,35 @@ public class TileCable extends TileModemBase
 
     @Override
     public void onNeighbourChange()
-    {
-        EnumFacing dir = getDirection();
-        if( !worldObj.isSideSolid(
+    {   
+        // Break if placed on non solid and non peripheral. Client don't know peripherals so this cheack is only done on server.
+        if( !worldObj.isRemote )
+        {
+           
+            EnumFacing dir = getDirection();
+            if( !worldObj.isSideSolid(
             getPos().offset( dir ),
             dir.getOpposite()
-        ) )
-        {
-            switch( getPeripheralType() )
+            ) && PeripheralUtil.getPeripheral( worldObj, getPos().offset( dir ), dir.getOpposite() ) == null
+            )
             {
-                case WiredModem:
+                switch( getPeripheralType() )
                 {
-                    // Drop everything and remove block
-                    ((BlockGeneric)getBlockType()).dropAllItems( worldObj, getPos(), false );
-                    worldObj.setBlockToAir( getPos() );
-                    break;
-                }
-                case WiredModemWithCable:
-                {
-                    // Drop the modem and convert to cable
-                    ((BlockGeneric)getBlockType()).dropItem( worldObj, getPos(), PeripheralItemFactory.create( PeripheralType.WiredModem, getLabel(), 1 ) );
-                    setLabel( null );
-                    setBlockState( getBlockState().withProperty( BlockCable.Properties.MODEM, BlockCableModemVariant.None ) );
-                    break;
+                    case WiredModem:
+                    {
+                        // Drop everything and remove block
+                        ((BlockGeneric)getBlockType()).dropAllItems( worldObj, getPos(), false );
+                        worldObj.setBlockToAir( getPos() );
+                        break;
+                    }
+                    case WiredModemWithCable:
+                    {
+                        // Drop the modem and convert to cable
+                        ((BlockGeneric)getBlockType()).dropItem( worldObj, getPos(), PeripheralItemFactory.create( PeripheralType.WiredModem, getLabel(), 1 ) );
+                        setLabel( null );
+                        setBlockState( getBlockState().withProperty( BlockCable.Properties.MODEM, BlockCableModemVariant.None ) );
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
This was created to remove need for hacky solutions like Peripheral Proxy from use. Allows any wired modem to be placed on any block that has peripheral on selected side no matter what type of side is it. As side effect allows placing wired modem on turtles. Modem will break normally if block stops being peripheral or is moved/broken.

This feature would allow for non solid peripheral to be connected to wired networks.
In base mod would work only for turtles but for other mods that add peripherals to normal blocks like chests, doors or minecart tracks or for mods that want to use fancy block models with non solid sides this feature would allow them to bypass adding buggy stopgap measures like  Peripheral Proxy or Full block modems.

In image below in place of turtle imagine any non solid peripheral you ever used.
![2017-06-11_18 52 25](https://user-images.githubusercontent.com/5893536/27012764-3121d9d8-4ed7-11e7-80e7-63ebcbd8f1f8.png)

This still keeps rule about not placing wired modem on non solid surfaces. Only adds case so peripheral block get to bypass that rule.

Sidenote: Github got really confused about changes i made in TileCable.java due to added indentation level.