### PR TITLE
Fix advanced monitor recipe.

### DIFF
--- a/src/main/resources/assets/computercraft/recipes/advanced_monitor.json
+++ b/src/main/resources/assets/computercraft/recipes/advanced_monitor.json
@@ -9,5 +9,5 @@
         "#": { "item": "minecraft:gold_ingot" },
         "G": { "item": "minecraft:glass_pane" }
     },
-    "result": { "item": "computercraft:peripheral", "data": 4 }
+    "result": { "item": "computercraft:peripheral", "data": 4, "count": 4 }
 }


### PR DESCRIPTION
Fix recipe to create 4 monitors.

It was set to create only 1 monitor in 1.12 port - this fixes it.