### PR TITLE
Fix ComputerCraftAPI.getWirelessNetwork() failing

### DIFF
--- a/src/main/java/dan200/computercraft/ComputerCraft.java
+++ b/src/main/java/dan200/computercraft/ComputerCraft.java
@@ -766,7 +766,7 @@ public class ComputerCraft
         return upgrades;
     }
 
-    public IPacketNetwork getWirelessNetwork()
+    public static IPacketNetwork getWirelessNetwork()
     {
         return WirelessNetwork.getUniversal();
     }


### PR DESCRIPTION
I've got to admit, it is super embarrassing that a) I didn't notice this when testing and b) no one else has noticed until now. Sorry.