### PR TITLE
Mixed-Lua-side-improvements.-Part-2

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/apis/paintutils.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/paintutils.lua
@@ -62,7 +62,7 @@ function drawLine( startX, startY, endX, endY, nColour )
         return
     end
     
-    local minX = math.min( startX, endX )
+    local minX, maxX, minY, maxY = math.min( startX, endX )
     if minX == startX then
         minY = startY
         maxX = endX
@@ -122,7 +122,7 @@ function drawBox( startX, startY, endX, endY, nColour )
         return
     end
 
-    local minX = math.min( startX, endX )
+    local minX, maxX, minY, maxY = math.min( startX, endX )
     if minX == startX then
         minY = startY
         maxX = endX
@@ -166,7 +166,7 @@ function drawFilledBox( startX, startY, endX, endY, nColour )
         return
     end
 
-    local minX = math.min( startX, endX )
+    local minX, maxX, minY, maxY = math.min( startX, endX )
     if minX == startX then
         minY = startY
         maxX = endX

--- a/src/main/resources/assets/computercraft/lua/rom/apis/paintutils.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/paintutils.lua
@@ -62,7 +62,8 @@ function drawLine( startX, startY, endX, endY, nColour )
         return
     end
     
-    local minX, maxX, minY, maxY = math.min( startX, endX )
+    local minX = math.min( startX, endX )
+    local maxX, minY, maxY
     if minX == startX then
         minY = startY
         maxX = endX
@@ -122,7 +123,8 @@ function drawBox( startX, startY, endX, endY, nColour )
         return
     end
 
-    local minX, maxX, minY, maxY = math.min( startX, endX )
+    local minX = math.min( startX, endX )
+    local maxX, minY, maxY 
     if minX == startX then
         minY = startY
         maxX = endX
@@ -166,7 +168,8 @@ function drawFilledBox( startX, startY, endX, endY, nColour )
         return
     end
 
-    local minX, maxX, minY, maxY = math.min( startX, endX )
+    local minX = math.min( startX, endX )
+    local maxX, minY, maxY
     if minX == startX then
         minY = startY
         maxX = endX

--- a/src/main/resources/assets/computercraft/lua/rom/apis/textutils.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/textutils.lua
@@ -409,12 +409,23 @@ function complete( sSearchText, tSearchTable )
                 if string.find( k, sPart, 1, true ) == 1 then
                     if not g_tLuaKeywords[k] and string.match( k, "^[%a_][%a%d_]*$" ) then
                         local sResult = string.sub( k, nPartLength + 1 )
-                        if type(v) == "function" then
-                            sResult = sResult .. "("
-                        elseif type(v) == "table" and next(v) ~= nil then
-                            sResult = sResult .. "."
+                        if nColon then
+                            if type(v) == "function" then
+                                table.insert( tResults, sResult .. "(" )
+                            elseif type(v) == "table" then
+                                local tMetatable = getmetatable( v )
+                                if tMetatable and ( type( tMetatable.__call ) == "function" or  type( tMetatable.__call ) == "table" ) then
+                                    table.insert( tResults, sResult .. "(" )
+                                end
+                            end
+                        else
+                            if type(v) == "function" then
+                                sResult = sResult .. "("
+                            elseif type(v) == "table" and next(v) ~= nil then
+                                sResult = sResult .. "."
+                            end
+                            table.insert( tResults, sResult )
                         end
-                        table.insert( tResults, sResult )
                     end
                 end
             end

--- a/src/main/resources/assets/computercraft/lua/rom/programs/advanced/multishell.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/advanced/multishell.lua
@@ -210,7 +210,7 @@ function multishell.getCurrent()
 end
 
 function multishell.launch( tProgramEnv, sProgramPath, ... )
-    if type( tProgramArgs ) ~= "table" then
+    if type( tProgramEnv ) ~= "table" then
         error( "bad argument #1 (expected table, got " .. type( tProgramEnv ) .. ")", 2 )
     end
     if type( sProgramPath ) ~= "string" then
@@ -264,7 +264,7 @@ while #tProcesses > 0 do
             -- Switch process
             local tabStart = 1
             for n=1,#tProcesses do
-                tabEnd = tabStart + string.len( tProcesses[n].sTitle ) + 1
+                local tabEnd = tabStart + string.len( tProcesses[n].sTitle ) + 1
                 if x >= tabStart and x <= tabEnd then
                     selectProcess( n )
                     redrawMenu()

--- a/src/main/resources/assets/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/edit.lua
@@ -642,7 +642,7 @@ while bRunning do
                 if x > 1 then
                     -- Remove character
                     local sLine = tLines[y]
-                    if x > 4 and string.sub(sLine,x-4,x-1) == "    " then
+                    if x > 4 and string.sub(sLine,x-4,x-1) == "    " and not string.sub(sLine, 1, x - 1):find("%S") then
                         tLines[y] = string.sub(sLine,1,x-5) .. string.sub(sLine,x)
                         setCursor( x - 4, y )
                     else

--- a/src/main/resources/assets/computercraft/lua/rom/programs/fun/advanced/redirection.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/fun/advanced/redirection.lua
@@ -197,7 +197,7 @@ local function loadLevel(nNum)
     fLevel = fs.open(sLevelD,"r")
     fLevel.readLine()
     for Line=2,Lines-1 do
-        sLine = fLevel.readLine()
+        local sLine = fLevel.readLine()
         local chars = string.len(sLine)
         for char = 1, chars do
             local el = string.sub(sLine,char,char)
@@ -313,7 +313,7 @@ local function drawMap()
             term.setBackgroundColor(cG)
                 term.setCursorPos(XOrgin+x,YOrgin+y+1)
             
-                sSide = string.sub(st,1,1)
+                local sSide = string.sub(st,1,1)
                 if sSide == "a" then
                     print("^")
                 elseif sSide == "b" then
@@ -348,7 +348,7 @@ local function drawMap()
                 term.setBackgroundColor(Cr)
                 term.setTextColor(colors.white)
                 term.setCursorPos(XOrgin+x,YOrgin+y+1)
-                sSide = string.sub(rb,1,1)
+                local sSide = string.sub(rb,1,1)
                 if sSide == "a" then
                     print("^")
                 elseif sSide == "b" then

--- a/src/main/resources/assets/computercraft/lua/rom/programs/fun/adventure.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/fun/adventure.lua
@@ -276,7 +276,6 @@ local tMonsters = {
 local tRecipes = {
     ["some planks"] = { "some wood" },
     ["some sticks"] = { "some planks" },
-    ["some sticks"] = { "some planks" },
     ["a crafting table"] = { "some planks" },
     ["a furnace"] = { "some stone" },
     ["some torches"] = { "some sticks", "some coal" },
@@ -753,7 +752,6 @@ function commands.dig( _sDir, _sTool )
         tTool = inventory[ sTool ]
     end
     
-    local room = getRoom( x, y, z )
     local bActuallyDigging = (room.exits[ _sDir ] ~= true)
     if bActuallyDigging then
         if sTool == nil or tTool.toolType ~= "pick" then

--- a/src/main/resources/assets/computercraft/lua/rom/programs/fun/worm.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/fun/worm.lua
@@ -137,8 +137,8 @@ local function update( )
     end
     
     local newHead = screen[newXPos][newYPos]
-    term.setCursorPos(1,1);
-    print( newHead.snake )
+    -- term.setCursorPos(1,1);
+    -- print( newHead.snake )
     if newHead.snake == true or newHead.wall == true then
         bRunning = false
         

--- a/src/main/resources/assets/computercraft/lua/rom/programs/fun/worm.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/fun/worm.lua
@@ -137,8 +137,6 @@ local function update( )
     end
     
     local newHead = screen[newXPos][newYPos]
-    -- term.setCursorPos(1,1);
-    -- print( newHead.snake )
     if newHead.snake == true or newHead.wall == true then
         bRunning = false
         

--- a/src/main/resources/assets/computercraft/lua/rom/programs/gps.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/gps.lua
@@ -87,11 +87,6 @@ elseif sCommand == "host" then
             end
         end
     end
-
-    -- Close the channel
-    print( "Closing channel" )
-    modem.close( gps.CHANNEL_GPS )
-
 else
     -- "gps somethingelse"
     -- Error

--- a/src/main/resources/assets/computercraft/lua/rom/programs/help.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/help.lua
@@ -1,4 +1,5 @@
 local tArgs = { ... }
+local sTopic
 if #tArgs > 0 then
     sTopic = tArgs[1]
 else

--- a/src/main/resources/assets/computercraft/lua/rom/programs/pocket/falling.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/pocket/falling.lua
@@ -473,7 +473,7 @@ local function playGame()
     if testBlockAt(curBlock,curX,curY+1,curRot) then
       pitBlock(curBlock,curX,curY,curRot)
       --detect rows that clear
-      clearRows(rows)
+      clearRows()
 
       curBlock=next
       curX=4

--- a/src/main/resources/assets/computercraft/lua/rom/programs/rednet/chat.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/rednet/chat.lua
@@ -58,7 +58,7 @@ if sCommand == "host" then
 
     local tUsers = {}
     local nUsers = 0
-    function send( sText, nUserID )
+    local function send( sText, nUserID )
         if nUserID then
             local tUser = tUsers[ nUserID ]
             if tUser then
@@ -81,7 +81,7 @@ if sCommand == "host" then
 
     -- Setup ping pong
     local tPingPongTimer = {}
-    function ping( nUserID )
+    local function ping( nUserID )
         local tUser = tUsers[ nUserID ]
         rednet.send( tUser.nID, {
             sType = "ping to client",
@@ -93,7 +93,7 @@ if sCommand == "host" then
         tPingPongTimer[ timer ] = nUserID
     end
 
-    function printUsers()
+    local function printUsers()
         local x,y = term.getCursorPos()
         term.setCursorPos( 1, y - 1 )
         term.clearLine()
@@ -274,7 +274,7 @@ elseif sCommand == "join" then
     local bPingPonged = true
     local pingPongTimer = os.startTimer( 0 )
 
-    function ping()
+    local function ping()
         rednet.send( nHostID, {
             sType = "ping to server",
             nUserID = nUserID,
@@ -296,7 +296,7 @@ elseif sCommand == "join" then
     term.redirect( promptWindow )
     promptWindow.restoreCursor()
 
-    function drawTitle()
+    local function drawTitle()
         local x,y = titleWindow.getCursorPos()
         local w,h = titleWindow.getSize()
         local sTitle = sUsername.." on "..sHostname
@@ -307,7 +307,7 @@ elseif sCommand == "join" then
         promptWindow.restoreCursor()
     end
 
-    function printMessage( sMessage )
+    local function printMessage( sMessage )
         term.redirect( historyWindow )
         print()
         if string.match( sMessage, "^%*" ) then

--- a/src/main/resources/assets/computercraft/lua/rom/startup.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/startup.lua
@@ -208,13 +208,11 @@ shell.setCompletionFunction( "rom/programs/command/exec.lua", completeExec )
 if turtle then
     local tGoOptions = { "left", "right", "forward", "back", "down", "up" }
     local function completeGo( shell, nIndex, sText )
-        return completeMultipleChoice(sText,tGoOptions)
+        return completeMultipleChoice( sText, tGoOptions, true)
     end
     local tTurnOptions = { "left", "right" }
     local function completeTurn( shell, nIndex, sText )
-        if nIndex == 1 then
-            return completeMultipleChoice( sText, tTurnOptions )
-        end
+            return completeMultipleChoice( sText, tTurnOptions, true )
     end
     local tEquipOptions = { "left", "right" }
     local function completeEquip( shell, nIndex, sText )


### PR DESCRIPTION
All changes in this PR::
 - Tweak to Colon syntax lua autocompletition. Changes autocompletition to only complete function names (Or table names treated as functions via __call metamethod) after the colon symbol. Those are only valid uses lie colon.
 - Tweak to Go and Turn autocompletition. Adds spaces to simplyfy making chains of commands.  Also fix up turn not autocompleting after first argument.
 - Tweak to Edit indentation deletion logic.
 - Fix several global definitions.
 - Remove some code that was never run.