### PR TITLE
Palette improvements

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/TermAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/TermAPI.java
@@ -10,6 +10,7 @@ import dan200.computercraft.api.lua.ILuaContext;
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.core.computer.IComputerEnvironment;
 import dan200.computercraft.core.terminal.Terminal;
+import dan200.computercraft.shared.util.Colour;
 import dan200.computercraft.shared.util.Palette;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -78,7 +79,9 @@ public class TermAPI implements ILuaAPI
             "setPaletteColour",
             "setPaletteColor",
             "getPaletteColour",
-            "getPaletteColor"
+            "getPaletteColor",
+            "nativePaletteColor",
+            "nativePaletteColour"
         };
     }
     
@@ -306,6 +309,29 @@ public class TermAPI implements ILuaAPI
                     }
                 }
                 return null;
+            }
+            case 23:
+            case 24:
+            {
+                // nativePaletteColour/nativePaletteColor
+                int colour = 15 - parseColour( args );
+                Colour c = Colour.fromInt( colour );
+                if ( c != null )
+                {
+                    float[] rgb = c.getRGB();
+                    Object[] rgb8 = new Object[ rgb.length ];
+
+                    for ( int i = 0; i < rgb8.length; ++i )
+                    {
+                        rgb8[i] = (int) ( rgb[i] * 255.0f );
+                    }
+
+                    return rgb8;
+                }
+                else
+                {
+                    return null;
+                }
             }
             default:
             {

--- a/src/main/java/dan200/computercraft/core/apis/TermAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/TermAPI.java
@@ -277,10 +277,10 @@ public class TermAPI implements ILuaAPI
                 }
                 else
                 {
-                    double r = getReal( args, 1 );
-                    double g = getReal( args, 2 );
-                    double b = getReal( args, 3 );
-                    setColour( m_terminal, colour, r, g, b );
+                    int r = getInt( args, 1 );
+                    int g = getInt( args, 2 );
+                    int b = getInt( args, 3 );
+                    setColour( m_terminal, colour, r / 255.0, g / 255.0, b / 255.0 );
                 }
                 return null;
             }
@@ -293,7 +293,16 @@ public class TermAPI implements ILuaAPI
                 {
                     if ( m_terminal.getPalette() != null )
                     {
-                        return ArrayUtils.toObject( m_terminal.getPalette().getColour( colour ) );
+                        Palette palette = m_terminal.getPalette();
+                        double[] colours = palette.getColour( colour );
+                        Object[] colours8 = new Object[ colours.length ];
+
+                        for ( int i = 0; i < colours8.length; ++i )
+                        {
+                            colours8[ i ] = (int) ( colours[ i ] * 255.0 );
+                        }
+
+                        return colours8;
                     }
                 }
                 return null;

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
@@ -227,10 +227,10 @@ public class MonitorPeripheral implements IPeripheral
                 }
                 else
                 {
-                    double r = getReal( args, 1 );
-                    double g = getReal( args, 2 );
-                    double b = getReal( args, 3 );
-                    TermAPI.setColour( terminal, colour, r, g, b );
+                    int r = getInt( args, 1 );
+                    int g = getInt( args, 2 );
+                    int b = getInt( args, 3 );
+                    TermAPI.setColour( terminal, colour, r / 255.0, g / 255.0, b / 255.0 );
                 }
                 return null;
             }
@@ -245,7 +245,15 @@ public class MonitorPeripheral implements IPeripheral
 
                 if( palette != null )
                 {
-                    return ArrayUtils.toObject( palette.getColour( colour ) );
+                    double[] colours = palette.getColour( colour );
+                    Object[] colours8 = new Object[ colours.length ];
+
+                    for ( int i = 0; i < colours8.length; ++i )
+                    {
+                        colours8[ i ] = (int) ( colours[ i ] * 255.0 );
+                    }
+
+                    return colours8;
                 }
                 return null;
             }

--- a/src/main/java/dan200/computercraft/shared/util/Colour.java
+++ b/src/main/java/dan200/computercraft/shared/util/Colour.java
@@ -36,7 +36,8 @@ public enum Colour
         return null;
     }
     
-    public static Colour fromHex(int colour) {
+    public static Colour fromHex(int colour)
+    {
         for( Colour entry : VALUES )
         {
             if( entry.getHex() == colour ) return entry;

--- a/src/main/resources/assets/computercraft/lua/rom/apis/colors.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/colors.lua
@@ -48,19 +48,19 @@ function test( colors, color )
     if type( color ) ~= "number" then
         error( "bad argument #2 (expected number, got " .. type( color ) .. ")", 2 )
     end
-    return ((bit32.band(colors, color)) == color)
+    return bit32.band( colors, color ) == color
 end
 
 function rgb8( r, g, b )
     if type( r ) ~= "number" then
         error( "bad argument #1 (expected number, got " .. type( r ) .. ")", 2 )
-    elseif type(r) == "number" and g == nil and b == nil then
-        return bit32.band( bit32.rshift( r, 16 ), 0xFF ) / 255, bit32.band( bit32.rshift( r, 8 ), 0xFF ) / 255, bit32.band( r, 0xFF ) / 255
-    elseif type(r) == "number" and type(g) == "number" and type(b) == "number" then
+    elseif type( r ) == "number" and g == nil and b == nil then
+        return bit32.band( bit32.rshift( r, 16 ), 0xFF ), bit32.band( bit32.rshift( r, 8 ), 0xFF ), bit32.band( r, 0xFF )
+    elseif type( r ) == "number" and type( g ) == "number" and type( b ) == "number" then
         return 
-            bit32.lshift( bit32.band(r * 255, 0xFF), 16 ) +
-            bit32.lshift( bit32.band(g * 255, 0xFF), 8 ) +
-            bit32.band(b * 255, 0xFF)
+            bit32.lshift( bit32.band( r, 0xFF ), 16 ) +
+            bit32.lshift( bit32.band( g, 0xFF ), 8 ) +
+            bit32.band( b, 0xFF )
     elseif type( g ) ~= "number" then
         error( "bad argument #2 (expected number, got " .. type( g ) .. ")", 2 )
     elseif type( b ) ~= "number" then

--- a/src/main/resources/assets/computercraft/lua/rom/apis/colors.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/colors.lua
@@ -51,19 +51,25 @@ function test( colors, color )
     return bit32.band( colors, color ) == color
 end
 
-function rgb8( r, g, b )
+function packRGB( r, g, b )
     if type( r ) ~= "number" then
         error( "bad argument #1 (expected number, got " .. type( r ) .. ")", 2 )
-    elseif type( r ) == "number" and g == nil and b == nil then
-        return bit32.band( bit32.rshift( r, 16 ), 0xFF ), bit32.band( bit32.rshift( r, 8 ), 0xFF ), bit32.band( r, 0xFF )
-    elseif type( r ) == "number" and type( g ) == "number" and type( b ) == "number" then
-        return 
-            bit32.lshift( bit32.band( r, 0xFF ), 16 ) +
-            bit32.lshift( bit32.band( g, 0xFF ), 8 ) +
-            bit32.band( b, 0xFF )
-    elseif type( g ) ~= "number" then
+    end
+    if type( g ) ~= "number" then
         error( "bad argument #2 (expected number, got " .. type( g ) .. ")", 2 )
-    elseif type( b ) ~= "number" then
+    end
+    if type( b ) ~= "number" then
         error( "bad argument #3 (expected number, got " .. type( b ) .. ")", 2 )
     end
+    return
+        bit32.lshift( bit32.band( r, 0xFF ), 16 ) +
+        bit32.lshift( bit32.band( g, 0xFF ), 8 ) +
+        bit32.band( b, 0xFF )
+end
+
+function unpackRGB( rgb )
+    if type( rgb ) ~= "number" then
+        error( "bad argument #1 (expected number, got " .. type( rgb ) .. ")", 2 )
+    end
+    return bit32.band( bit32.rshift( rgb, 16 ), 0xFF ), bit32.band( bit32.rshift( rgb, 8 ), 0xFF ), bit32.band( rgb, 0xFF )
 end

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
@@ -290,7 +290,7 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
         
         local tCol
         if type( r ) == "number" and g == nil and b == nil then
-            tCol = { colours.rgb8( r ) }
+            tCol = { colours.unpackRGB( r ) }
             tPalette[ colour ] = tCol
         else
             if type( r ) ~= "number" then error( "bad argument #2 (expected number, got " .. type( r ) .. ")", 2 ) end

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
@@ -458,6 +458,9 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
         end
     end
 
+    window.nativePaletteColor = parent.nativePaletteColor
+    window.nativePaletteColour = parent.nativePaletteColour
+
     if bVisible then
         window.redraw()
     end

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
@@ -107,7 +107,7 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
 
     local function updatePalette()
         for k,v in pairs( tPalette ) do
-            parent.setPaletteColour( k, v[1], v[2], v[3] )
+            parent.setPaletteColour( k, math.floor( v[1] ), math.floor( v[2] ), math.floor( v[3] ) )
         end
     end
 
@@ -289,7 +289,7 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
         if type( colour ) ~= "number" then error( "bad argument #1 (expected number, got " .. type( colour ) .. ")", 2 ) end
         
         local tCol
-        if type(r) == "number" and g == nil and b == nil then
+        if type( r ) == "number" and g == nil and b == nil then
             tCol = { colours.rgb8( r ) }
             tPalette[ colour ] = tCol
         else
@@ -304,15 +304,14 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
         end
 
         if bVisible then
-            return parent.setPaletteColour( colour, tCol[1], tCol[2], tCol[3] )
+            return parent.setPaletteColour( colour, math.floor( tCol[1] ), math.floor( tCol[2] ), math.floor( tCol[3] ) )
         end
     end
 
     window.setPaletteColor = window.setPaletteColour
 
     function window.getPaletteColour( colour )
-        local tCol = tPalette[ colour ]
-        return tCol[1], tCol[2], tCol[3]
+        return table.unpack( tPalette[ colour ] )
     end
 
     window.getPaletteColor = window.getPaletteColour


### PR DESCRIPTION
After heavy debate, as seen in #343 and #197, I feel it's time for a new PR to fix some of the things that people were complaining about.

This includes:
- Functions like `term.(g|s)etPaletteColou?r` now deal with colours encoded as RGB8 instead of 0-1 range values.
- There is now a `term.nativePaletteColo(u)r( colour )`, as suggested by @SquidDev, which returns the default RGB8 values for a certain colour. @BombBloke I'd love to put this in `colours`, but writing this function in Java is a lot cleaner, since all the colours are stored in the `Colours` class.
- `colours.rgb8` is now neatly divided into `colours.packRGB` and `colours.unpackRGB`.

This is going to break a lot of stuff, but that's why we haven't released yet, after all.