### PR TITLE
Fix turtle overlay not being rendered in items

### DIFF
--- a/src/main/java/dan200/computercraft/client/render/TurtleSmartItemModel.java
+++ b/src/main/java/dan200/computercraft/client/render/TurtleSmartItemModel.java
@@ -146,7 +146,7 @@ public class TurtleSmartItemModel implements IBakedModel, IResourceManagerReload
         ModelResourceLocation baseModelLocation = TileEntityTurtleRenderer.getTurtleModel( combo.m_family, combo.m_colour );
         ModelResourceLocation overlayModelLocation = TileEntityTurtleRenderer.getTurtleOverlayModel( combo.m_family, combo.m_overlay, combo.m_christmas );
         IBakedModel baseModel = modelManager.getModel( baseModelLocation );
-        IBakedModel overlayModel = (overlayModelLocation != null) ? modelManager.getModel( baseModelLocation ) : null;
+        IBakedModel overlayModel = (overlayModelLocation != null) ? modelManager.getModel( overlayModelLocation ) : null;
         Pair<IBakedModel, Matrix4f> leftModel = (combo.m_leftUpgrade != null) ? combo.m_leftUpgrade.getModel( null, TurtleSide.Left ) : null;
         Pair<IBakedModel, Matrix4f> rightModel = (combo.m_rightUpgrade != null) ? combo.m_rightUpgrade.getModel( null, TurtleSide.Right ) : null;
         if( leftModel != null && rightModel != null )


### PR DESCRIPTION
The base model was being used twice, instead of the overlay model. Consequently elf turtles were being rendered as normal ones inside the inventory.