### PR TITLE
[WIP] Only instantiate ServerComputer on tile ticks

### DIFF
--- a/src/main/java/dan200/computercraft/shared/computer/blocks/ComputerPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/ComputerPeripheral.java
@@ -10,7 +10,6 @@ import dan200.computercraft.api.lua.ILuaContext;
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
-import dan200.computercraft.shared.computer.core.ServerComputer;
 
 import javax.annotation.Nonnull;
 
@@ -18,9 +17,9 @@ public class ComputerPeripheral
     implements IPeripheral
 {
     private final String m_type;
-    private final ServerComputer m_computer;
+    private final ComputerProxy m_computer;
 
-    public ComputerPeripheral( String type, ServerComputer computer )
+    public ComputerPeripheral( String type, ComputerProxy computer )
     {
         m_type = type;
         m_computer = computer;

--- a/src/main/java/dan200/computercraft/shared/computer/blocks/ComputerProxy.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/ComputerProxy.java
@@ -1,0 +1,87 @@
+package dan200.computercraft.shared.computer.blocks;
+
+import dan200.computercraft.shared.computer.core.ServerComputer;
+
+/**
+ * A proxy object for computer objects, delegating to {@link ServerComputer} or {@link TileComputer} where appropriate.
+ */
+public abstract class ComputerProxy
+{
+    protected abstract TileComputerBase getTile();
+
+    public void turnOn()
+    {
+        TileComputerBase tile = getTile();
+        ServerComputer computer = tile.getServerComputer();
+        if( computer == null )
+        {
+            tile.m_startOn = true;
+        }
+        else
+        {
+            computer.turnOn();
+        }
+    }
+
+    public void shutdown()
+    {
+        TileComputerBase tile = getTile();
+        ServerComputer computer = tile.getServerComputer();
+        if( computer == null )
+        {
+            tile.m_startOn = false;
+        }
+        else
+        {
+            computer.shutdown();
+        }
+    }
+
+    public void reboot()
+    {
+        TileComputerBase tile = getTile();
+        ServerComputer computer = tile.getServerComputer();
+        if( computer == null )
+        {
+            tile.m_startOn = true;
+        }
+        else
+        {
+            computer.reboot();
+        }
+    }
+
+    public int assignID()
+    {
+        TileComputerBase tile = getTile();
+        ServerComputer computer = tile.getServerComputer();
+        if( computer == null )
+        {
+            return tile.m_computerID;
+        }
+        else
+        {
+            return computer.getID();
+        }
+    }
+
+    public boolean isOn()
+    {
+        ServerComputer computer = getTile().getServerComputer();
+        return computer != null && computer.isOn();
+    }
+
+    public String getLabel()
+    {
+        TileComputerBase tile = getTile();
+        ServerComputer computer = tile.getServerComputer();
+        if( computer == null )
+        {
+            return tile.m_label;
+        }
+        else
+        {
+            return computer.getLabel();
+        }
+    }
+}

--- a/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputer.java
@@ -19,14 +19,14 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 
 import javax.annotation.Nonnull;
-import java.util.List;
 
 public class TileComputer extends TileComputerBase
 {
     // Statics
 
     // Members
-
+    private ComputerProxy m_proxy;
+    
     public TileComputer()
     {
     }
@@ -46,6 +46,23 @@ public class TileComputer extends TileComputerBase
         );
         computer.setPosition( getPos() );
         return computer;
+    }
+
+    @Override
+    public ComputerProxy createProxy()
+    {
+        if( m_proxy == null )
+        {
+            m_proxy = new ComputerProxy()
+            {
+                @Override
+                protected TileComputerBase getTile()
+                {
+                    return TileComputer.this;
+                }
+            };
+        }
+        return m_proxy;
     }
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputerBase.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputerBase.java
@@ -386,6 +386,8 @@ public abstract class TileComputerBase extends TileGeneric
 
     protected abstract ServerComputer createComputer( int instanceID, int id );
 
+    public abstract ComputerProxy createProxy();
+
     // ITerminalTile
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/peripheral/common/DefaultPeripheralProvider.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/common/DefaultPeripheralProvider.java
@@ -45,12 +45,12 @@ public class DefaultPeripheralProvider implements IPeripheralProvider
                 {
                     if( !((TileTurtle)tile).hasMoved() )
                     {
-                        return new ComputerPeripheral( "turtle", computerTile.createServerComputer() );
+                        return new ComputerPeripheral( "turtle", computerTile.createProxy() );
                     }
                 }
                 else
                 {
-                    return new ComputerPeripheral( "computer", computerTile.createServerComputer() );
+                    return new ComputerPeripheral( "computer", computerTile.createProxy() );
                 }
             }
         }

--- a/src/main/java/dan200/computercraft/shared/pocket/items/ItemPocketComputer.java
+++ b/src/main/java/dan200/computercraft/shared/pocket/items/ItemPocketComputer.java
@@ -402,10 +402,10 @@ public class ItemPocketComputer extends Item implements IComputerItem, IMedia, I
     @Override
     public IMount createDataMount( @Nonnull ItemStack stack, @Nonnull World world )
     {
-        ServerComputer computer = createServerComputer( world, null, null, stack );
-        if( computer != null )
+        int id = getComputerID( stack );
+        if( id >= 0 )
         {
-            return computer.getRootMount();
+            return ComputerCraft.createSaveDirMount( world, "computer/" + id, ComputerCraft.computerSpaceLimit );
         }
         return null;
     }

--- a/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtle.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtle.java
@@ -10,6 +10,7 @@ import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.api.turtle.ITurtleAccess;
 import dan200.computercraft.api.turtle.ITurtleUpgrade;
 import dan200.computercraft.api.turtle.TurtleSide;
+import dan200.computercraft.shared.computer.blocks.ComputerProxy;
 import dan200.computercraft.shared.computer.blocks.TileComputerBase;
 import dan200.computercraft.shared.computer.core.ComputerFamily;
 import dan200.computercraft.shared.computer.core.IComputer;
@@ -43,7 +44,6 @@ import net.minecraftforge.items.wrapper.InvWrapper;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.List;
 
 import static net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY;
 
@@ -112,6 +112,12 @@ public class TileTurtle extends TileComputerBase
     protected ServerComputer createComputer( int instanceID, int id )
     {
         return createComputer( instanceID, id, ComputerCraft.terminalWidth_turtle, ComputerCraft.terminalHeight_turtle );
+    }
+
+    @Override
+    public ComputerProxy createProxy()
+    {
+        return m_brain.getProxy();
     }
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
@@ -12,6 +12,8 @@ import dan200.computercraft.api.lua.ILuaContext;
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.api.turtle.*;
+import dan200.computercraft.shared.computer.blocks.ComputerProxy;
+import dan200.computercraft.shared.computer.blocks.TileComputerBase;
 import dan200.computercraft.shared.computer.core.ComputerFamily;
 import dan200.computercraft.shared.computer.core.IComputer;
 import dan200.computercraft.shared.computer.core.ServerComputer;
@@ -104,6 +106,7 @@ public class TurtleBrain implements ITurtleAccess
     private static final int ANIM_DURATION = 8;
 
     private TileTurtle m_owner;
+    private ComputerProxy m_proxy;
 
     private LinkedList<TurtleCommandQueueEntry> m_commandQueue;
     private int m_commandsIssued;
@@ -167,6 +170,21 @@ public class TurtleBrain implements ITurtleAccess
     public TileTurtle getOwner()
     {
         return m_owner;
+    }
+
+    public ComputerProxy getProxy()
+    {
+        if(m_proxy == null) {
+            m_proxy = new ComputerProxy()
+            {
+                @Override
+                protected TileComputerBase getTile()
+                {
+                    return m_owner;
+                }
+            };
+        }
+        return m_proxy;
     }
 
     public ComputerFamily getFamily()


### PR DESCRIPTION
This implements a couple of the solutions proposed in #409 and #442. There are a couple of things to note:

 - Fixes #442 (whilst #453 also fixes it, I believe the two together form a more complete solution).
 - *Hopefully* fixes #409. I'm going to run this on Airwaves for a week or so to see if this actually works though.
 - Calling `.getID()` when the computer has no id **will not** allocate one. This is a regression from current behaviour, so it's worth discussing what the appropriate behaviour should be. This is pretty rare (it'll only ever happen within the first tick of a computer being placed), but should still be considered.

I'll remove the WIP mark once I've resolved the last two points.