### PR TITLE
[WIP] World thread-safety

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/common/TilePeripheralBase.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/common/TilePeripheralBase.java
@@ -24,7 +24,7 @@ public abstract class TilePeripheralBase extends TileGeneric
 {
     // Statics
 
-    private EnumFacing m_dir;
+    protected EnumFacing m_dir;
     private int m_anim;
     private boolean m_changed;
 
@@ -94,6 +94,11 @@ public abstract class TilePeripheralBase extends TileGeneric
 
     @Override
     public EnumFacing getDirection()
+    {
+        return m_dir;
+    }
+
+    public EnumFacing getCachedDirection()
     {
         return m_dir;
     }

--- a/src/main/java/dan200/computercraft/shared/peripheral/modem/TileAdvancedModem.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/modem/TileAdvancedModem.java
@@ -8,8 +8,8 @@ package dan200.computercraft.shared.peripheral.modem;
 
 import dan200.computercraft.api.peripheral.IPeripheral;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
@@ -40,7 +40,7 @@ public class TileAdvancedModem extends TileModemBase
         @Override
         public Vec3d getPosition()
         {
-            BlockPos pos = m_entity.getPos().offset( m_entity.getDirection() );
+            BlockPos pos = m_entity.getPos().offset( m_entity.getCachedDirection() );
             return new Vec3d( (double)pos.getX(), (double)pos.getY(), (double)pos.getZ() );
         }
 
@@ -57,9 +57,40 @@ public class TileAdvancedModem extends TileModemBase
     }
 
     // Members
+    private boolean m_hasDirection = false;
 
     public TileAdvancedModem()
     {
+        m_dir = EnumFacing.DOWN;
+    }
+
+    @Override
+    public void onLoad()
+    {
+        super.onLoad();
+        updateDirection();
+    }
+
+    @Override
+    public void updateContainingBlockInfo()
+    {
+        m_hasDirection = false;
+    }
+
+    @Override
+    public void update()
+    {
+        super.update();
+        updateDirection();
+    }
+
+    private void updateDirection()
+    {
+        if( !m_hasDirection )
+        {
+            m_hasDirection = true;
+            m_dir = getDirection();
+        }
     }
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/peripheral/modem/TileCable.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/modem/TileCable.java
@@ -99,7 +99,7 @@ public class TileCable extends TileModemBase
         @Override
         public Vec3d getPosition()
         {
-            EnumFacing direction = m_entity.getDirection();
+            EnumFacing direction = m_entity.getCachedDirection();
             BlockPos pos = m_entity.getPos().offset( direction );
             return new Vec3d( (double)pos.getX() + 0.5, (double)pos.getY() + 0.5, (double)pos.getZ() + 0.5 );
         }
@@ -244,6 +244,8 @@ public class TileCable extends TileModemBase
     private boolean m_destroyed;
     
     private int m_lastSearchID;
+
+    private boolean m_hasDirection = false;
     
     public TileCable()
     {
@@ -270,6 +272,28 @@ public class TileCable extends TileModemBase
             networkChanged();
         }
         super.destroy();
+    }
+
+    @Override
+    public void onLoad()
+    {
+        super.onLoad();
+        updateDirection();
+    }
+
+    @Override
+    public void updateContainingBlockInfo()
+    {
+        m_hasDirection = false;
+    }
+
+    private void updateDirection()
+    {
+        if( !m_hasDirection )
+        {
+            m_hasDirection = true;
+            m_dir = getDirection();
+        }
     }
 
     @Override
@@ -550,6 +574,7 @@ public class TileCable extends TileModemBase
     public void update()
     {
         super.update();
+        updateDirection();
         if( !getWorld().isRemote )
         {        
             synchronized( m_peripheralsByName )

--- a/src/main/java/dan200/computercraft/shared/peripheral/modem/TileWirelessModem.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/modem/TileWirelessModem.java
@@ -12,8 +12,8 @@ import dan200.computercraft.shared.peripheral.PeripheralType;
 import dan200.computercraft.shared.peripheral.common.BlockPeripheral;
 import dan200.computercraft.shared.peripheral.common.BlockPeripheralVariant;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
@@ -44,8 +44,8 @@ public class TileWirelessModem extends TileModemBase
         @Override
         public Vec3d getPosition()
         {
-            BlockPos pos = m_entity.getPos().offset( m_entity.getDirection() );
-            return new Vec3d( (double)pos.getX(), (double)pos.getY(), (double)pos.getZ() );
+            BlockPos pos = m_entity.getPos().offset( m_entity.getCachedDirection() );
+            return new Vec3d( (double) pos.getX(), (double) pos.getY(), (double) pos.getZ() );
         }
 
         @Override
@@ -53,7 +53,7 @@ public class TileWirelessModem extends TileModemBase
         {
             if( other instanceof Peripheral )
             {
-                Peripheral otherModem = (Peripheral)other;
+                Peripheral otherModem = (Peripheral) other;
                 return otherModem.m_entity == m_entity;
             }
             return false;
@@ -62,8 +62,40 @@ public class TileWirelessModem extends TileModemBase
 
     // Members
 
+    private boolean m_hasDirection = false;
+
     public TileWirelessModem()
     {
+        m_dir = EnumFacing.DOWN;
+    }
+
+    @Override
+    public void onLoad()
+    {
+        super.onLoad();
+        updateDirection();
+    }
+
+    @Override
+    public void updateContainingBlockInfo()
+    {
+        m_hasDirection = false;
+    }
+
+    @Override
+    public void update()
+    {
+        super.update();
+        updateDirection();
+    }
+
+    private void updateDirection()
+    {
+        if( !m_hasDirection )
+        {
+            m_hasDirection = true;
+            m_dir = getDirection();
+        }
     }
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtle.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtle.java
@@ -43,7 +43,6 @@ import net.minecraftforge.items.wrapper.InvWrapper;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.List;
 
 import static net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY;
 
@@ -71,14 +70,21 @@ public class TileTurtle extends TileComputerBase
     private boolean m_inventoryChanged;
     private TurtleBrain m_brain;
     private MoveState m_moveState;
+    private ComputerFamily m_family;
 
     public TileTurtle()
+    {
+        this( ComputerFamily.Normal );
+    }
+
+    public TileTurtle(ComputerFamily family)
     {
         m_inventory = NonNullList.withSize( INVENTORY_SIZE, ItemStack.EMPTY );
         m_previousInventory = NonNullList.withSize( INVENTORY_SIZE, ItemStack.EMPTY );
         m_inventoryChanged = false;
         m_brain = createBrain();
         m_moveState = MoveState.NOT_MOVED;
+        m_family = family;
     }
 
     public boolean hasMoved()
@@ -446,6 +452,13 @@ public class TileTurtle extends TileComputerBase
     public float getToolRenderAngle( TurtleSide side, float f )
     {
         return m_brain.getToolRenderAngle( side, f );
+    }
+
+    // IComputerTile
+    @Override
+    public ComputerFamily getFamily()
+    {
+        return m_family;
     }
 
     // IInventory

--- a/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtleAdvanced.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtleAdvanced.java
@@ -6,9 +6,12 @@
 
 package dan200.computercraft.shared.turtle.blocks;
 
+import dan200.computercraft.shared.computer.core.ComputerFamily;
+
 public class TileTurtleAdvanced extends TileTurtle
 {
     public TileTurtleAdvanced()
     {
+        super( ComputerFamily.Advanced);
     }
 }

--- a/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtleExpanded.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtleExpanded.java
@@ -6,9 +6,12 @@
 
 package dan200.computercraft.shared.turtle.blocks;
 
+import dan200.computercraft.shared.computer.core.ComputerFamily;
+
 public class TileTurtleExpanded extends TileTurtle
 {
     public TileTurtleExpanded()
     {
+        super( ComputerFamily.Normal);
     }
 }


### PR DESCRIPTION
This is an attempt at ensuring peripherals/other Lua calls do not access the world from the Lua thread. I'm going to be honest, none of the fixes are especially elegant. I'm expecting several of the fixes to require some level of polling, which is a pain. Currently most peripherals implement `ITickable` so it's not the end of the world,  but it'd be nice to reduce the number which do in the future.

Current progress of the PR:

 - [x] Cache direction of modems. (see #410).
 - [x] Cache turtle family. (see SquidDev-CC/CCTweaks#113).
 - [ ] Cache monitor's terminal and peripheral type.
 - Probably lots of other things I haven't come across yet.