### PR TITLE
Fix turtle speaker upgrade's missing texture

### DIFF
--- a/src/main/java/dan200/computercraft/client/proxy/CCTurtleProxyClient.java
+++ b/src/main/java/dan200/computercraft/client/proxy/CCTurtleProxyClient.java
@@ -143,6 +143,7 @@ public class CCTurtleProxyClient extends CCTurtleProxyCommon
         public void onTextureStitchEvent( TextureStitchEvent.Pre event )
         {
             event.getMap().registerSprite( new ResourceLocation( "computercraft", "blocks/crafty_upgrade" ) );
+            event.getMap().registerSprite( new ResourceLocation( "computercraft", "blocks/turtle_speaker_face" ) );
         }
 
         @SubscribeEvent


### PR DESCRIPTION
The sprite was not registered into the atlas, meaning it rendered the missing texture instead. I'm going to be honest, I'm not sure why it was working in 1.11.2 - the code hasn't changed since then.