### PR TITLE
Replaced "no value" with "nil" in ArgumentHelper

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/ArgumentHelper.java
+++ b/src/main/java/dan200/computercraft/core/apis/ArgumentHelper.java
@@ -57,7 +57,7 @@ public final class ArgumentHelper
 
     public static double getNumber( @Nonnull Object[] args, int index ) throws LuaException
     {
-        if( index >= args.length ) throw badArgument( index, "number", "no value" );
+        if( index >= args.length ) throw badArgument( index, "number", "nil" );
         Object value = args[ index ];
         if( value instanceof Number )
         {
@@ -71,7 +71,7 @@ public final class ArgumentHelper
 
     public static int getInt( @Nonnull Object[] args, int index ) throws LuaException
     {
-        if( index >= args.length ) throw badArgument( index, "number", "no value" );
+        if( index >= args.length ) throw badArgument( index, "number", "nil" );
         Object value = args[ index ];
         if( value instanceof Number )
         {
@@ -90,7 +90,7 @@ public final class ArgumentHelper
 
     public static boolean getBoolean( @Nonnull Object[] args, int index ) throws LuaException
     {
-        if( index >= args.length ) throw badArgument( index, "boolean", "no value" );
+        if( index >= args.length ) throw badArgument( index, "boolean", "nil" );
         Object value = args[ index ];
         if( value instanceof Boolean )
         {
@@ -105,7 +105,7 @@ public final class ArgumentHelper
     @Nonnull
     public static String getString( @Nonnull Object[] args, int index ) throws LuaException
     {
-        if( index >= args.length ) throw badArgument( index, "string", "no value" );
+        if( index >= args.length ) throw badArgument( index, "string", "nil" );
         Object value = args[ index ];
         if( value instanceof String )
         {
@@ -121,7 +121,7 @@ public final class ArgumentHelper
     @Nonnull
     public static Map<Object, Object> getTable( @Nonnull Object[] args, int index ) throws LuaException
     {
-        if( index >= args.length ) throw badArgument( index, "table", "no value" );
+        if( index >= args.length ) throw badArgument( index, "table", "nil" );
         Object value = args[ index ];
         if( value instanceof Map )
         {


### PR DESCRIPTION
If you call a function who is coded in LUA with a missing Argument, you get the error: "bad argument #1 (expected string, got nil)" if you call a function who is coded in Java with a missing Argument, you get the error: "bad argument #1 (expected string, got no value)". With this PR, the two error messages become the same look.