### PR TITLE
Modify logic behind ... and more in file path.

### DIFF
--- a/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
+++ b/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
@@ -765,14 +765,15 @@ public class FileSystem
         Stack<String> outputParts = new Stack<String>();
         for( String part : parts )
         {
-            if( part.length() == 0 || part.equals( "." ) )
+            if( part.length() == 0 || part.equals( "." ) || part.matches( "^\\.{3,}$" ) )
             {
                 // . is redundant
+                // ... and more are treated as .
                 continue;
             }
-            else if( part.equals( ".." ) || part.equals( "..." ) )
+            else if( part.equals( ".." ) )
             {
-                // .. or ... can cancel out the last folder entered
+                // .. can cancel out the last folder entered
                 if( !outputParts.empty() )
                 {
                     String top = outputParts.peek();

--- a/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
+++ b/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
@@ -740,6 +740,7 @@ public class FileSystem
         return sanitizePath( path, false );
     }
 
+    private static final Pattern threeDotsPattern = Pattern.compile( "^\\.{3,}$" );
     private static String sanitizePath( String path, boolean allowWildcards )
     {
         // Allow windowsy slashes
@@ -765,7 +766,7 @@ public class FileSystem
         Stack<String> outputParts = new Stack<String>();
         for( String part : parts )
         {
-            if( part.length() == 0 || part.equals( "." ) || part.matches( "^\\.{3,}$" ) )
+            if( part.length() == 0 || part.equals( "." ) || threeDotsPattern.matcher( part ).matches() ) 
             {
                 // . is redundant
                 // ... and more are treated as .


### PR DESCRIPTION
Changes all equal or longer then 3 multidots setups to be treated as .
This removes other potentially dangerous situations and brings it closer to windows in how it treats said dots. This makes sure that even on systems that have wierd magic meanings to ... and onward CC will work with predictable path no matter the system.

This fixed the bugs expressed in #35 , http://www.computercraft.info/forums2/index.php?/topic/16882-computercraft-beta-versions-bug-reports/page__st__40__p__213941#entry213941 and http://www.computercraft.info/forums2/index.php?/topic/28870-command-crashes-computer/