### PR TITLE
Fix background and tooltips not rendering within containers

### DIFF
--- a/src/main/java/dan200/computercraft/client/gui/GuiDiskDrive.java
+++ b/src/main/java/dan200/computercraft/client/gui/GuiDiskDrive.java
@@ -43,4 +43,12 @@ public class GuiDiskDrive extends GuiContainer
         int i1 = (height - ySize) / 2;
         drawTexturedModalRect(l, i1, 0, 0, xSize, ySize);
     }
+
+    @Override
+    public void drawScreen( int mouseX, int mouseY, float partialTicks)
+    {
+        drawDefaultBackground();
+        super.drawScreen(mouseX, mouseY, partialTicks);
+        renderHoveredToolTip(mouseX, mouseY);
+    }
 }

--- a/src/main/java/dan200/computercraft/client/gui/GuiPrinter.java
+++ b/src/main/java/dan200/computercraft/client/gui/GuiPrinter.java
@@ -51,4 +51,12 @@ public class GuiPrinter extends GuiContainer
             drawTexturedModalRect(startX + 34, startY + 21, 176, 0, 25, 45);
         }
     }
+
+    @Override
+    public void drawScreen( int mouseX, int mouseY, float partialTicks)
+    {
+        drawDefaultBackground();
+        super.drawScreen(mouseX, mouseY, partialTicks);
+        renderHoveredToolTip(mouseX, mouseY);
+    }
 }

--- a/src/main/java/dan200/computercraft/client/gui/GuiTurtle.java
+++ b/src/main/java/dan200/computercraft/client/gui/GuiTurtle.java
@@ -155,4 +155,12 @@ public class GuiTurtle extends GuiContainer
         
         drawSelectionSlot( advanced );
     }
+
+    @Override
+    public void drawScreen( int mouseX, int mouseY, float partialTicks)
+    {
+        drawDefaultBackground();
+        super.drawScreen(mouseX, mouseY, partialTicks);
+        renderHoveredToolTip(mouseX, mouseY);
+    }
 }


### PR DESCRIPTION
As of 1.12, the methods to draw the background and tooltip have to be called explicitly. Sorry. I'm really not sure how this hadn't been picked up on yet.