### PR TITLE
Make io.open() return Error

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/apis/io.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/io.lua
@@ -63,9 +63,9 @@ end
 
 function open( _sPath, _sMode )
 	local sMode = _sMode or "r"
-	local file = fs.open( _sPath, sMode )
+	local file, err = fs.open( _sPath, sMode )
 	if not file then
-		return nil
+		return nil, err
 	end
 	
 	if sMode == "r"then


### PR DESCRIPTION
If fs.open() failed, it will return nil and a a error message like "No such file"  or "Out of space". This PR make, that io.open() returned this error too.