### PR TITLE
Add Defaultprograms to extensions

### DIFF
--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -915,8 +915,10 @@ settings.set( "edit.default_extension", "lua" )
 settings.set( "paint.default_extension", "nfp" )
 settings.set( "lua.autocomplete", true )
 settings.set( "list.show_hidden", false )
+settings.set( "filetype.txt", "edit {}" )
 if term.isColour() then
     settings.set( "bios.use_multishell", true )
+    settings.set( "filetype.nfp", "paint {}" )
 end
 if _CC_DEFAULT_SETTINGS then
     for sPair in string.gmatch( _CC_DEFAULT_SETTINGS, "[^,]+" ) do

--- a/src/main/resources/assets/computercraft/lua/rom/programs/shell.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/shell.lua
@@ -171,6 +171,14 @@ function shell.run( ... )
     local tWords = tokenise( ... )
     local sCommand = tWords[1]
     if sCommand then
+        local nExtensionPos = sCommand:find(".",1,true)
+        if nExtensionPos ~= nil then
+            sExtension = sCommand:sub(nExtensionPos+1)
+            if settings.get("filetype."..sExtension) ~= nil then
+                shell.run(settings.get("filetype."..sExtension):gsub("{}",sCommand))
+                return true
+            end
+        end
         return run( sCommand, table.unpack( tWords, 2 ) )
     end
     return false


### PR DESCRIPTION
If you just type "picture.nfp" the shell will open the file in paint and not execute it..txt files will be open in edit. Other programs can add their own filetypes with the settings API.