### PR TITLE
Remove term.isColor() check from hello.lua

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/fun/hello.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/fun/hello.lua
@@ -1,5 +1,3 @@
-if term.isColour() then
-    term.setTextColour( 2^math.random(0,15) )
-end
+term.setTextColour( 2^math.random(0,15) )
 textutils.slowPrint( "Hello World!" )
 term.setTextColour( colours.white )


### PR DESCRIPTION
Now that normal Computer had term.setTextColor() and can change the colour to gray, we don't need this check anymore.