### PR TITLE
Simple fix to os.sleep()

### DIFF
--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -676,7 +676,7 @@ function os.unloadAPI( _sName )
 end
 
 function os.sleep( nTime )
-    sleep( nTime )
+    return sleep( nTime )
 end
 
 local nativeShutdown = os.shutdown


### PR DESCRIPTION
If you call os.sleep() with a wrong argument, you will get a error in bios.lua line 679. By adding return, the error will show the line in the program, that calls os.sleep() with the wrong argument.