### PR TITLE
Make lua.lua display all tables

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/lua.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/lua.lua
@@ -19,15 +19,25 @@ local tEnv = {
 setmetatable( tEnv, { __index = _ENV } )
 
 local function displayTable( tDisplay )
+    local tSeen = {}
     local sShow = "{\n"
-    for k, v in pairs( tDisplay ) do
+    for k, v in ipairs( tDisplay ) do
         sShow = sShow .. "  "
-        if type( v ) == "number" or type( v ) == "boolean" then
-            sShow = sShow .. k .. " = " .. tostring( v ) .. ",\n"
-        elseif type( v ) == "string" then
-            sShow = sShow ..k .. ' = "' .. v .. '",\n'
+        if type( v ) == "string" then
+            sShow = sShow .. '"' .. v .. '",\n'
         else
-            sShow = sShow .. k .. " = ".. type( v ) .. ",\n"
+            sShow = sShow .. tostring( v ) .. ",\n"
+        end
+        tSeen[k] = true
+    end
+    for k, v in pairs( tDisplay ) do
+        if not tSeen[k] then
+            sShow = sShow .. "  "
+            if type( v ) == "string" then
+                sShow = sShow ..k .. ' = "' .. v .. '",\n'
+            else
+                sShow = sShow .. k .. " = ".. tostring( v ) .. ",\n"
+            end
         end
     end
     sShow = sShow .. "}"

--- a/src/main/resources/assets/computercraft/lua/rom/programs/lua.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/lua.lua
@@ -18,6 +18,22 @@ local tEnv = {
 }
 setmetatable( tEnv, { __index = _ENV } )
 
+local function displayTable( tDisplay )
+    local sShow = "{\n"
+    for k, v in pairs( tDisplay ) do
+        sShow = sShow .. "  "
+        if type( v ) == "number" or type( v ) == "boolean" then
+            sShow = sShow .. k .. " = " .. tostring( v ) .. ",\n"
+        elseif type( v ) == "string" then
+            sShow = sShow ..k .. ' = "' .. v .. '",\n'
+        else
+            sShow = sShow .. k .. " = ".. type( v ) .. ",\n"
+        end
+    end
+    sShow = sShow .. "}"
+    return sShow
+end
+
 if term.isColour() then
     term.setTextColour( colours.yellow )
 end
@@ -78,7 +94,7 @@ while bRunning do
                         if ok then
                             print( serialised )
                         else
-                            print( tostring( value ) )
+                            print( displayTable( value ) )
                         end
                     end
                 else


### PR DESCRIPTION
At the moment, lua.lua can only display who are work with textutils.serialise(). With this PR, all table will be displayed.

Here's a screen how it looks, if textutils.serialise() not working:
![cclite_1504794266](https://user-images.githubusercontent.com/15185051/30168670-647cd0b4-93ea-11e7-8755-2cfb27c8035b.png)
