### PR TITLE
Fix BlockFaceShape not being overridden for turtles and peripherals

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/common/BlockCable.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/common/BlockCable.java
@@ -12,6 +12,7 @@ import dan200.computercraft.shared.peripheral.modem.TileCable;
 import net.minecraft.block.Block;
 import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.properties.PropertyEnum;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.Item;
@@ -250,5 +251,27 @@ public class BlockCable extends BlockPeripheralBase
     public TilePeripheralBase createTile( PeripheralType type )
     {
         return new TileCable();
+    }
+
+    @Override
+    @Deprecated
+    public final boolean isOpaqueCube( IBlockState state )
+    {
+        return false;
+    }
+
+    @Override
+    @Deprecated
+    public final boolean isFullCube( IBlockState state )
+    {
+        return false;
+    }
+
+    @Nonnull
+    @Override
+    @Deprecated
+    public BlockFaceShape getBlockFaceShape( IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing side )
+    {
+        return BlockFaceShape.UNDEFINED;
     }
 }

--- a/src/main/java/dan200/computercraft/shared/peripheral/common/BlockPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/common/BlockPeripheral.java
@@ -16,6 +16,7 @@ import dan200.computercraft.shared.peripheral.speaker.TileSpeaker;
 import dan200.computercraft.shared.util.DirectionUtil;
 import net.minecraft.block.properties.PropertyDirection;
 import net.minecraft.block.properties.PropertyEnum;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
@@ -611,5 +612,30 @@ public class BlockPeripheral extends BlockPeripheralBase
                 break;
             }
         }
+    }
+
+    @Override
+    @Deprecated
+    public final boolean isOpaqueCube( IBlockState state )
+    {
+        PeripheralType type = getPeripheralType( state );
+        return type == PeripheralType.DiskDrive || type == PeripheralType.Printer
+            || type == PeripheralType.Monitor || type == PeripheralType.AdvancedMonitor
+            || type == PeripheralType.Speaker;
+    }
+
+    @Override
+    @Deprecated
+    public final boolean isFullCube( IBlockState state )
+    {
+        return isOpaqueCube( state );
+    }
+
+    @Nonnull
+    @Override
+    @Deprecated
+    public BlockFaceShape getBlockFaceShape( IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing side )
+    {
+        return isOpaqueCube( state ) ? BlockFaceShape.SOLID : BlockFaceShape.UNDEFINED;
     }
 }

--- a/src/main/java/dan200/computercraft/shared/peripheral/common/BlockPeripheralBase.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/common/BlockPeripheralBase.java
@@ -32,20 +32,6 @@ public abstract class BlockPeripheralBase extends BlockDirectional
     protected abstract TilePeripheralBase createTile( PeripheralType type );
 
     @Override
-    @Deprecated
-    public final boolean isOpaqueCube( IBlockState state )
-    {
-        return false;
-    }
-
-    @Override
-    @Deprecated
-    public final boolean isFullCube( IBlockState state )
-    {
-        return false;
-    }
-
-    @Override
     public final boolean canPlaceBlockOnSide( @Nonnull World world, @Nonnull BlockPos pos, EnumFacing side )
     {
         return true; // ItemPeripheralBase handles this

--- a/src/main/java/dan200/computercraft/shared/peripheral/modem/BlockAdvancedModem.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/modem/BlockAdvancedModem.java
@@ -12,11 +12,12 @@ import dan200.computercraft.shared.peripheral.common.BlockPeripheralBase;
 import dan200.computercraft.shared.peripheral.common.TilePeripheralBase;
 import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.properties.PropertyDirection;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
 import javax.annotation.Nonnull;
@@ -113,5 +114,27 @@ public class BlockAdvancedModem extends BlockPeripheralBase
     public TilePeripheralBase createTile( PeripheralType type )
     {
         return new TileAdvancedModem();
+    }
+
+    @Override
+    @Deprecated
+    public final boolean isOpaqueCube( IBlockState state )
+    {
+        return false;
+    }
+
+    @Override
+    @Deprecated
+    public final boolean isFullCube( IBlockState state )
+    {
+        return false;
+    }
+
+    @Nonnull
+    @Override
+    @Deprecated
+    public BlockFaceShape getBlockFaceShape( IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing side )
+    {
+        return BlockFaceShape.UNDEFINED;
     }
 }

--- a/src/main/java/dan200/computercraft/shared/turtle/blocks/BlockTurtle.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/blocks/BlockTurtle.java
@@ -13,6 +13,7 @@ import dan200.computercraft.shared.computer.core.ComputerFamily;
 import dan200.computercraft.shared.util.DirectionUtil;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyDirection;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
@@ -73,6 +74,14 @@ public class BlockTurtle extends BlockComputerBase
     public boolean isFullCube( IBlockState state )
     {
         return false;
+    }
+
+    @Nonnull
+    @Override
+    @Deprecated
+    public BlockFaceShape getBlockFaceShape( IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing side )
+    {
+        return BlockFaceShape.UNDEFINED;
     }
 
     @Nonnull


### PR DESCRIPTION
This meant one could perform various illogical actions to non-full-blocks, such as connecting fences and placing paitings.

We also modify the behaviour of `isOpaqueCube` and `isFullCube` for peripherals, only returning false for the case of modems and cables. I'm happy to revert this change if needed, it just seemed a nice tweak to have.

## Broken 1.12 behaviour
![image](https://user-images.githubusercontent.com/4346137/30532497-85047a98-9c4c-11e7-9385-9318632016af.png)


## Current 1.11.2 behaviour
![image](https://user-images.githubusercontent.com/4346137/30532498-87747698-9c4c-11e7-9545-8572885f74a1.png)

## New 1.12 behaviour
![image](https://user-images.githubusercontent.com/4346137/30532508-9270ea72-9c4c-11e7-8151-1ee2e60b207a.png)

Sorry about the slightly skew-whiff screenshots.
