### PR TITLE
Use custom packet to play records, instead of using block events

### DIFF
--- a/src/main/java/dan200/computercraft/ComputerCraft.java
+++ b/src/main/java/dan200/computercraft/ComputerCraft.java
@@ -533,6 +533,11 @@ public class ComputerCraft
         networkEventChannel.sendToServer( encode( packet ) );
     }
 
+    public static void sendToAllAround( ComputerCraftPacket packet, NetworkRegistry.TargetPoint point )
+    {
+        networkEventChannel.sendToAllAround( encode( packet ), point );
+    }
+
     public static void handlePacket( ComputerCraftPacket packet, EntityPlayer player )
     {
         proxy.handlePacket( packet, player );

--- a/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
+++ b/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
@@ -51,7 +51,6 @@ import net.minecraftforge.client.event.RenderHandEvent;
 import net.minecraftforge.client.event.RenderPlayerEvent;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.fml.client.FMLClientHandler;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
@@ -315,17 +314,6 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
     }
 
     @Override
-    public void playRecord( SoundEvent record, String recordInfo, World world, BlockPos pos )
-    {
-        Minecraft mc = FMLClientHandler.instance().getClient();
-        world.playRecord( pos, record );
-        if( record != null )
-        {
-            mc.ingameGUI.setRecordPlayingMessage( recordInfo );
-        }
-    }
-
-    @Override
     public Object getDiskDriveGUI( InventoryPlayer inventory, TileDiskDrive drive )
     {
         return new GuiDiskDrive( inventory, drive );
@@ -384,6 +372,7 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
         {
             case ComputerCraftPacket.ComputerChanged:
             case ComputerCraftPacket.ComputerDeleted:
+            case ComputerCraftPacket.PlayRecord:
             {
                 // Packet from Server to Client
                 IThreadListener listener = Minecraft.getMinecraft();
@@ -435,6 +424,22 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
                 }
                 break;
             }
+            case ComputerCraftPacket.PlayRecord:
+            {
+                BlockPos pos = new BlockPos( packet.m_dataInt[ 0 ], packet.m_dataInt[ 1 ], packet.m_dataInt[ 2 ] );
+                Minecraft mc = Minecraft.getMinecraft();
+                if( packet.m_dataInt.length > 3 )
+                {
+                    SoundEvent sound = SoundEvent.REGISTRY.getObjectById( packet.m_dataInt[ 3 ] );
+                    mc.world.playRecord( pos, sound );
+                    mc.ingameGUI.setRecordPlayingMessage( packet.m_dataString[ 0 ] );
+                }
+                else
+                {
+                    mc.world.playRecord( pos, null );
+                }
+            }
+
         }
     }
 

--- a/src/main/java/dan200/computercraft/server/proxy/ComputerCraftProxyServer.java
+++ b/src/main/java/dan200/computercraft/server/proxy/ComputerCraftProxyServer.java
@@ -6,7 +6,9 @@
 
 package dan200.computercraft.server.proxy;
 
+import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.shared.computer.blocks.TileComputer;
+import dan200.computercraft.shared.network.ComputerCraftPacket;
 import dan200.computercraft.shared.peripheral.diskdrive.TileDiskDrive;
 import dan200.computercraft.shared.peripheral.printer.TilePrinter;
 import dan200.computercraft.shared.proxy.ComputerCraftProxyCommon;
@@ -63,11 +65,6 @@ public class ComputerCraftProxyServer extends ComputerCraftProxyCommon
     public Object getFixedWidthFontRenderer()
     {
         return null;
-    }
-    
-    @Override
-    public void playRecord( SoundEvent record, String recordInfo, World world, BlockPos pos )
-    {
     }
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
+++ b/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
@@ -337,22 +337,6 @@ public abstract class BlockGeneric extends Block implements
         return 0;
     }
 
-    @Override
-    @Deprecated
-    public boolean eventReceived( IBlockState state, World world, BlockPos pos, int eventID, int eventParameter )
-    {
-        if( world.isRemote )
-        {
-            TileEntity tile = world.getTileEntity( pos );
-            if( tile != null && tile instanceof TileGeneric )
-            {
-                TileGeneric generic = (TileGeneric)tile;
-                generic.onBlockEvent( eventID, eventParameter );
-            }
-        }
-        return true;
-    }
-
     @Nonnull
     @Override
     public final TileEntity createTileEntity( @Nonnull World world, @Nonnull IBlockState state )

--- a/src/main/java/dan200/computercraft/shared/common/TileGeneric.java
+++ b/src/main/java/dan200/computercraft/shared/common/TileGeneric.java
@@ -175,20 +175,6 @@ public abstract class TileGeneric extends TileEntity
     {
     }
 
-    public final void sendBlockEvent( int eventID )
-    {
-        sendBlockEvent( eventID, 0 );
-    }
-
-    public final void sendBlockEvent( int eventID, int eventParameter )
-    {
-        getWorld().addBlockEvent( getPos(), getWorld().getBlockState( getPos() ).getBlock(), eventID, eventParameter );
-    }
-
-    public void onBlockEvent( int eventID, int eventParameter )
-    {
-    }
-
     @Override
     public boolean shouldRefresh( World world, BlockPos pos, @Nonnull IBlockState oldState, @Nonnull IBlockState newState )
     {

--- a/src/main/java/dan200/computercraft/shared/network/ComputerCraftPacket.java
+++ b/src/main/java/dan200/computercraft/shared/network/ComputerCraftPacket.java
@@ -31,6 +31,7 @@ public class ComputerCraftPacket
     // To client
     public static final byte ComputerChanged = 7;
     public static final byte ComputerDeleted = 8;
+    public static final byte PlayRecord = 10;
 
     // Packet class
     public byte m_packetType;

--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/TileDiskDrive.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/TileDiskDrive.java
@@ -46,11 +46,6 @@ import static net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABI
 public class TileDiskDrive extends TilePeripheralBase
     implements IInventory, ITickable
 {
-    // Statics
-
-    private static final int BLOCKEVENT_PLAY_RECORD = 0;
-    private static final int BLOCKEVENT_STOP_RECORD = 1;
-
     private static class MountInfo
     {
         public String mountPath;
@@ -90,7 +85,7 @@ public class TileDiskDrive extends TilePeripheralBase
         {
             if( m_recordPlaying )
             {
-                sendBlockEvent( BLOCKEVENT_STOP_RECORD );
+                stopRecord();
             }
         }
     }
@@ -188,7 +183,7 @@ public class TileDiskDrive extends TilePeripheralBase
         // Music
         synchronized( this )
         {
-            if( m_recordPlaying != m_recordQueued || m_restartRecord )
+            if( !world.isRemote && m_recordPlaying != m_recordQueued || m_restartRecord )
             {
                 m_restartRecord = false;
                 if( m_recordQueued )
@@ -198,7 +193,7 @@ public class TileDiskDrive extends TilePeripheralBase
                     if( record != null )
                     {
                         m_recordPlaying = true;
-                        sendBlockEvent( BLOCKEVENT_PLAY_RECORD );
+                        playRecord();
                     }
                     else
                     {
@@ -207,7 +202,7 @@ public class TileDiskDrive extends TilePeripheralBase
                 }
                 else
                 {
-                    sendBlockEvent( BLOCKEVENT_STOP_RECORD );
+                    stopRecord();
                     m_recordPlaying = false;
                 }
             }
@@ -306,7 +301,7 @@ public class TileDiskDrive extends TilePeripheralBase
             // Stop music
             if( m_recordPlaying )
             {
-                sendBlockEvent( BLOCKEVENT_STOP_RECORD );
+                stopRecord();
                 m_recordPlaying = false;
                 m_recordQueued = false;
             }
@@ -655,25 +650,6 @@ public class TileDiskDrive extends TilePeripheralBase
             NBTTagCompound item = new NBTTagCompound();
             m_diskStack.writeToNBT( item );
             nbttagcompound.setTag( "item", item );
-        }
-    }
-
-    @Override
-    public void onBlockEvent( int eventID, int eventParameter )
-    {
-        super.onBlockEvent( eventID, eventParameter );
-        switch( eventID )
-        {
-            case BLOCKEVENT_PLAY_RECORD:
-            {
-                playRecord();
-                break;
-            }
-            case BLOCKEVENT_STOP_RECORD:
-            {
-                stopRecord();
-                break;
-            }
         }
     }
 

--- a/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
+++ b/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
@@ -145,7 +145,22 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
     }
 
     @Override
-    public abstract void playRecord( SoundEvent record, String recordInfo, World world, BlockPos pos );
+    public void playRecord( SoundEvent record, String recordInfo, World world, BlockPos pos )
+    {
+        ComputerCraftPacket packet = new ComputerCraftPacket();
+        packet.m_packetType = ComputerCraftPacket.PlayRecord;
+        if( record != null )
+        {
+            packet.m_dataInt = new int[] { pos.getX(), pos.getY(), pos.getZ(), SoundEvent.REGISTRY.getIDForObject( record ) };
+            packet.m_dataString = new String[] { recordInfo };
+        }
+        else
+        {
+            packet.m_dataInt = new int[] { pos.getX(), pos.getY(), pos.getZ() };
+        }
+
+        ComputerCraft.sendToAllPlayers( packet );
+    }
 
     @Override
     public abstract Object getDiskDriveGUI( InventoryPlayer inventory, TileDiskDrive drive );


### PR DESCRIPTION
Breaking a disk drive was not stopping the record being played as the block event never reached the client. Instead, we send a custom packet which starts/stops music at a given location.

We also remove all the plumbing for `eventReceived`/`sendBlockEvent` from the generic block/tile classes, as they are no longer used.

Closes #443