### PR TITLE
Add Charlimit to read()

### DIFF
--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -283,7 +283,7 @@ function printError( ... )
     end
 end
 
-function read( _sReplaceChar, _tHistory, _fnComplete, _sDefault )
+function read( _sReplaceChar, _tHistory, _fnComplete, _sDefault, _nCharlimit )
     if _sReplaceChar ~= nil and type( _sReplaceChar ) ~= "string" then
         error( "bad argument #1 (expected string, got " .. type( _sReplaceChar ) .. ")", 2 ) 
     end
@@ -295,6 +295,9 @@ function read( _sReplaceChar, _tHistory, _fnComplete, _sDefault )
     end
     if _sDefault ~= nil and type( _sDefault ) ~= "string" then
         error( "bad argument #4 (expected string, got " .. type( _sDefault ) .. ")", 2 ) 
+    end
+    if _nCharlimit ~= nil and type( _nCharlimit ) ~= "number" then
+        error( "bad argument #5 (expected number, got " .. type( _nCharlimit ) .. ")", 2 ) 
     end
     term.setCursorBlink( true )
 
@@ -358,6 +361,11 @@ function read( _sReplaceChar, _tHistory, _fnComplete, _sDefault )
                 term.setTextColor( colors.white )
                 term.setBackgroundColor( colors.gray )
             end
+            if type( _nCharlimit ) == "number" then
+                if #sCompletion+#sLine > _nCharlimit then
+                    sCompletion = sCompletion:sub(1,-(((#sCompletion+#sLine)-_nCharlimit)+#sLine))
+                end
+            end
             if sReplace then
                 term.write( string.rep( sReplace, string.len( sCompletion ) ) )
             else
@@ -387,6 +395,11 @@ function read( _sReplaceChar, _tHistory, _fnComplete, _sDefault )
             -- Find the common prefix of all the other suggestions which start with the same letter as the current one
             local sCompletion = tCompletions[ nCompletion ]
             sLine = sLine .. sCompletion
+            if type( _nCharlimit ) == "number" then
+                if #sLine > _nCharlimit then
+                    sLine = sLine:sub(1,-((#sLine-_nCharlimit)+1))
+                end
+            end
             nPos = string.len( sLine )
 
             -- Redraw
@@ -396,7 +409,7 @@ function read( _sReplaceChar, _tHistory, _fnComplete, _sDefault )
     end
     while true do
         local sEvent, param = os.pullEvent()
-        if sEvent == "char" then
+        if sEvent == "char" and nPos ~= _nCharlimit then
             -- Typed key
             clear()
             sLine = string.sub( sLine, 1, nPos ) .. param .. string.sub( sLine, nPos + 1 )


### PR DESCRIPTION
I think this is useful for textboxes and it will make read() more realistic.

Example Code:
```
term.setBackgroundColor(colors.green)
term.setTextColor(colors.black)
term.clear()
paintutils.drawFilledBox(2,2,23,2,colors.blue)
term.setCursorPos(2,2)
term.write("Textbox without Limit:")
paintutils.drawFilledBox(2,3,23,3,colors.white)
paintutils.drawFilledBox(2,5,23,5,colors.blue)
term.setCursorPos(2,5)
term.write("Textbox with Limit:")
paintutils.drawFilledBox(2,6,23,6,colors.white)
term.setCursorPos(2,3)
read()
term.setCursorPos(2,6)
read(nil,nil,nil,nil,21)
term.setCursorPos(1,1)
term.setBackgroundColor(colors.black)
term.clear()
```

Running this code:
![read](https://user-images.githubusercontent.com/15185051/27442006-604efc72-576f-11e7-82e1-2dc67ada9a92.gif)

