### PR TITLE
Fix logPeripheralErrors not being set

### DIFF
--- a/src/main/java/dan200/computercraft/ComputerCraft.java
+++ b/src/main/java/dan200/computercraft/ComputerCraft.java
@@ -364,6 +364,7 @@ public class ComputerCraft
         http_blacklist = new AddressPredicate( Config.http_blacklist.getStringList() );
         disable_lua51_features = Config.disable_lua51_features.getBoolean();
         default_computer_settings = Config.default_computer_settings.getString();
+        logPeripheralErrors = Config.logPeripheralErrors.getBoolean();
 
         enableCommandBlock = Config.enableCommandBlock.getBoolean();
 


### PR DESCRIPTION
Apologies for the really small PR (and the underlying bug), but I didn't think it fitted on any of my existing branches.