### PR TITLE
Add turtle.getEquipLeft() and turtle.getEquipRight()

### DIFF
--- a/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
@@ -11,6 +11,7 @@ import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.turtle.ITurtleAccess;
 import dan200.computercraft.api.turtle.ITurtleCommand;
 import dan200.computercraft.api.turtle.TurtleSide;
+import dan200.computercraft.api.turtle.ITurtleUpgrade;
 import dan200.computercraft.core.apis.IAPIEnvironment;
 import dan200.computercraft.core.apis.ILuaAPI;
 import dan200.computercraft.shared.turtle.core.*;
@@ -107,6 +108,8 @@ public class TurtleAPI implements ILuaAPI
             "inspectUp",
             "inspectDown",
             "getItemDetail",
+            "getEquipLeft",
+            "getEquipRight",
         };
     }
     
@@ -445,6 +448,40 @@ public class TurtleAPI implements ILuaAPI
                 {
                     return new Object[] { null };
                 }
+            }
+            case 42:
+            {
+                //getEquipLeft
+                ITurtleUpgrade upgrade = m_turtle.getUpgrade( TurtleSide.Left );
+                if( upgrade != null ) 
+                {
+                    ItemStack stack = upgrade.getCraftingItem();
+                    Item item = stack.getItem();
+                    String name = Item.REGISTRY.getNameForObject( item ).toString();
+                    return new Object[] { name };
+                }
+                else 
+                {
+                    return new Object[] { null };
+                }
+                    
+            }
+            case 43:
+            {
+                //getEquipRight
+                ITurtleUpgrade upgrade = m_turtle.getUpgrade( TurtleSide.Right );
+                if( upgrade != null ) 
+                {
+                    ItemStack stack = upgrade.getCraftingItem();
+                    Item item = stack.getItem();
+                    String name = Item.REGISTRY.getNameForObject( item ).toString();
+                    return new Object[] { name };
+                }
+                else 
+                {
+                    return new Object[] { null };
+                }
+                    
             }
             default:
             {

--- a/src/main/resources/assets/computercraft/lua/rom/help/turtle.txt
+++ b/src/main/resources/assets/computercraft/lua/rom/help/turtle.txt
@@ -43,6 +43,8 @@ turtle.getFuelLevel()
 turtle.getFuelLimit()
 turtle.refuel( [quantity] )
 turtle.craft( [quantity] ) (requires Crafty Turtle)
+turtle.getEquipLeft()
+turtle.getEquipRight()
 
 Events fired by the Turtle API:
 "turtle_inventory" when any of the items in the inventory are changed. Use comparison operations to inspect the changes.


### PR DESCRIPTION
This functions allows you to get to equipped Item.

I know, this is already possible with unequip the Item, get Item Detail and reequip it. But the current methode has 2 Problems in my Opinion:
1. The User see, that the Item is unequip and reequip.
2. It will not work, if the Turtle had a full Inventory.