### PR TITLE
Fix Bug in copy.lua, mkdir.lua and rename.lua

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/copy.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/copy.lua
@@ -11,7 +11,7 @@ local tFiles = fs.find( sSource )
 if #tFiles > 0 then
     for n,sFile in ipairs( tFiles ) do
         if fs.exists( sDest ) == true then
-            printError( "File exists" )
+            printError( "Destination exists" )
         elseif fs.isDir( sDest ) then
             fs.copy( sFile, fs.combine( sDest, fs.getName(sFile) ) )
         elseif #tFiles == 1 then

--- a/src/main/resources/assets/computercraft/lua/rom/programs/copy.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/copy.lua
@@ -10,7 +10,9 @@ local sDest = shell.resolve( tArgs[2] )
 local tFiles = fs.find( sSource )
 if #tFiles > 0 then
     for n,sFile in ipairs( tFiles ) do
-        if fs.isDir( sDest ) then
+        if fs.exists( sDest ) == true then
+            printError( "File exists" )
+        elseif fs.isDir( sDest ) then
             fs.copy( sFile, fs.combine( sDest, fs.getName(sFile) ) )
         elseif #tFiles == 1 then
             fs.copy( sFile, sDest )

--- a/src/main/resources/assets/computercraft/lua/rom/programs/mkdir.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/mkdir.lua
@@ -7,7 +7,7 @@ end
 local sNewDir = shell.resolve( tArgs[1] )
 
 if fs.exists( sNewDir ) == true then
-    printError( "File exists" )
+    printError( "Destination exists" )
     return
 end
 

--- a/src/main/resources/assets/computercraft/lua/rom/programs/mkdir.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/mkdir.lua
@@ -5,5 +5,11 @@ if #tArgs < 1 then
 end
 
 local sNewDir = shell.resolve( tArgs[1] )
+
+if fs.exists( sNewDir ) == true then
+    printError( "File exists" )
+    return
+end
+
 fs.makeDir( sNewDir )
 

--- a/src/main/resources/assets/computercraft/lua/rom/programs/rename.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/rename.lua
@@ -8,7 +8,7 @@ local sSource = shell.resolve( tArgs[1] )
 local sDest = shell.resolve( tArgs[2] )
 
 if fs.exists( sDest ) == true then
-    printError( "File exists" )
+    printError( "Destination exists" )
 end
 
 fs.move( sSource, sDest )

--- a/src/main/resources/assets/computercraft/lua/rom/programs/rename.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/rename.lua
@@ -6,4 +6,9 @@ end
 
 local sSource = shell.resolve( tArgs[1] )
 local sDest = shell.resolve( tArgs[2] )
+
+if fs.exists( sDest ) == true then
+    printError( "File exists" )
+end
+
 fs.move( sSource, sDest )


### PR DESCRIPTION
If the Destination exists, copy will crash with the Error "copy.lua:14: File exists". This PR fix this.

Edit:
I have noticed, that mkdir and rename have the same problem. This is also fixed in this PR.