### PR TITLE
Fix Bug in Paint and Edit

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/edit.lua
@@ -16,7 +16,7 @@ end
 -- Create .lua files by default
 if not fs.exists( sPath ) and not string.find( sPath, "%." ) then
     local sExtension = settings.get("edit.default_extension", "" )
-    if sExtension ~= "" then
+    if sExtension ~= "" and type( sExtension ) == "string" then
         sPath = sPath .. "." .. sExtension
     end
 end

--- a/src/main/resources/assets/computercraft/lua/rom/programs/fun/advanced/paint.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/fun/advanced/paint.lua
@@ -47,7 +47,7 @@ end
 -- Create .nfp files by default
 if not fs.exists( sPath ) and not string.find( sPath, "%." ) then
     local sExtension = settings.get("paint.default_extension", "" )
-    if sExtension ~= "" then
+    if sExtension ~= "" and type( sExtension ) == "string" then
         sPath = sPath .. "." .. sExtension
     end
 end


### PR DESCRIPTION
Paint and Edit will now no longer crash, if the setting for the extension is not a string.