### PR TITLE
Fix redstone not being propagated through solid blocks

### DIFF
--- a/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputerBase.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputerBase.java
@@ -76,7 +76,7 @@ public abstract class TileComputerBase extends TileGeneric
         unload();
         for( EnumFacing dir : EnumFacing.VALUES )
         {
-            RedstoneUtil.propogateRedstoneOutput( getWorld(), getPos(), dir );
+            RedstoneUtil.propagateRedstoneOutput( getWorld(), getPos(), dir );
         }
     }
 
@@ -380,7 +380,7 @@ public abstract class TileComputerBase extends TileGeneric
         updateBlock();
         for( EnumFacing dir : EnumFacing.VALUES )
         {
-            RedstoneUtil.propogateRedstoneOutput( getWorld(), getPos(), dir );
+            RedstoneUtil.propagateRedstoneOutput( getWorld(), getPos(), dir );
         }
     }
 

--- a/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtle.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtle.java
@@ -141,7 +141,7 @@ public class TileTurtle extends TileComputerBase
             // Just turn off any redstone we had on
             for( EnumFacing dir : EnumFacing.VALUES )
             {
-                RedstoneUtil.propogateRedstoneOutput( getWorld(), getPos(), dir );
+                RedstoneUtil.propagateRedstoneOutput( getWorld(), getPos(), dir );
             }
         }
     }

--- a/src/main/java/dan200/computercraft/shared/util/RedstoneUtil.java
+++ b/src/main/java/dan200/computercraft/shared/util/RedstoneUtil.java
@@ -68,9 +68,9 @@ public class RedstoneUtil
         return 0;
     }
 
-    public static void propogateRedstoneOutput( World world, BlockPos pos, EnumFacing side )
+    public static void propagateRedstoneOutput( World world, BlockPos pos, EnumFacing side )
     {
-        // Propogate ordinary output
+        // Propagate ordinary output
         IBlockState block = world.getBlockState( pos );
         BlockPos neighbourPos = pos.offset( side );
         IBlockState neighbour = world.getBlockState( neighbourPos );
@@ -79,7 +79,7 @@ public class RedstoneUtil
             world.neighborChanged( neighbourPos, block.getBlock(), pos );
             if( neighbour.getBlock().isNormalCube( neighbour, world, neighbourPos ) )
             {
-                world.notifyNeighborsOfStateExcept( neighbourPos, neighbour.getBlock(), side.getOpposite() );
+                world.notifyNeighborsOfStateExcept( neighbourPos, block.getBlock(), side.getOpposite() );
             }
         }
     }


### PR DESCRIPTION
`notifyBlockOfStateChange` and `notifyNeighborsOfStateExcept` expect the block which caused the redstone update, rather than the neighbour block.

I've also fixed the spelling of propagate. I'm happy to revert that if it makes the diff too noisy.

Fixes #393