### PR TITLE
Fix setting an invalid content-encoding header

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/http/HTTPRequest.java
+++ b/src/main/java/dan200/computercraft/core/apis/http/HTTPRequest.java
@@ -141,7 +141,6 @@ public class HTTPRequest implements HTTPTask.IHTTPTask
             if( m_postText != null )
             {
                 connection.setRequestProperty( "content-type", "application/x-www-form-urlencoded; charset=utf-8" );
-                connection.setRequestProperty( "content-encoding", "UTF-8" );
             }
             if( m_headers != null )
             {


### PR DESCRIPTION
I should really read the spec before adding these sorts of things. In this case the encoding refers to the compression algorithm used, rather than the text format.