### PR TITLE
Type checking utility function

### DIFF
--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -666,9 +666,7 @@ function os.unloadAPI( _sName )
     end
 end
 
-function os.sleep( nTime )
-    return sleep( nTime )
-end
+os.sleep = sleep
 
 local nativeShutdown = os.shutdown
 function os.shutdown()

--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -283,8 +283,10 @@ function printError( ... )
     end
 end
 
+local fnTablePack = table.pack
+
 function check( ... )
-    local tArgs = table.pack( ... )
+    local tArgs = fnTablePack( ... )
     local nArgs = tArgs.n
     if nArgs % 2 ~= 0 then
         return error( "amount of check args is not divisible by 2" )

--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -291,7 +291,6 @@ function check( ... )
     end
 
     for i=1,nArgs,2 do
-        local nArg = i / 2 + 1
         local sParam = tArgs[ i ]
         local sActualType = type( sParam )
         local sExpectedTypes = tArgs[ i + 1 ]
@@ -306,7 +305,7 @@ function check( ... )
         if tExpectedTypes and not tExpectedTypes[ sActualType ] then
             local sErr = string.format(
                 "bad argument #%d (expected %s; got %s)",
-                nArg, sExpectedTypes, sActualType
+                i / 2 + 1, sExpectedTypes, sActualType
             )
             return error( sErr, 2 )
         end

--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -284,6 +284,10 @@ function printError( ... )
 end
 
 local fnTablePack = table.pack
+local fnType = type
+local fnStringLower = string.lower
+local fnStringGmatch = string.gmatch
+local fnStringFormat = string.format
 
 function check( ... )
     local tArgs = fnTablePack( ... )
@@ -294,12 +298,12 @@ function check( ... )
 
     for i=1,nArgs,2 do
         local sParam = tArgs[ i ]
-        local sActualType = type( sParam )
+        local sActualType = fnType( sParam )
         local sExpectedTypes = tArgs[ i + 1 ]
 
-        if string.lower( sExpectedTypes ) ~= "any" then
+        if fnStringLower( sExpectedTypes ) ~= "any" then
             local bFound = false
-            for t in string.gmatch( sExpectedTypes, "[^,]+" ) do
+            for t in fnStringGmatch( sExpectedTypes, "[^,]+" ) do
                 if t == sActualType then
                     bFound = true
                     break
@@ -307,7 +311,7 @@ function check( ... )
             end
 
             if not bFound then
-                local sErr = string.format(
+                local sErr = fnStringFormat(
                     "bad argument #%d (expected %s; got %s)",
                     i / 2 + 1, sExpectedTypes, sActualType
                 )

--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -9,7 +9,7 @@ if _VERSION == "Lua 5.1" then
         if mode ~= nil and mode ~= "t" then
             error( "Binary chunk loading prohibited", 2 )
         end
-        local ok, p1, p2 = pcall( function()        
+        local ok, p1, p2 = pcall( function()
             if type(x) == "string" then
                 local result, err = nativeloadstring( x, name )
                 if result then
@@ -38,7 +38,7 @@ if _VERSION == "Lua 5.1" then
             return p1, p2
         else
             error( p1, 2 )
-        end        
+        end
     end
     table.unpack = unpack
     table.pack = function( ... ) return { n = select( "#", ... ), ... } end
@@ -185,7 +185,7 @@ end
 -- Install globals
 function sleep( nTime )
     if nTime ~= nil and type( nTime ) ~= "number" then
-        error( "bad argument #1 (expected number, got " .. type( nTime ) .. ")", 2 ) 
+        error( "bad argument #1 (expected number, got " .. type( nTime ) .. ")", 2 )
     end
     local timer = os.startTimer( nTime or 0 )
     repeat
@@ -195,12 +195,12 @@ end
 
 function write( sText )
     if sText ~= nil and type( sText ) ~= "string" and type( sText ) ~= "number" then
-        error( "bad argument #1 (expected string, got " .. type( sText ) .. ")", 2 ) 
+        error( "bad argument #1 (expected string, got " .. type( sText ) .. ")", 2 )
     end
 
-    local w,h = term.getSize()        
+    local w,h = term.getSize()
     local x,y = term.getCursorPos()
-    
+
     local nLinesPrinted = 0
     local function newLine()
         if y + 1 <= h then
@@ -212,7 +212,7 @@ function write( sText )
         x, y = term.getCursorPos()
         nLinesPrinted = nLinesPrinted + 1
     end
-    
+
     -- Print the line with proper word wrapping
     while string.len(sText) > 0 do
         local whitespace = string.match( sText, "^[ \t]+" )
@@ -222,19 +222,19 @@ function write( sText )
             x,y = term.getCursorPos()
             sText = string.sub( sText, string.len(whitespace) + 1 )
         end
-        
+
         local newline = string.match( sText, "^\n" )
         if newline then
             -- Print newlines
             newLine()
             sText = string.sub( sText, 2 )
         end
-        
+
         local text = string.match( sText, "^[^ \t\n]+" )
         if text then
             sText = string.sub( sText, string.len(text) + 1 )
             if string.len(text) > w then
-                -- Print a multiline word                
+                -- Print a multiline word
                 while string.len( text ) > 0 do
                     if x > w then
                         newLine()
@@ -253,7 +253,7 @@ function write( sText )
             end
         end
     end
-    
+
     return nLinesPrinted
 end
 
@@ -283,18 +283,48 @@ function printError( ... )
     end
 end
 
+function check( ... )
+    local tArgs = table.pack( ... )
+    local nArgs = tArgs.n
+    if nArgs % 2 ~= 0 then
+        return error( "amount of check args is not divisible by 2" )
+    end
+
+    for i=1,nArgs,2 do
+        local nArg = i / 2 + 1
+        local sParam = tArgs[ i ]
+        local sActualType = type( sParam )
+        local sExpectedTypes = tArgs[ i + 1 ]
+        local tExpectedTypes
+        if string.lower( sExpectedTypes ) ~= "any" then
+            tExpectedTypes = {}
+            for t in string.gmatch( sExpectedTypes, "[^,]+" ) do
+                tExpectedTypes[ t ] = true
+            end
+        end
+
+        if tExpectedTypes and not tExpectedTypes[ sActualType ] then
+            local sErr = string.format(
+                "bad argument #%d (expected %s; got %s)",
+                nArg, sExpectedTypes, sActualType
+            )
+            return error( sErr )
+        end
+    end
+end
+
 function read( _sReplaceChar, _tHistory, _fnComplete, _sDefault )
     if _sReplaceChar ~= nil and type( _sReplaceChar ) ~= "string" then
-        error( "bad argument #1 (expected string, got " .. type( _sReplaceChar ) .. ")", 2 ) 
+        error( "bad argument #1 (expected string, got " .. type( _sReplaceChar ) .. ")", 2 )
     end
     if _tHistory ~= nil and type( _tHistory ) ~= "table" then
-        error( "bad argument #2 (expected table, got " .. type( _tHistory ) .. ")", 2 ) 
+        error( "bad argument #2 (expected table, got " .. type( _tHistory ) .. ")", 2 )
     end
     if _fnComplete ~= nil and type( _fnComplete ) ~= "function" then
-        error( "bad argument #3 (expected function, got " .. type( _fnComplete ) .. ")", 2 ) 
+        error( "bad argument #3 (expected function, got " .. type( _fnComplete ) .. ")", 2 )
     end
     if _sDefault ~= nil and type( _sDefault ) ~= "string" then
-        error( "bad argument #4 (expected string, got " .. type( _sDefault ) .. ")", 2 ) 
+        error( "bad argument #4 (expected string, got " .. type( _sDefault ) .. ")", 2 )
     end
     term.setCursorBlink( true )
 
@@ -371,7 +401,7 @@ function read( _sReplaceChar, _tHistory, _fnComplete, _sDefault )
 
         term.setCursorPos( sx + nPos - nScroll, cy )
     end
-    
+
     local function clear()
         redraw( true )
     end
@@ -421,7 +451,7 @@ function read( _sReplaceChar, _tHistory, _fnComplete, _sDefault )
                     redraw()
                 end
                 break
-                
+
             elseif param == keys.left then
                 -- Left
                 if nPos > 0 then
@@ -430,9 +460,9 @@ function read( _sReplaceChar, _tHistory, _fnComplete, _sDefault )
                     recomplete()
                     redraw()
                 end
-                
+
             elseif param == keys.right then
-                -- Right                
+                -- Right
                 if nPos < string.len(sLine) then
                     -- Move right
                     clear()
@@ -480,11 +510,11 @@ function read( _sReplaceChar, _tHistory, _fnComplete, _sDefault )
                             nHistoryPos = nil
                         elseif nHistoryPos ~= nil then
                             nHistoryPos = nHistoryPos + 1
-                        end                        
+                        end
                     end
                     if nHistoryPos then
                         sLine = _tHistory[nHistoryPos]
-                        nPos = string.len( sLine ) 
+                        nPos = string.len( sLine )
                     else
                         sLine = ""
                         nPos = 0
@@ -517,7 +547,7 @@ function read( _sReplaceChar, _tHistory, _fnComplete, _sDefault )
                 -- Delete
                 if nPos < string.len(sLine) then
                     clear()
-                    sLine = string.sub( sLine, 1, nPos ) .. string.sub( sLine, nPos + 2 )                
+                    sLine = string.sub( sLine, 1, nPos ) .. string.sub( sLine, nPos + 2 )
                     recomplete()
                     redraw()
                 end
@@ -549,16 +579,16 @@ function read( _sReplaceChar, _tHistory, _fnComplete, _sDefault )
     term.setCursorBlink( false )
     term.setCursorPos( w + 1, cy )
     print()
-    
+
     return sLine
 end
 
 loadfile = function( _sFile, _tEnv )
     if type( _sFile ) ~= "string" then
-        error( "bad argument #1 (expected string, got " .. type( _sFile ) .. ")", 2 ) 
+        error( "bad argument #1 (expected string, got " .. type( _sFile ) .. ")", 2 )
     end
     if _tEnv ~= nil and type( _tEnv ) ~= "table" then
-        error( "bad argument #2 (expected table, got " .. type( _tEnv ) .. ")", 2 ) 
+        error( "bad argument #2 (expected table, got " .. type( _tEnv ) .. ")", 2 )
     end
     local file = fs.open( _sFile, "r" )
     if file then
@@ -571,7 +601,7 @@ end
 
 dofile = function( _sFile )
     if type( _sFile ) ~= "string" then
-        error( "bad argument #1 (expected string, got " .. type( _sFile ) .. ")", 2 ) 
+        error( "bad argument #1 (expected string, got " .. type( _sFile ) .. ")", 2 )
     end
     local fnFile, e = loadfile( _sFile, _G )
     if fnFile then
@@ -584,10 +614,10 @@ end
 -- Install the rest of the OS api
 function os.run( _tEnv, _sPath, ... )
     if type( _tEnv ) ~= "table" then
-        error( "bad argument #1 (expected table, got " .. type( _tEnv ) .. ")", 2 ) 
+        error( "bad argument #1 (expected table, got " .. type( _tEnv ) .. ")", 2 )
     end
     if type( _sPath ) ~= "string" then
-        error( "bad argument #2 (expected string, got " .. type( _sPath ) .. ")", 2 ) 
+        error( "bad argument #2 (expected string, got " .. type( _sPath ) .. ")", 2 )
     end
     local tArgs = table.pack( ... )
     local tEnv = _tEnv
@@ -614,7 +644,7 @@ end
 local tAPIsLoading = {}
 function os.loadAPI( _sPath )
     if type( _sPath ) ~= "string" then
-        error( "bad argument #1 (expected string, got " .. type( _sPath ) .. ")", 2 ) 
+        error( "bad argument #1 (expected string, got " .. type( _sPath ) .. ")", 2 )
     end
     local sName = fs.getName( _sPath )
     if sName:sub(-4) == ".lua" then
@@ -641,7 +671,7 @@ function os.loadAPI( _sPath )
         tAPIsLoading[sName] = nil
         return false
     end
-    
+
     local tAPI = {}
     for k,v in pairs( tEnv ) do
         if k ~= "_ENV" then
@@ -649,14 +679,14 @@ function os.loadAPI( _sPath )
         end
     end
 
-    _G[sName] = tAPI    
+    _G[sName] = tAPI
     tAPIsLoading[sName] = nil
     return true
 end
 
 function os.unloadAPI( _sName )
     if type( _sName ) ~= "string" then
-        error( "bad argument #1 (expected string, got " .. type( _sName ) .. ")", 2 ) 
+        error( "bad argument #1 (expected string, got " .. type( _sName ) .. ")", 2 )
     end
     if _sName ~= "_G" and type(_G[_sName]) == "table" then
         _G[_sName] = nil
@@ -701,39 +731,39 @@ if http then
         end
         return nil, err
     end
-    
+
     http.get = function( _url, _headers, _binary)
         if type( _url ) ~= "string" then
-            error( "bad argument #1 (expected string, got " .. type( _url ) .. ")", 2 ) 
+            error( "bad argument #1 (expected string, got " .. type( _url ) .. ")", 2 )
         end
         if _headers ~= nil and type( _headers ) ~= "table" then
-            error( "bad argument #2 (expected table, got " .. type( _headers ) .. ")", 2 ) 
+            error( "bad argument #2 (expected table, got " .. type( _headers ) .. ")", 2 )
         end
         return wrapRequest( _url, nil, _headers, _binary)
     end
 
     http.post = function( _url, _post, _headers, _binary)
         if type( _url ) ~= "string" then
-            error( "bad argument #1 (expected string, got " .. type( _url ) .. ")", 2 ) 
+            error( "bad argument #1 (expected string, got " .. type( _url ) .. ")", 2 )
         end
         if type( _post ) ~= "string" then
-            error( "bad argument #2 (expected string, got " .. type( _post ) .. ")", 2 ) 
+            error( "bad argument #2 (expected string, got " .. type( _post ) .. ")", 2 )
         end
         if _headers ~= nil and type( _headers ) ~= "table" then
-            error( "bad argument #3 (expected table, got " .. type( _headers ) .. ")", 2 ) 
+            error( "bad argument #3 (expected table, got " .. type( _headers ) .. ")", 2 )
         end
         return wrapRequest( _url, _post or "", _headers, _binary)
     end
 
     http.request = function( _url, _post, _headers, _binary )
         if type( _url ) ~= "string" then
-            error( "bad argument #1 (expected string, got " .. type( _url ) .. ")", 2 ) 
+            error( "bad argument #1 (expected string, got " .. type( _url ) .. ")", 2 )
         end
         if _post ~= nil and type( _post ) ~= "string" then
-            error( "bad argument #2 (expected string, got " .. type( _post ) .. ")", 2 ) 
+            error( "bad argument #2 (expected string, got " .. type( _post ) .. ")", 2 )
         end
         if _headers ~= nil and type( _headers ) ~= "table" then
-            error( "bad argument #3 (expected table, got " .. type( _headers ) .. ")", 2 ) 
+            error( "bad argument #3 (expected table, got " .. type( _headers ) .. ")", 2 )
         end
         local ok, err = nativeHTTPRequest( _url, _post, _headers, _binary )
         if not ok then
@@ -741,13 +771,13 @@ if http then
         end
         return ok, err
     end
-    
+
     local nativeCheckURL = http.checkURL
     http.checkURLAsync = nativeCheckURL
     http.checkURL = function( _url )
         local ok, err = nativeCheckURL( _url )
         if not ok then return ok, err end
-    
+
         while true do
             local event, url, ok, err = os.pullEvent( "http_check" )
             if url == _url then return ok, err end
@@ -759,16 +789,16 @@ end
 local tEmpty = {}
 function fs.complete( sPath, sLocation, bIncludeFiles, bIncludeDirs )
     if type( sPath ) ~= "string" then
-        error( "bad argument #1 (expected string, got " .. type( sPath ) .. ")", 2 ) 
+        error( "bad argument #1 (expected string, got " .. type( sPath ) .. ")", 2 )
     end
     if type( sLocation ) ~= "string" then
-        error( "bad argument #2 (expected string, got " .. type( sLocation ) .. ")", 2 ) 
+        error( "bad argument #2 (expected string, got " .. type( sLocation ) .. ")", 2 )
     end
     if bIncludeFiles ~= nil and type( bIncludeFiles ) ~= "boolean" then
-        error( "bad argument #3 (expected boolean, got " .. type( bIncludeFiles ) .. ")", 2 ) 
+        error( "bad argument #3 (expected boolean, got " .. type( bIncludeFiles ) .. ")", 2 )
     end
     if bIncludeDirs ~= nil and type( bIncludeDirs ) ~= "boolean" then
-        error( "bad argument #4 (expected boolean, got " .. type( bIncludeDirs ) .. ")", 2 ) 
+        error( "bad argument #4 (expected boolean, got " .. type( bIncludeDirs ) .. ")", 2 )
     end
     bIncludeFiles = (bIncludeFiles ~= false)
     bIncludeDirs = (bIncludeDirs ~= false)
@@ -910,7 +940,7 @@ end
 settings.set( "shell.allow_startup", true )
 settings.set( "shell.allow_disk_startup", (commands == nil) )
 settings.set( "shell.autocomplete", true )
-settings.set( "edit.autocomplete", true ) 
+settings.set( "edit.autocomplete", true )
 settings.set( "edit.default_extension", "lua" )
 settings.set( "paint.default_extension", "nfp" )
 settings.set( "lua.autocomplete", true )
@@ -950,7 +980,7 @@ end
 
 -- Run the shell
 local ok, err = pcall( function()
-    parallel.waitForAny( 
+    parallel.waitForAny(
         function()
             local sShell
             if term.isColour() and settings.get( "bios.use_multishell" ) then

--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -308,24 +308,13 @@ function check( ... )
                 "bad argument #%d (expected %s; got %s)",
                 nArg, sExpectedTypes, sActualType
             )
-            return error( sErr )
+            return error( sErr, 2 )
         end
     end
 end
 
 function read( _sReplaceChar, _tHistory, _fnComplete, _sDefault )
-    if _sReplaceChar ~= nil and type( _sReplaceChar ) ~= "string" then
-        error( "bad argument #1 (expected string, got " .. type( _sReplaceChar ) .. ")", 2 )
-    end
-    if _tHistory ~= nil and type( _tHistory ) ~= "table" then
-        error( "bad argument #2 (expected table, got " .. type( _tHistory ) .. ")", 2 )
-    end
-    if _fnComplete ~= nil and type( _fnComplete ) ~= "function" then
-        error( "bad argument #3 (expected function, got " .. type( _fnComplete ) .. ")", 2 )
-    end
-    if _sDefault ~= nil and type( _sDefault ) ~= "string" then
-        error( "bad argument #4 (expected string, got " .. type( _sDefault ) .. ")", 2 )
-    end
+    check( _sReplaceChar, "string,nil", _tHistory, "table,nil", _fnComplete, "function,nil", _sDefault, "string,nil")
     term.setCursorBlink( true )
 
     local sLine
@@ -584,12 +573,7 @@ function read( _sReplaceChar, _tHistory, _fnComplete, _sDefault )
 end
 
 loadfile = function( _sFile, _tEnv )
-    if type( _sFile ) ~= "string" then
-        error( "bad argument #1 (expected string, got " .. type( _sFile ) .. ")", 2 )
-    end
-    if _tEnv ~= nil and type( _tEnv ) ~= "table" then
-        error( "bad argument #2 (expected table, got " .. type( _tEnv ) .. ")", 2 )
-    end
+    check( _sFile, "string", _tEnv, "table,nil" )
     local file = fs.open( _sFile, "r" )
     if file then
         local func, err = load( file.readAll(), fs.getName( _sFile ), "t", _tEnv )
@@ -600,9 +584,7 @@ loadfile = function( _sFile, _tEnv )
 end
 
 dofile = function( _sFile )
-    if type( _sFile ) ~= "string" then
-        error( "bad argument #1 (expected string, got " .. type( _sFile ) .. ")", 2 )
-    end
+    check( _sFile, "string" )
     local fnFile, e = loadfile( _sFile, _G )
     if fnFile then
         return fnFile()
@@ -613,12 +595,7 @@ end
 
 -- Install the rest of the OS api
 function os.run( _tEnv, _sPath, ... )
-    if type( _tEnv ) ~= "table" then
-        error( "bad argument #1 (expected table, got " .. type( _tEnv ) .. ")", 2 )
-    end
-    if type( _sPath ) ~= "string" then
-        error( "bad argument #2 (expected string, got " .. type( _sPath ) .. ")", 2 )
-    end
+    check( _tEnv, "table", _sPath, "string")
     local tArgs = table.pack( ... )
     local tEnv = _tEnv
     setmetatable( tEnv, { __index = _G } )
@@ -643,9 +620,7 @@ end
 
 local tAPIsLoading = {}
 function os.loadAPI( _sPath )
-    if type( _sPath ) ~= "string" then
-        error( "bad argument #1 (expected string, got " .. type( _sPath ) .. ")", 2 )
-    end
+    check( _sPath, "string" )
     local sName = fs.getName( _sPath )
     if sName:sub(-4) == ".lua" then
         sName = sName:sub(1,-5)
@@ -685,16 +660,14 @@ function os.loadAPI( _sPath )
 end
 
 function os.unloadAPI( _sName )
-    if type( _sName ) ~= "string" then
-        error( "bad argument #1 (expected string, got " .. type( _sName ) .. ")", 2 )
-    end
+    check( _sName, "string" )
     if _sName ~= "_G" and type(_G[_sName]) == "table" then
         _G[_sName] = nil
     end
 end
 
 function os.sleep( nTime )
-    sleep( nTime )
+    return sleep( nTime )
 end
 
 local nativeShutdown = os.shutdown
@@ -733,38 +706,17 @@ if http then
     end
 
     http.get = function( _url, _headers, _binary)
-        if type( _url ) ~= "string" then
-            error( "bad argument #1 (expected string, got " .. type( _url ) .. ")", 2 )
-        end
-        if _headers ~= nil and type( _headers ) ~= "table" then
-            error( "bad argument #2 (expected table, got " .. type( _headers ) .. ")", 2 )
-        end
+        check( _url, "string", _headers, "table,nil", _binary, "boolean,nil" )
         return wrapRequest( _url, nil, _headers, _binary)
     end
 
     http.post = function( _url, _post, _headers, _binary)
-        if type( _url ) ~= "string" then
-            error( "bad argument #1 (expected string, got " .. type( _url ) .. ")", 2 )
-        end
-        if type( _post ) ~= "string" then
-            error( "bad argument #2 (expected string, got " .. type( _post ) .. ")", 2 )
-        end
-        if _headers ~= nil and type( _headers ) ~= "table" then
-            error( "bad argument #3 (expected table, got " .. type( _headers ) .. ")", 2 )
-        end
+        check( _url, "string", _post, "string", _headers, "table,nil", _binary, "boolean,nil")
         return wrapRequest( _url, _post or "", _headers, _binary)
     end
 
     http.request = function( _url, _post, _headers, _binary )
-        if type( _url ) ~= "string" then
-            error( "bad argument #1 (expected string, got " .. type( _url ) .. ")", 2 )
-        end
-        if _post ~= nil and type( _post ) ~= "string" then
-            error( "bad argument #2 (expected string, got " .. type( _post ) .. ")", 2 )
-        end
-        if _headers ~= nil and type( _headers ) ~= "table" then
-            error( "bad argument #3 (expected table, got " .. type( _headers ) .. ")", 2 )
-        end
+        check( _url, "string", _post, "string,nil", _headers, "table,nil", _binary, "boolean,nil")
         local ok, err = nativeHTTPRequest( _url, _post, _headers, _binary )
         if not ok then
             os.queueEvent( "http_failure", _url, err )
@@ -788,18 +740,7 @@ end
 -- Install the lua part of the FS api
 local tEmpty = {}
 function fs.complete( sPath, sLocation, bIncludeFiles, bIncludeDirs )
-    if type( sPath ) ~= "string" then
-        error( "bad argument #1 (expected string, got " .. type( sPath ) .. ")", 2 )
-    end
-    if type( sLocation ) ~= "string" then
-        error( "bad argument #2 (expected string, got " .. type( sLocation ) .. ")", 2 )
-    end
-    if bIncludeFiles ~= nil and type( bIncludeFiles ) ~= "boolean" then
-        error( "bad argument #3 (expected boolean, got " .. type( bIncludeFiles ) .. ")", 2 )
-    end
-    if bIncludeDirs ~= nil and type( bIncludeDirs ) ~= "boolean" then
-        error( "bad argument #4 (expected boolean, got " .. type( bIncludeDirs ) .. ")", 2 )
-    end
+    check( sPath, "string", sLocation, "string", bIncludeFiles, "boolean,nil", bIncludeDirs, "boolean,nil")
     bIncludeFiles = (bIncludeFiles ~= false)
     bIncludeDirs = (bIncludeDirs ~= false)
     local sDir = sLocation

--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -296,20 +296,23 @@ function check( ... )
         local sParam = tArgs[ i ]
         local sActualType = type( sParam )
         local sExpectedTypes = tArgs[ i + 1 ]
-        local tExpectedTypes
-        if string.lower( sExpectedTypes ) ~= "any" then
-            tExpectedTypes = {}
-            for t in string.gmatch( sExpectedTypes, "[^,]+" ) do
-                tExpectedTypes[ t ] = true
-            end
-        end
 
-        if tExpectedTypes and not tExpectedTypes[ sActualType ] then
-            local sErr = string.format(
-                "bad argument #%d (expected %s; got %s)",
-                i / 2 + 1, sExpectedTypes, sActualType
-            )
-            return error( sErr, 2 )
+        if string.lower( sExpectedTypes ) ~= "any" then
+            local bFound = false
+            for t in string.gmatch( sExpectedTypes, "[^,]+" ) do
+                if t == sActualType then
+                    bFound = true
+                    break
+                end
+            end
+
+            if not bFound then
+                local sErr = string.format(
+                    "bad argument #%d (expected %s; got %s)",
+                    i / 2 + 1, sExpectedTypes, sActualType
+                )
+                return error( sErr, 2 )
+            end
         end
     end
 end


### PR DESCRIPTION
This PR adds a `check` utility function to `bios.lua`, used as such:
```Lua
local function add(x, y)
    check(x, "number", y, "number")
    return x + y
end
```

It's also possible to specify multiple possible types for certain arguments:
```Lua
check(x, "number,string,boolean", y, "string,table", z, "table,nil")
```
By including `nil` as a possible type, the argument becomes optional.
Intuitively, you can use `"any"` to mean any type:
```Lua
check(x, "string", y, "any", z, "boolean")
``` 
This is useful for maintaining the parameter numbering in the error output.

