### PR TITLE
Prevent turtles moving beyond the world border

### DIFF
--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
@@ -496,10 +496,11 @@ public class TurtleBrain implements ITurtleAccess
             return true;
         }
 
-        if ( !world.isBlockLoaded( pos ) )
-        {
-            return false;
-        }
+        // Ensure the chunk is loaded
+        if( !world.isBlockLoaded( pos ) ) return false;
+
+        // Ensure we're inside the world border
+        if( !world.getWorldBorder().contains( pos ) ) return false;
 
         oldOwner.notifyMoveStart();
 

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleMoveCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleMoveCommand.java
@@ -14,9 +14,9 @@ import dan200.computercraft.api.turtle.TurtleCommandResult;
 import dan200.computercraft.shared.util.WorldUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
@@ -169,6 +169,10 @@ public class TurtleMoveCommand implements ITurtleCommand
         if( !world.isBlockLoaded( position ) )
         {
             return TurtleCommandResult.failure( "Cannot leave loaded world" );
+        }
+        if( !world.getWorldBorder().contains( position ) )
+        {
+            return TurtleCommandResult.failure( "Cannot pass the world border" );
         }
         return TurtleCommandResult.success();
     }


### PR DESCRIPTION
As tiles outside the world border are not ticked, turtles are rendered entirely useless. Furthermore, the turtle animation will never progress resulting in visual glitches.

In order to avoid this, we ensure the target position is within the world border when moving to it.