### PR TITLE
Fix wireless modems suffocating entities

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/common/BlockPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/common/BlockPeripheral.java
@@ -631,11 +631,34 @@ public class BlockPeripheral extends BlockPeripheralBase
         return isOpaqueCube( state );
     }
 
+    @Override
+    @Deprecated
+    public boolean isFullBlock( IBlockState state )
+    {
+        return isOpaqueCube( state );
+    }
+
     @Nonnull
     @Override
     @Deprecated
     public BlockFaceShape getBlockFaceShape( IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing side )
     {
         return isOpaqueCube( state ) ? BlockFaceShape.SOLID : BlockFaceShape.UNDEFINED;
+    }
+
+    @Override
+    @Deprecated
+    public boolean causesSuffocation(IBlockState state)
+    {
+        // This normally uses the default state 
+        return blockMaterial.blocksMovement() && state.isOpaqueCube();
+    }
+
+    @Override
+    @Deprecated
+    public int getLightOpacity( IBlockState state )
+    {
+        // This normally uses the default state
+        return isOpaqueCube( state ) ? 255 : 0;
     }
 }


### PR DESCRIPTION
As of #458, `BlockPeripheral` will act as a full/opaque block for some peripherals and a transparent one for others. However, some `Block` methods use the default state rather than the current one. This means modems report being a full block when they are not, leading to
suffocating entities and lighting glitches.

Here's a [gif of the issue](https://cdn.discordapp.com/attachments/318002748165455872/413700561221976064/2018-02-15_15-16-40.gif) that Ale32bit made.

