### PR TITLE
Fix check of write()

### DIFF
--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -206,8 +206,8 @@ function sleep( nTime )
 end
 
 function write( sText )
-    if sText ~= nil and type( sText ) ~= "string" and type( sText ) ~= "number" then
-        error( "bad argument #1 (expected string, got " .. type( sText ) .. ")", 2 ) 
+    if type( sText ) ~= "string" and type( sText ) ~= "number" then
+        error( "bad argument #1 (expected string or number, got " .. type( sText ) .. ")", 2 ) 
     end
 
     local w,h = term.getSize()        


### PR DESCRIPTION
if you call write(nil), you will get the error "bios.lua:229: bad argument: string expected, got nil", so nil is not a valid argument for write() and should be removed.