### PR TITLE
Replace direct equality with InventoryUtil.areItemsEqual

### DIFF
--- a/src/main/java/dan200/computercraft/shared/util/InventoryUtil.java
+++ b/src/main/java/dan200/computercraft/shared/util/InventoryUtil.java
@@ -163,13 +163,13 @@ public class InventoryUtil
         }
 
         // Inspect the slots in order and try to find empty or stackable slots
-        ItemStack remainder = stack;
+        ItemStack remainder = stack.copy();
         for( int slot : slots )
         {
             if( remainder == null ) break;
             remainder = inventory.insertItem( slot, remainder, false );
         }
-        return remainder;
+        return areItemsEqual( stack, remainder ) ? stack : remainder;
     }
 
     private static ItemStack takeItems( int count, IItemHandler inventory, int[] slots )


### PR DESCRIPTION
Some IItemHandler.insertItem implementations clone the item, so we must
check whether the object is equal instead. It would be possible to
compare stack sizes instead, I just feel this is a little clearer.

Fixes #340