### PR TITLE
Fix fatal Bug with coroutine.yield

### DIFF
--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -177,13 +177,18 @@ if string.find( _HOST, "ComputerCraft" ) == 1 then
     end
 end
 
+local nativeyield = coroutine.yield
+function coroutine.yield( sFilter )
+    return nativeyield( sFilter )
+end
+
 -- Install lua parts of the os api
 function os.version()
     return "CraftOS 1.8"
 end
 
 function os.pullEventRaw( sFilter )
-    return coroutine.yield( sFilter )
+    return nativeyield( sFilter )
 end
 
 function os.pullEvent( sFilter )
@@ -683,7 +688,7 @@ local nativeShutdown = os.shutdown
 function os.shutdown()
     nativeShutdown()
     while true do
-        coroutine.yield()
+        nativeyield()
     end
 end
 
@@ -691,7 +696,7 @@ local nativeReboot = os.reboot
 function os.reboot()
     nativeReboot()
     while true do
-        coroutine.yield()
+        nativeyield()
     end
 end
 


### PR DESCRIPTION
It is possible to froze all Computers in the world by running this code:
```
coroutine.yield = function() end
while true do
end
```
To only Way to break the freeze is to rejoin the world. With this fix, the Computer who run this code will crash after a few seconds and everything works normal.