### PR TITLE
Fixed possible Typo.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -36,7 +36,7 @@ This mod is provided 'as is' with no warranties, implied or otherwise. The owner
 of this mod takes no responsibility for any damages incurred from the use of
 this mod. This mod alters fundamental parts of the Minecraft game, parts of
 Minecraft may not work with this mod installed. All damages caused from the use
-or misuse of this may fall on the user.
+or misuse of this mod fall on the user.
 
 3. Play rights
 --------------

--- a/LICENSE
+++ b/LICENSE
@@ -36,7 +36,7 @@ This mod is provided 'as is' with no warranties, implied or otherwise. The owner
 of this mod takes no responsibility for any damages incurred from the use of
 this mod. This mod alters fundamental parts of the Minecraft game, parts of
 Minecraft may not work with this mod installed. All damages caused from the use
-or misuse of this mad fall on the user.
+or misuse of this may fall on the user.
 
 3. Play rights
 --------------


### PR DESCRIPTION
Fixed a possible typo in the License file. 

It originally said: 
"All damages caused from the use or misuse of this mad fall on the user."
Not sure if this was intentional but I assumed you meant:
"All damages caused from the use or misuse of this may fall on the user."