### PR TITLE
Make pastebin.lua use HTTPS

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/http/pastebin.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/http/pastebin.lua
@@ -21,7 +21,7 @@ end
 local function get(paste)
     write( "Connecting to pastebin.com... " )
     local response = http.get(
-        "http://pastebin.com/raw/"..textutils.urlEncode( paste )
+        "https://pastebin.com/raw/"..textutils.urlEncode( paste )
     )
         
     if response then
@@ -56,7 +56,7 @@ if sCommand == "put" then
     write( "Connecting to pastebin.com... " )
     local key = "0ec2eb25b6166c0c27a394ae118ad829"
     local response = http.post(
-        "http://pastebin.com/api/api_post.php", 
+        "https://pastebin.com/api/api_post.php", 
         "api_option=paste&"..
         "api_dev_key="..key.."&"..
         "api_paste_format=lua&"..


### PR DESCRIPTION
This PR makes `pastebin` use HTTPS for all requests. This makes file upload more secure<sup>[citation needed]</sup> and prevents relying on the HTTP->HTTPS redirect in the pastebin API.

Old PR message:

> Attempting to use pastebin with plain HTTP results in a 301 redirect to the HTTPS version. This PR makes the pastebin command work again.
> 
> Before this PR:
>  - `pastebin get` - works
>  - `pastebin run` - works (internally uses same pastebin file get method from `get`)
>  - `pastebin put` - fails
> 
> After this PR:
>  - `pastebin get` - works
>  - `pastebin run` - works (internally uses same pastebin file get method from `get`)
>  - `pastebin put` - works (theoretically, haven't had time to test it)