### PR TITLE
Add ore dictionary support to all recipes

### DIFF
--- a/src/main/java/dan200/computercraft/shared/media/recipes/DiskRecipe.java
+++ b/src/main/java/dan200/computercraft/shared/media/recipes/DiskRecipe.java
@@ -10,19 +10,23 @@ import dan200.computercraft.shared.media.items.ItemDiskLegacy;
 import dan200.computercraft.shared.util.Colour;
 import dan200.computercraft.shared.util.ColourTracker;
 import dan200.computercraft.shared.util.ColourUtils;
-import net.minecraft.init.Items;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.NonNullList;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.oredict.OreIngredient;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 
 import javax.annotation.Nonnull;
 
 public class DiskRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements IRecipe
 {
+    private final Ingredient paper = new OreIngredient( "paper" );
+    private final Ingredient redstone = new OreIngredient( "dustRedstone" );
+    
     @Override
     public boolean matches( @Nonnull InventoryCrafting inv, @Nonnull World world )
     {
@@ -35,12 +39,12 @@ public class DiskRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements IRe
 
             if( !stack.isEmpty() )
             {
-                if( stack.getItem() == Items.PAPER )
+                if( paper.apply( stack ) )
                 {
                     if( paperFound ) return false;
                     paperFound = true;
                 }
-                else if( stack.getItem() == Items.REDSTONE )
+                else if( redstone.apply( stack ) )
                 {
                     if( redstoneFound ) return false;
                     redstoneFound = true;
@@ -66,8 +70,8 @@ public class DiskRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements IRe
             ItemStack stack = inv.getStackInSlot( i );
 
             if( stack.isEmpty() ) continue;
-            
-            if( stack.getItem() != Items.PAPER && stack.getItem() != Items.REDSTONE )
+
+            if( !paper.apply( stack ) && !redstone.apply( stack ) )
             {
                 int index = ColourUtils.getStackColour( stack );
                 if( index < 0 ) continue;

--- a/src/main/java/dan200/computercraft/shared/media/recipes/PrintoutRecipe.java
+++ b/src/main/java/dan200/computercraft/shared/media/recipes/PrintoutRecipe.java
@@ -7,23 +7,24 @@
 package dan200.computercraft.shared.media.recipes;
 
 import dan200.computercraft.shared.media.items.ItemPrintout;
-import net.minecraft.init.Items;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.NonNullList;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.oredict.OreIngredient;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 
 import javax.annotation.Nonnull;
 
 public class PrintoutRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements IRecipe
 {
-    public PrintoutRecipe( )
-    {
-    }
+    private final Ingredient paper = new OreIngredient( "paper" );
+    private final Ingredient leather = new OreIngredient( "leather" );
+    private final Ingredient string = new OreIngredient( "string" );
 
     @Override
     public boolean canFit( int x, int y )
@@ -68,8 +69,7 @@ public class PrintoutRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements
                 ItemStack stack = inventory.getStackInRowAndColumn(x, y);
                 if( !stack.isEmpty() )
                 {
-                    Item item = stack.getItem();
-                    if( item instanceof ItemPrintout && ItemPrintout.getType( stack ) != ItemPrintout.Type.Book )
+                    if( stack.getItem() instanceof ItemPrintout && ItemPrintout.getType( stack ) != ItemPrintout.Type.Book )
                     {
                         if( printouts == null )
                         {
@@ -80,7 +80,7 @@ public class PrintoutRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements
                         numPrintouts++;
                         printoutFound = true;
                     }
-                    else if( item == Items.PAPER )
+                    else if( paper.apply( stack ) )
                     {
                         if( printouts == null )
                         {
@@ -90,11 +90,11 @@ public class PrintoutRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements
                         numPages++;
                         numPrintouts++;
                     }
-                    else if( item == Items.STRING && !stringFound )
+                    else if( string.apply( stack ) && !stringFound )
                     {
                         stringFound = true;
                     }
-                    else if( item == Items.LEATHER && !leatherFound )
+                    else if( leather.apply( stack ) && !leatherFound )
                     {
                         leatherFound = true;
                     }

--- a/src/main/resources/assets/computercraft/recipes/advanced_computer.json
+++ b/src/main/resources/assets/computercraft/recipes/advanced_computer.json
@@ -6,9 +6,9 @@
         "#G#"
     ],
     "key": {
-        "#": { "item": "minecraft:gold_ingot" },
-        "R": { "item": "minecraft:redstone" },
-        "G": { "item": "minecraft:glass_pane" }
+        "#": { "type": "forge:ore_dict", "ore": "ingotGold" },
+        "R": { "type": "forge:ore_dict", "ore": "dustRedstone" },
+        "G": { "type": "forge:ore_dict", "ore": "paneGlass" }
     },
     "result": { "item": "computercraft:computer", "data": 16384 }
 }

--- a/src/main/resources/assets/computercraft/recipes/advanced_monitor.json
+++ b/src/main/resources/assets/computercraft/recipes/advanced_monitor.json
@@ -6,8 +6,8 @@
         "###"
     ],
     "key": {
-        "#": { "item": "minecraft:gold_ingot" },
-        "G": { "item": "minecraft:glass_pane" }
+        "#": { "type": "forge:ore_dict", "ore": "ingotGold" },
+        "G": { "type": "forge:ore_dict", "ore": "paneGlass" }
     },
     "result": { "item": "computercraft:peripheral", "data": 4, "count": 4 }
 }

--- a/src/main/resources/assets/computercraft/recipes/advanced_pocket_computer.json
+++ b/src/main/resources/assets/computercraft/recipes/advanced_pocket_computer.json
@@ -6,8 +6,8 @@
         "#G#"
     ],
     "key": {
-        "#": { "item": "minecraft:gold_ingot" },
-        "G": { "item": "minecraft:glass_pane" },
+        "#": { "type": "forge:ore_dict", "ore": "ingotGold" },
+        "G": { "type": "forge:ore_dict", "ore": "paneGlass" },
         "A": { "item": "minecraft:golden_apple", "data": 0 }
     },
     "result": { "item": "computercraft:pocket_computer", "data": 1 }

--- a/src/main/resources/assets/computercraft/recipes/advanced_turtle.json
+++ b/src/main/resources/assets/computercraft/recipes/advanced_turtle.json
@@ -6,9 +6,9 @@
         "#I#"
     ],
     "key": {
-        "#": { "item": "minecraft:gold_ingot" },
+        "#": { "type": "forge:ore_dict", "ore": "ingotGold" },
         "C": { "item": "computercraft:computer", "data": 16384 },
-        "I": { "item": "minecraft:chest" }
+        "I": { "type": "forge:ore_dict", "ore": "chestWood" }
     },
     "family": "Advanced"
 }

--- a/src/main/resources/assets/computercraft/recipes/cable.json
+++ b/src/main/resources/assets/computercraft/recipes/cable.json
@@ -6,8 +6,8 @@
         " # "
     ],
     "key": {
-        "#": { "item": "minecraft:stone", "data": 0 },
-        "R": { "item": "minecraft:redstone" }
+        "#": { "type": "forge:ore_dict", "ore": "stone" },
+        "R": { "type": "forge:ore_dict", "ore": "dustRedstone" }
     },
     "result": { "item": "computercraft:cable", "data": 0, "count": 6 }
 }

--- a/src/main/resources/assets/computercraft/recipes/command_computer.json
+++ b/src/main/resources/assets/computercraft/recipes/command_computer.json
@@ -6,9 +6,9 @@
         "#G#"
     ],
     "key": {
-        "#": { "item": "minecraft:stone", "data": 0 },
+        "#": { "type": "forge:ore_dict", "ore": "stone" },
         "C": { "item": "minecraft:command_block" },
-        "G": { "item": "minecraft:glass_pane" }
+        "G": { "type": "forge:ore_dict", "ore": "paneGlass" }
     },
     "result": { "item": "computercraft:command_computer", "data": 0 }
 }

--- a/src/main/resources/assets/computercraft/recipes/disk_drive.json
+++ b/src/main/resources/assets/computercraft/recipes/disk_drive.json
@@ -6,8 +6,8 @@
         "#R#"
     ],
     "key": {
-        "#": { "item": "minecraft:stone", "data": 0 },
-        "R": { "item": "minecraft:redstone" }
+        "#": { "type": "forge:ore_dict", "ore": "stone" },
+        "R": { "type": "forge:ore_dict", "ore": "dustRedstone" }
     },
     "result": { "item": "computercraft:peripheral", "data": 0 }
 }

--- a/src/main/resources/assets/computercraft/recipes/disk_impostor.json
+++ b/src/main/resources/assets/computercraft/recipes/disk_impostor.json
@@ -1,8 +1,8 @@
 {
     "type": "computercraft:impostor_shapeless",
     "ingredients": [
-        { "item": "minecraft:redstone" },
-        { "item": "minecraft:paper" }
+        { "type": "forge:ore_dict", "ore": "dustRedstone" },
+        { "type": "forge:ore_dict", "ore": "paper" }
     ],
     "result": { "item": "computercraft:disk", "data": 0 }
 }

--- a/src/main/resources/assets/computercraft/recipes/ender_modem.json
+++ b/src/main/resources/assets/computercraft/recipes/ender_modem.json
@@ -6,7 +6,7 @@
         "###"
     ],
     "key": {
-        "#": { "item": "minecraft:gold_ingot" },
+        "#": { "type": "forge:ore_dict", "ore": "ingotGold" },
         "E": { "item": "minecraft:ender_eye" }
     },
     "result": { "item": "computercraft:advanced_modem", "data": 0 }

--- a/src/main/resources/assets/computercraft/recipes/normal_computer.json
+++ b/src/main/resources/assets/computercraft/recipes/normal_computer.json
@@ -6,9 +6,9 @@
         "#G#"
     ],
     "key": {
-        "#": { "item": "minecraft:stone", "data": 0 },
-        "R": { "item": "minecraft:redstone" },
-        "G": { "item": "minecraft:glass_pane" }
+        "#": { "type": "forge:ore_dict", "ore": "stone" },
+        "R": { "type": "forge:ore_dict", "ore": "dustRedstone" },
+        "G": { "type": "forge:ore_dict", "ore": "paneGlass" }
     },
     "result": { "item": "computercraft:computer", "data": 0 }
 }

--- a/src/main/resources/assets/computercraft/recipes/normal_monitor.json
+++ b/src/main/resources/assets/computercraft/recipes/normal_monitor.json
@@ -6,8 +6,8 @@
         "###"
     ],
     "key": {
-        "#": { "item": "minecraft:stone", "data": 0 },
-        "G": { "item": "minecraft:glass_pane" }
+        "#": { "type": "forge:ore_dict", "ore": "stone" },
+        "G": { "type": "forge:ore_dict", "ore": "paneGlass" }
     },
     "result": { "item": "computercraft:peripheral", "data": 2 }
 }

--- a/src/main/resources/assets/computercraft/recipes/normal_pocket_computer.json
+++ b/src/main/resources/assets/computercraft/recipes/normal_pocket_computer.json
@@ -6,8 +6,8 @@
         "#G#"
     ],
     "key": {
-        "#": { "item": "minecraft:stone", "data": 0 },
-        "G": { "item": "minecraft:glass_pane" },
+        "#": { "type": "forge:ore_dict", "ore": "stone" },
+        "G": { "type": "forge:ore_dict", "ore": "paneGlass" },
         "A": { "item": "minecraft:golden_apple", "data": 0 }
     },
     "result": { "item": "computercraft:pocket_computer", "data": 0 }

--- a/src/main/resources/assets/computercraft/recipes/normal_turtle.json
+++ b/src/main/resources/assets/computercraft/recipes/normal_turtle.json
@@ -6,9 +6,9 @@
         "#I#"
     ],
     "key": {
-        "#": { "item": "minecraft:iron_ingot" },
+        "#": { "type": "forge:ore_dict", "ore": "ingotIron" },
         "C": { "item": "computercraft:computer", "data": 0 },
-        "I": { "item": "minecraft:chest" }
+        "I": { "type": "forge:ore_dict", "ore": "chestWood" }
     },
     "family": "Normal"
 }

--- a/src/main/resources/assets/computercraft/recipes/printed_book.json
+++ b/src/main/resources/assets/computercraft/recipes/printed_book.json
@@ -1,9 +1,9 @@
 {
     "type": "computercraft:impostor_shapeless",
     "ingredients": [
-        { "item": "minecraft:leather" },
+        { "type": "forge:ore_dict", "ore": "leather" },
         { "item": "computercraft:printout", "data": 0 },
-        { "item": "minecraft:string" }
+        { "type": "forge:ore_dict", "ore": "string" }
     ],
     "result": { "item": "computercraft:printout", "data": 2 }
 }

--- a/src/main/resources/assets/computercraft/recipes/printed_pages.json
+++ b/src/main/resources/assets/computercraft/recipes/printed_pages.json
@@ -3,7 +3,7 @@
     "ingredients": [
         { "item": "computercraft:printout", "data": 0 },
         { "item": "computercraft:printout", "data": 0 },
-        { "item": "minecraft:string" }
+        { "type": "forge:ore_dict", "ore": "string" }
     ],
     "result": { "item": "computercraft:printout", "data": 1 }
 }

--- a/src/main/resources/assets/computercraft/recipes/printer.json
+++ b/src/main/resources/assets/computercraft/recipes/printer.json
@@ -6,9 +6,9 @@
         "#D#"
     ],
     "key": {
-        "#": { "item": "minecraft:stone", "data": 0 },
-        "R": { "item": "minecraft:redstone" },
-        "D": { "item": "minecraft:dye", "data": 0 }
+        "#": { "type": "forge:ore_dict", "ore": "stone" },
+        "R": { "type": "forge:ore_dict", "ore": "paneGlass" },
+        "D": { "type": "forge:ore_dict", "ore": "dye" }
     },
     "result": { "item": "computercraft:peripheral", "data": 3 }
 }

--- a/src/main/resources/assets/computercraft/recipes/speaker.json
+++ b/src/main/resources/assets/computercraft/recipes/speaker.json
@@ -6,8 +6,8 @@
         "#R#"
     ],
     "key": {
-        "#": { "item": "minecraft:stone", "data": 0 },
-        "R": { "item": "minecraft:redstone" },
+        "#": { "type": "forge:ore_dict", "ore": "stone" },
+        "R": { "type": "forge:ore_dict", "ore": "dustRedstone" },
         "N": { "item": "minecraft:noteblock" }
     },
     "result": { "item": "computercraft:peripheral", "data": 5 }

--- a/src/main/resources/assets/computercraft/recipes/wired_modem.json
+++ b/src/main/resources/assets/computercraft/recipes/wired_modem.json
@@ -6,8 +6,8 @@
         "###"
     ],
     "key": {
-        "#": { "item": "minecraft:stone", "data": 0 },
-        "R": { "item": "minecraft:redstone" }
+        "#": { "type": "forge:ore_dict", "ore": "stone" },
+        "R": { "type": "forge:ore_dict", "ore": "dustRedstone" }
     },
     "result": { "item": "computercraft:cable", "data": 1 }
 }

--- a/src/main/resources/assets/computercraft/recipes/wireless_modem.json
+++ b/src/main/resources/assets/computercraft/recipes/wireless_modem.json
@@ -6,8 +6,8 @@
         "###"
     ],
     "key": {
-        "#": { "item": "minecraft:stone", "data": 0 },
-        "E": { "item": "minecraft:ender_pearl" }
+        "#": { "type": "forge:ore_dict", "ore": "stone" },
+        "E": { "type": "forge:ore_dict", "ore": "enderpearl" }
     },
     "result": { "item": "computercraft:peripheral", "data": 1 }
 }


### PR DESCRIPTION
This allows people to use alternative items, such as Quark chests or dyed glass panes, in recipes instead of the "standard" one. The former is especially useful as Quark makes it much harder to acquire a "standard" chest.