### PR TITLE
Add simple JEI integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,28 +41,16 @@ minecraft {
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 
+repositories {
+    maven {
+        name = "JEI"
+        url  = "http://dvs1.progwml6.com/files/maven" 
+    }
+}
+
 dependencies {
-    // you may put jars on which you depend on in ./libs
-    // or you may define them like so..
-    //compile "some.group:artifact:version:classifier"
-    //compile "some.group:artifact:version"
-
-    // real examples
-    //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
-    //compile 'com.googlecode.efficient-java-matrix-library:ejml:0.24' // adds ejml to the dev env
-
-    // the 'provided' configuration is for optional dependencies that exist at compile-time but might not at runtime.
-    //provided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-
-    // the deobf configurations:  'deobfCompile' and 'deobfProvided' are the same as the normal compile and provided,
-    // except that these dependencies get remapped to your current MCP mappings
-    //deobfCompile 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-    //deobfProvided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-
-    // for more info...
-    // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
-    // http://www.gradle.org/docs/current/userguide/dependency_management.html
-
+    deobfProvided "mezz.jei:jei_1.12:4.7.5.86:api"
+    runtime "mezz.jei:jei_1.12:4.7.5.86"
 }
 
 jar {

--- a/src/main/java/dan200/computercraft/shared/integration/JEIComputerCraft.java
+++ b/src/main/java/dan200/computercraft/shared/integration/JEIComputerCraft.java
@@ -1,0 +1,99 @@
+package dan200.computercraft.shared.integration;
+
+import dan200.computercraft.ComputerCraft;
+import dan200.computercraft.api.pocket.IPocketUpgrade;
+import dan200.computercraft.api.turtle.ITurtleUpgrade;
+import dan200.computercraft.api.turtle.TurtleSide;
+import dan200.computercraft.shared.media.items.ItemDiskLegacy;
+import dan200.computercraft.shared.pocket.items.ItemPocketComputer;
+import dan200.computercraft.shared.turtle.items.ITurtleItem;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.IModRegistry;
+import mezz.jei.api.ISubtypeRegistry;
+import mezz.jei.api.ISubtypeRegistry.ISubtypeInterpreter;
+import mezz.jei.api.JEIPlugin;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+@JEIPlugin
+public class JEIComputerCraft implements IModPlugin
+{
+    @Override
+    public void registerItemSubtypes( ISubtypeRegistry subtypeRegistry )
+    {
+        subtypeRegistry.registerSubtypeInterpreter( Item.getItemFromBlock( ComputerCraft.Blocks.turtle ), turtleSubtype );
+        subtypeRegistry.registerSubtypeInterpreter( Item.getItemFromBlock( ComputerCraft.Blocks.turtleExpanded ), turtleSubtype );
+        subtypeRegistry.registerSubtypeInterpreter( Item.getItemFromBlock( ComputerCraft.Blocks.turtleAdvanced ), turtleSubtype );
+
+        subtypeRegistry.registerSubtypeInterpreter( ComputerCraft.Items.pocketComputer, pocketSubtype );
+
+        subtypeRegistry.registerSubtypeInterpreter( ComputerCraft.Items.disk, diskSubtype );
+        subtypeRegistry.registerSubtypeInterpreter( ComputerCraft.Items.diskExpanded, diskSubtype );
+    }
+
+    @Override
+    public void register( IModRegistry registry )
+    {
+        // Hide treasure disks from the ingredient list
+        registry.getJeiHelpers().getIngredientBlacklist()
+            .addIngredientToBlacklist( new ItemStack( ComputerCraft.Items.treasureDisk, OreDictionary.WILDCARD_VALUE ) );
+    }
+
+    /**
+     * Distinguishes turtles by upgrades and family
+     */
+    private static final ISubtypeInterpreter turtleSubtype = stack -> {
+        Item item = stack.getItem();
+        if( !(item instanceof ITurtleItem) ) return "";
+
+        ITurtleItem turtle = (ITurtleItem) item;
+        StringBuilder name = new StringBuilder();
+
+        name.append( turtle.getFamily( stack ).toString() );
+
+        // Add left and right upgrades to the identifier
+        ITurtleUpgrade left = turtle.getUpgrade( stack, TurtleSide.Left );
+        name.append( '|' );
+        if( left != null ) name.append( left.getUpgradeID() );
+
+        ITurtleUpgrade right = turtle.getUpgrade( stack, TurtleSide.Right );
+        name.append( '|' );
+        if( right != null ) name.append( '|' ).append( right.getUpgradeID() );
+
+        return name.toString();
+    };
+
+    /**
+     * Distinguishes pocket computers by upgrade and family
+     */
+    private static final ISubtypeInterpreter pocketSubtype = stack -> {
+        Item item = stack.getItem();
+        if( !(item instanceof ItemPocketComputer) ) return "";
+
+        ItemPocketComputer pocket = (ItemPocketComputer) item;
+        StringBuilder name = new StringBuilder();
+
+        name.append( pocket.getFamily( stack ).toString() );
+
+        // Add the upgrade to the identifier
+        IPocketUpgrade upgrade = pocket.getUpgrade( stack );
+        name.append( '|' );
+        if( upgrade != null ) name.append( upgrade.getUpgradeID() );
+
+        return name.toString();
+    };
+
+    /**
+     * Distinguishes disks by colour
+     */
+    private static final ISubtypeInterpreter diskSubtype = stack -> {
+        Item item = stack.getItem();
+        if( !(item instanceof ItemDiskLegacy) ) return "";
+
+        ItemDiskLegacy disk = (ItemDiskLegacy) item;
+
+        int colour = disk.getColour( stack );
+        return colour == -1 ? "" : String.format( "%06x", colour );
+    };
+}


### PR DESCRIPTION
I know that mod integration is something that ComputerCraft normally steers clear of, but JEI is sufficiently ubiquitous that this is probably worth it.

JEI compares items simply by item name and damage value, ignoring NBT. This means many recipes do not function correctly. For instance, viewing the recipe of a Melee Turtle will display all upgrade recipes. This PR fixes this:

 - Pocket computers and turtles are distinguished by upgrades and computer family.
 - Disks are distinguished by colour.
 - Hide treasure disks from the item list