### PR TITLE
Small cleanup in ComboMount

### DIFF
--- a/src/main/java/dan200/computercraft/ComputerCraft.java
+++ b/src/main/java/dan200/computercraft/ComputerCraft.java
@@ -79,10 +79,7 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -863,6 +860,7 @@ public class ComputerCraft
         // Return the combination of all the mounts found
         if( mounts.size() >= 2 )
         {
+            Collections.reverse( mounts );
             IMount[] mountArray = new IMount[ mounts.size() ];
             mounts.toArray( mountArray );
             return new ComboMount( mountArray );

--- a/src/main/java/dan200/computercraft/core/filesystem/ComboMount.java
+++ b/src/main/java/dan200/computercraft/core/filesystem/ComboMount.java
@@ -20,7 +20,7 @@ public class ComboMount implements IMount
 {    
     private IMount[] m_parts;
     
-    public ComboMount( IMount[] parts )
+    public ComboMount( IMount... parts )
     {
         m_parts = parts;
     }
@@ -30,9 +30,8 @@ public class ComboMount implements IMount
     @Override
     public boolean exists( @Nonnull String path ) throws IOException
     {
-        for( int i=m_parts.length-1; i>=0; --i )
+        for( IMount part : m_parts )
         {
-            IMount part = m_parts[i];
             if( part.exists( path ) )
             {
                 return true;
@@ -44,9 +43,8 @@ public class ComboMount implements IMount
     @Override
     public boolean isDirectory( @Nonnull String path ) throws IOException
     {
-        for( int i=m_parts.length-1; i>=0; --i )
+        for( IMount part : m_parts )
         {
-            IMount part = m_parts[i];
             if( part.isDirectory( path ) )
             {
                 return true;
@@ -61,16 +59,15 @@ public class ComboMount implements IMount
         // Combine the lists from all the mounts
         List<String> foundFiles = null;
         int foundDirs = 0;
-        for( int i=m_parts.length-1; i>=0; --i )
+        for ( IMount part : m_parts )
         {
-            IMount part = m_parts[i];
             if( part.exists( path ) && part.isDirectory( path ) )
             {
                 if( foundFiles == null )
                 {
                     foundFiles = new ArrayList<String>();
                 }
-                part.list(  path, foundFiles );
+                part.list( path, foundFiles );
                 foundDirs++;
             }
         }
@@ -101,9 +98,8 @@ public class ComboMount implements IMount
     @Override
     public long getSize( @Nonnull String path ) throws IOException
     {
-        for( int i=m_parts.length-1; i>=0; --i )
+        for( IMount part : m_parts )
         {
-            IMount part = m_parts[i];
             if( part.exists( path ) )
             {
                 return part.getSize( path );
@@ -116,9 +112,8 @@ public class ComboMount implements IMount
     @Override
     public InputStream openForRead( @Nonnull String path ) throws IOException
     {
-        for( int i=m_parts.length-1; i>=0; --i )
+        for( IMount part : m_parts )
         {
-            IMount part = m_parts[i];
             if( part.exists( path ) && !part.isDirectory( path ) )
             {
                 return part.openForRead( path );


### PR DESCRIPTION
I changed the constructor to take varargs instead of an array and changed all the loops to iterate forwards, so that the mount parts are prioritised in the order they are passed to the constructor, not in the reverse order.