### PR TITLE
Make shell autocompletion works with \

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/shell.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/shell.lua
@@ -299,7 +299,7 @@ function shell.programs( _bIncludeHidden )
 end
 
 local function completeProgram( sLine )
-    if #sLine > 0 and string.sub( sLine, 1, 1 ) == "/" then
+    if #sLine > 0 and (string.sub( sLine, 1, 1 ) == "/" or string.sub( sLine, 1, 1 ) == "\\") then
         -- Add programs from the root
         return fs.complete( sLine, "", true, false )
 


### PR DESCRIPTION
The autocompletion of the shell works now, if the path start with \.