### PR TITLE
Propagate errors arising from API loading

### DIFF
--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -644,14 +644,12 @@ function os.loadAPI( _sPath )
     if fnAPI then
         local ok, err = pcall( fnAPI )
         if not ok then
-            printError( err )
             tAPIsLoading[sName] = nil
-            return false
+            return error( "Failed to load API " .. sName .. " due to " .. err, 1 )
         end
     else
-        printError( err )
         tAPIsLoading[sName] = nil
-        return false
+        return error( "Failed to load API " .. sName .. " due to " .. err, 1 )
     end
     
     local tAPI = {}


### PR DESCRIPTION
This (admittedly backwards-incompatible commit, but read on) changes the behaviour of `os.loadAPI` to propagate errors that happen during the loading of APIs. The old behaviour would lead to objectively worse error messages, by delaying the reporting of errors. As an example, consider the following code.

```
os.loadAPI("foo") -- foo doesn't exist
foo.bar()
```
In this case, the code will end up printing something like
```
File not found
file:2: attempt to index global 'foo' (a nil value)
```

An inexperienced programmer could easily be stumped by the fact their code is failing in the wrong place - what would be expected is that the error raised by `loadfile` would be propagated upwards from `os.loadAPI`, thus halting in the first line with an useful error message.
