### PR TITLE
Fix Bug with term.getPaletteColour()

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
@@ -311,8 +311,12 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     window.setPaletteColor = window.setPaletteColour
 
     function window.getPaletteColour( colour )
-        local tCol = tPalette[ colour ]
-        return tCol[1], tCol[2], tCol[3]
+        if type( colour ) ~= "number" then
+            error( "bad argument #1 (expected number, got " .. type( colour ) .. ")", 2 )
+        elseif tHex[colour] == nil then
+            error( "Invalid color (got " .. colour .. ")", 2 )
+        end
+        return parent.getPaletteColor( colour )
     end
 
     window.getPaletteColor = window.getPaletteColour


### PR DESCRIPTION
The Problem is, that the Colour Palette is global and not bound to a window. You can trigger the Bug with this code:
```
local win1 = window.create(term.current(),1,1,20,10)
local win2 = window.create(term.current(),20,1,20,10)
win1.setTextColor(colors.red)
win1.write("Hello World")
win2.setTextColor(colors.red)
win2.write("Hello World")
win1.setPaletteColor(colors.red,0.4,0.4,0.4)
win2.setPaletteColor(colors.red,0.5,0.5,0.5)
win1.setCursorPos(1,2)
win1.write(win1.getPaletteColor(colors.red))
win2.setCursorPos(1,2)
win2.write(win2.getPaletteColor(colors.red))
```
If you run this code, you will see, that the 2 Window have the same Palette but getPaletteColor return different values. 