### PR TITLE
Fix a non-existent method being used in paintutils

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/apis/paintutils.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/paintutils.lua
@@ -35,7 +35,7 @@ function loadImage( sPath )
 
     if fs.exists( sPath ) then
         local file = io.open( sPath, "r" )
-        local sContent = file:readAll()
+        local sContent = file:read("*a")
         file:close()
         return parseImage( sContent ) -- delegate image parse to parseImage
     end


### PR DESCRIPTION
`:readAll()` was being used, but the handle came from the `io` library, which doesn't have such a thing.