### PR TITLE
Remove tile before calling destroy

### DIFF
--- a/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
+++ b/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
@@ -111,13 +111,13 @@ public abstract class BlockGeneric extends Block implements
     public final void breakBlock( @Nonnull World world, @Nonnull BlockPos pos, @Nonnull IBlockState newState )
     {
         TileEntity tile = world.getTileEntity( pos );
+        super.breakBlock( world, pos, newState );
+        world.removeTileEntity( pos );
         if( tile != null && tile instanceof TileGeneric )
         {
             TileGeneric generic = (TileGeneric)tile;
             generic.destroy();
         }
-        super.breakBlock( world, pos, newState );
-        world.removeTileEntity( pos );
     }
 
     @Nonnull


### PR DESCRIPTION
This ensures that the tile will updating neighbouring blocks, and so the destroyed tile will not be wrapped as a peripheral. This should avoid problems like those mentioned in #442 occurring again, but is no means a full solution to that problem - see the issue for more details.

I've done a pretty through read-through of the related code to ensure this won't break anything (#443 will occur with or without this patch), as well as testing this in-game. *However*, it's possible I've missed something, so any additional verification would be appreciated.