### PR TITLE
Fix getCollisionBoundingBox not using all AABBs

### DIFF
--- a/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
+++ b/src/main/java/dan200/computercraft/shared/common/BlockGeneric.java
@@ -241,10 +241,9 @@ public abstract class BlockGeneric extends Block implements
             if( collision.size() > 0 )
             {
                 AxisAlignedBB aabb = collision.get( 0 );
-                for (int i=1; i<collision.size(); ++i )
+                for( int i = 1; i < collision.size(); i++ )
                 {
-                    AxisAlignedBB other = collision.get( 1 );
-                    aabb = aabb.union( other );
+                    aabb = aabb.union( collision.get( i ) );
                 }
                 return aabb;
             }


### PR DESCRIPTION
Closes #493 

This might be nicer with `.stream().reduce(AxisAlignedBB::union).get()` but let's keep it simple :).