### PR TITLE
Fix incorrect null check in HTTP API

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/http/HTTPRequest.java
+++ b/src/main/java/dan200/computercraft/core/apis/http/HTTPRequest.java
@@ -143,7 +143,7 @@ public class HTTPRequest implements HTTPTask.IHTTPTask
                 connection.setRequestProperty( "content-type", "application/x-www-form-urlencoded; charset=utf-8" );
                 connection.setRequestProperty( "content-encoding", "UTF-8" );
             }
-            if( m_postText != null )
+            if( m_headers != null )
             {
                 for( Map.Entry<String, String> header : m_headers.entrySet() )
                 {


### PR DESCRIPTION
This was causing NPEs when no headers were specified and one was attempting to POST data.

Solves the issues mentioned [in this comment](https://github.com/dan200/ComputerCraft/pull/355#issuecomment-315889160).

Sorry about this, this was a really stupid mistake on my part :/.