### PR TITLE
Only send terminal state to interacting players

### DIFF
--- a/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
+++ b/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
@@ -383,6 +383,7 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
         switch( packet.m_packetType )
         {
             case ComputerCraftPacket.ComputerChanged:
+            case ComputerCraftPacket.ComputerTerminalChanged:
             case ComputerCraftPacket.ComputerDeleted:
             {
                 // Packet from Server to Client
@@ -417,6 +418,7 @@ public class ComputerCraftProxyClient extends ComputerCraftProxyCommon
             // Packets from Server to Client //
             ///////////////////////////////////
             case ComputerCraftPacket.ComputerChanged:
+            case ComputerCraftPacket.ComputerTerminalChanged:
             {
                 int instanceID = packet.m_dataInt[ 0 ];
                 if( !ComputerCraft.clientComputerRegistry.contains( instanceID ) )

--- a/src/main/java/dan200/computercraft/shared/computer/core/ClientComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/core/ClientComputer.java
@@ -153,11 +153,8 @@ public class ClientComputer extends ClientTerminal
         ComputerCraft.sendToServer( packet );
     }
 
-    @Override
-    public void readDescription( NBTTagCompound nbttagcompound )
+    private void readComputerDescription( NBTTagCompound nbttagcompound )
     {
-        super.readDescription( nbttagcompound );
-
         int oldID = m_computerID;
         String oldLabel = m_label;
         boolean oldOn = m_on;
@@ -189,10 +186,11 @@ public class ClientComputer extends ClientTerminal
         switch( packet.m_packetType )
         {
             case ComputerCraftPacket.ComputerChanged:
-            {
+                readComputerDescription( packet.m_dataNBT );
+                break;
+            case ComputerCraftPacket.ComputerTerminalChanged:
                 readDescription( packet.m_dataNBT );
                 break;
-            }
         }
     }
 }

--- a/src/main/java/dan200/computercraft/shared/computer/core/ServerComputerRegistry.java
+++ b/src/main/java/dan200/computercraft/shared/computer/core/ServerComputerRegistry.java
@@ -33,7 +33,7 @@ public class ServerComputerRegistry extends ComputerRegistry<ServerComputer>
                 computer.update();
                 if( computer.hasTerminalChanged() || computer.hasOutputChanged() )
                 {
-                    computer.broadcastState();
+                    computer.broadcastState(false);
                 }
             }
         }
@@ -44,7 +44,7 @@ public class ServerComputerRegistry extends ComputerRegistry<ServerComputer>
     {
         //System.out.println( "ADD SERVER COMPUTER " + instanceID );
         super.add( instanceID, computer );
-        computer.broadcastState();
+        computer.broadcastState(true);
         //System.out.println( getComputers().size() + " SERVER COMPUTERS" );
     }
 

--- a/src/main/java/dan200/computercraft/shared/network/ComputerCraftPacket.java
+++ b/src/main/java/dan200/computercraft/shared/network/ComputerCraftPacket.java
@@ -30,7 +30,8 @@ public class ComputerCraftPacket
 
     // To client
     public static final byte ComputerChanged = 7;
-    public static final byte ComputerDeleted = 8;
+    public static final byte ComputerTerminalChanged = 8;
+    public static final byte ComputerDeleted = 9;
 
     // Packet class
     public byte m_packetType;

--- a/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
+++ b/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
@@ -18,6 +18,8 @@ import dan200.computercraft.shared.computer.blocks.BlockComputer;
 import dan200.computercraft.shared.computer.blocks.TileCommandComputer;
 import dan200.computercraft.shared.computer.blocks.TileComputer;
 import dan200.computercraft.shared.computer.core.ComputerFamily;
+import dan200.computercraft.shared.computer.core.IComputer;
+import dan200.computercraft.shared.computer.core.IContainerComputer;
 import dan200.computercraft.shared.computer.core.ServerComputer;
 import dan200.computercraft.shared.computer.inventory.ContainerComputer;
 import dan200.computercraft.shared.computer.items.ItemCommandComputer;
@@ -58,6 +60,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.init.Items;
+import net.minecraft.inventory.Container;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemRecord;
 import net.minecraft.item.ItemStack;
@@ -70,6 +73,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.event.entity.player.PlayerContainerEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -644,6 +648,21 @@ public abstract class ComputerCraftProxyCommon implements IComputerCraftProxy
             if( event.getModID().equals( ComputerCraft.MOD_ID ) )
             {
                 ComputerCraft.syncConfig();
+            }
+        }
+
+        @SubscribeEvent
+        public void onContainerOpen( PlayerContainerEvent.Open event )
+        {
+            // If we're opening a computer container then broadcast the terminal state
+            Container container = event.getContainer();
+            if( container instanceof IContainerComputer )
+            {
+                IComputer computer = ((IContainerComputer) container).getComputer();
+                if( computer instanceof ServerComputer )
+                {
+                    ((ServerComputer) computer).sendTerminalState( event.getEntityPlayer() );
+                }
             }
         }
     }


### PR DESCRIPTION
This splits the computer state (blinking, label, etc...) and terminal state into two separate packets. When a computer changes, the computer state is sent to all players and the terminal state is sent to players who are currently using the computer. This reduces network usage by a substantial amount. 

CCTweaks has employed a similar optimisation for a while now, and not seen any adverse effects.