### PR TITLE
Added support for notifications in chat

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/rednet/chat.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/rednet/chat.lua
@@ -153,6 +153,15 @@ if sCommand == "host" then
                         end
                         send( sUsers, tUser.nUserID )
                     end,
+                    ["mute"] = function( tUser, sContent )
+                       if muted then
+                         muted = false
+                         send("* Sucessfully unmuted notifications.", tUser.nUserID)
+                       else
+                         muted = true
+                         send("* Sucessfully muted notifications.", tUser.nUserID)
+                       end
+                    end,   
                     ["help"] = function( tUser, sContent )
                         send( "* Available commands:", tUser.nUserID )
                         local sCommands = "*"
@@ -310,6 +319,7 @@ elseif sCommand == "join" then
     function printMessage( sMessage )
         term.redirect( historyWindow )
         print()
+        
         if string.match( sMessage, "^\*" ) then
             -- Information
             term.setTextColour( highlightColour )
@@ -325,6 +335,15 @@ elseif sCommand == "join" then
                 write( string.sub( sMessage, string.len( sUsernameBit ) + 1 ) )
             else
                 write( sMessage )
+            end
+            
+            local tmp = "<"..sUsername..">"
+            
+            if sUsernameBit ~= tmp then
+              local speaker = peripheral.find("speaker")
+              if speaker and mute ~= true then 
+                speaker.playNote("harp", 1,10)
+              end
             end
         end
         term.redirect( promptWindow )

--- a/src/main/resources/assets/computercraft/lua/rom/programs/rednet/chat.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/rednet/chat.lua
@@ -341,7 +341,7 @@ elseif sCommand == "join" then
             
             if sUsernameBit ~= tmp then
               local speaker = peripheral.find("speaker")
-              if speaker and mute ~= true then 
+              if speaker and muted ~= true then 
                 speaker.playNote("harp", 1,10)
               end
             end


### PR DESCRIPTION
As you might know in the new versions of CC there are new speakers. No programs that came with CraftOS used the speaker in any way. I have made it so the chat program can use speakers for notifications. In a chat you can toggle notifications with the `mute` command. It would be very useful so you don't miss a message if someone sends one.