### PR TITLE
Turn on ServerComputer instances if they have timed out

### DIFF
--- a/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputerBase.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputerBase.java
@@ -37,6 +37,7 @@ public abstract class TileComputerBase extends TileGeneric
     protected String m_label;
     protected boolean m_on;
     protected boolean m_startOn;
+    protected boolean m_fresh;
 
     protected TileComputerBase()
     {
@@ -45,6 +46,7 @@ public abstract class TileComputerBase extends TileGeneric
         m_label = null;
         m_on = false;
         m_startOn = false;
+        m_fresh = false;
     }
 
     @Override
@@ -213,7 +215,7 @@ public abstract class TileComputerBase extends TileGeneric
             ServerComputer computer = createServerComputer();
             if( computer != null )
             {
-                if( m_startOn )
+                if( m_startOn || (m_fresh && m_on) )
                 {
                     computer.turnOn();
                     m_startOn = false;
@@ -223,6 +225,7 @@ public abstract class TileComputerBase extends TileGeneric
                 {
                     updateOutput();
                 }
+                m_fresh = false;
                 m_computerID = computer.getID();
                 m_label = computer.getLabel();
                 m_on = computer.isOn();
@@ -471,6 +474,7 @@ public abstract class TileComputerBase extends TileGeneric
             {
                 ServerComputer computer = createComputer( m_instanceID, m_computerID );
                 ComputerCraft.serverComputerRegistry.add( m_instanceID, computer );
+                m_fresh = true;
                 changed = true;
             }
             if( changed )


### PR DESCRIPTION
This is an attempt at solving parts of #95. It is not a complete solution. Namely, it solves the case where a server is running but has no one online.

## Diagnosis
When a server has no players, some chunks (and so their tile entities) are kept alive but are not ticked. Consequently, each computer tile's `ServerComputer` times out and is removed from the registry. 

When the chunk starts to tick again, the tile tries to find the `ServerComputer`. But, as this no longer exists, it creates a new one. _However_, it does not turn on this new computer (as the `m_startOn` flag is `false`) and so the computer remains off.

## Solution
We add an additional flag `m_fresh` which determines whether a new `ServerComputer` has just been created. If so (and the computer was previously on) then this new computer will also be turned on when required.

## Further notes
This shares some similarities with SquidDev-CC/CCTweaks#136. Whilst the fix implemented there is different, it should also fix this one (and vice versa).