### PR TITLE
Adds the ability to load custom bios.lua files from resource packs

### DIFF
--- a/src/main/java/dan200/computercraft/core/computer/Computer.java
+++ b/src/main/java/dan200/computercraft/core/computer/Computer.java
@@ -635,7 +635,7 @@ public class Computer
         InputStream biosStream;
         try
         {
-            biosStream = Computer.class.getResourceAsStream( "/assets/computercraft/lua/bios.lua" );
+            biosStream = m_environment.createResourceFile( "computercraft", "lua/bios.lua" );
         }
         catch( Exception e )
         {

--- a/src/main/java/dan200/computercraft/core/computer/IComputerEnvironment.java
+++ b/src/main/java/dan200/computercraft/core/computer/IComputerEnvironment.java
@@ -8,6 +8,8 @@ package dan200.computercraft.core.computer;
 import dan200.computercraft.api.filesystem.IMount;
 import dan200.computercraft.api.filesystem.IWritableMount;
 
+import java.io.InputStream;
+
 public interface IComputerEnvironment
 {
     int getDay();
@@ -19,4 +21,5 @@ public interface IComputerEnvironment
     int assignNewID();
     IWritableMount createSaveDirMount( String subPath, long capacity );
     IMount createResourceMount( String domain, String subPath );
+    InputStream createResourceFile( String domain, String subPath );
 }

--- a/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
@@ -26,6 +26,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.Loader;
 
+import java.io.InputStream;
+
 public class ServerComputer extends ServerTerminal
     implements IComputer, IComputerEnvironment, INetworkedThing
 {
@@ -307,6 +309,12 @@ public class ServerComputer extends ServerTerminal
     public IMount createResourceMount( String domain, String subPath )
     {
         return ComputerCraftAPI.createResourceMount( ComputerCraft.class, domain, subPath );
+    }
+
+    @Override
+    public InputStream createResourceFile( String domain, String subPath )
+    {
+        return ComputerCraft.getResourceFile( ComputerCraft.class, domain, subPath );
     }
 
     @Override


### PR DESCRIPTION
[See here for context](https://github.com/dan200/ComputerCraft/pull/272#issuecomment-303023045)

`Computer.initLua` now delegates to `IComputerEnvironment.createResourceFile` which, by default, looks in the following locations:

 - Resouce pack files
 - The "debug" folder
 - The original ComputerCraft jar

I'm doing it this rather convoluted way to remain consistent with the `rom` mount loading, as well as ensuring the "core" doesn't add a dependency on Minecraft.

I believe this closes #240, but I'd want to discuss this too :).

Note that this is **not** indented as a replacement for #347, but something to go along side it.