### PR TITLE
Fix term.redirect

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/apis/term.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/term.lua
@@ -18,11 +18,11 @@ term.redirect = function( target )
         error( "term is not a recommended redirect target, try term.current() instead", 2 )
     end
 	for k,v in pairs( native ) do
-		if type( k ) == "string" and type( v ) == "function" then
-			if type( target[k] ) ~= "function" then
-				error( "Redirect object is missing method "..k..".", 2 )
-			end
-		end
+		if type( target[k] ) ~= "function" then
+				target[k] = function()
+					error( "Redirect object is missing method "..k..".", 2 )
+				end
+        end
 	end
 	local oldRedirectTarget = redirectTarget
 	redirectTarget = target

--- a/src/main/resources/assets/computercraft/lua/rom/apis/term.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/term.lua
@@ -12,7 +12,7 @@ local term = {}
 
 term.redirect = function( target )
 	if target == nil or type( target ) ~= "table" then
-		error( "Invalid redirect target", 2 )
+		error( "bad argument #1 (expected table, got " .. type( target ) .. ")", 2 )
 	end
     if target == term then
         error( "term is not a recommended redirect target, try term.current() instead", 2 )
@@ -20,9 +20,7 @@ term.redirect = function( target )
 	for k,v in pairs( native ) do
 		if type( k ) == "string" and type( v ) == "function" then
 			if type( target[k] ) ~= "function" then
-				target[k] = function()
-					error( "Redirect object is missing method "..k..".", 2 )
-				end
+				error( "Redirect object is missing method "..k..".", 2 )
 			end
 		end
 	end


### PR DESCRIPTION
If you call term.redirect with a table, who not contain all function, your Computer will Crash. This PR fix this. And I Update the error with missing table to the new style.