### PR TITLE
[WIP] Turtle events

### DIFF
--- a/src/main/java/dan200/computercraft/ComputerCraft.java
+++ b/src/main/java/dan200/computercraft/ComputerCraft.java
@@ -7,6 +7,7 @@
 package dan200.computercraft;
 
 import com.google.common.base.CaseFormat;
+import com.google.common.base.Converter;
 import dan200.computercraft.api.filesystem.IMount;
 import dan200.computercraft.api.filesystem.IWritableMount;
 import dan200.computercraft.api.media.IMedia;
@@ -18,6 +19,7 @@ import dan200.computercraft.api.permissions.ITurtlePermissionProvider;
 import dan200.computercraft.api.pocket.IPocketUpgrade;
 import dan200.computercraft.api.redstone.IBundledRedstoneProvider;
 import dan200.computercraft.api.turtle.ITurtleUpgrade;
+import dan200.computercraft.api.turtle.event.TurtleAction;
 import dan200.computercraft.core.apis.AddressPredicate;
 import dan200.computercraft.core.filesystem.ComboMount;
 import dan200.computercraft.core.filesystem.FileMount;
@@ -81,10 +83,7 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -133,6 +132,7 @@ public class ComputerCraft
     public static int advancedTurtleFuelLimit = 100000;
     public static boolean turtlesObeyBlockProtection = true;
     public static boolean turtlesCanPush = true;
+    public static EnumSet<TurtleAction> turtleDisabledActions = EnumSet.noneOf( TurtleAction.class );
 
     public static final int terminalWidth_computer = 51;
     public static final int terminalHeight_computer = 19;
@@ -212,6 +212,7 @@ public class ComputerCraft
         public static Property advancedTurtleFuelLimit;
         public static Property turtlesObeyBlockProtection;
         public static Property turtlesCanPush;
+        public static Property turtleDisabledActions;
 
         public static Property modem_range;
         public static Property modem_highAltitudeRange;
@@ -341,6 +342,9 @@ public class ComputerCraft
         Config.turtlesCanPush = Config.config.get( Configuration.CATEGORY_GENERAL, "turtlesCanPush", turtlesCanPush );
         Config.turtlesCanPush.setComment( "If set to true, Turtles will push entities out of the way instead of stopping if there is space to do so" );
 
+        Config.turtleDisabledActions = Config.config.get( Configuration.CATEGORY_GENERAL, "turtle_disabled_actions", new String[ 0 ] );
+        Config.turtleDisabledActions.setComment( "A list of turtle actions which are disabled." );
+
         Config.maxNotesPerTick = Config.config.get( Configuration.CATEGORY_GENERAL, "maxNotesPerTick", maxNotesPerTick );
         Config.maxNotesPerTick.setComment( "Maximum amount of notes a speaker can play at once" );
 
@@ -384,6 +388,20 @@ public class ComputerCraft
         advancedTurtleFuelLimit = Config.advancedTurtleFuelLimit.getInt();
         turtlesObeyBlockProtection = Config.turtlesObeyBlockProtection.getBoolean();
         turtlesCanPush = Config.turtlesCanPush.getBoolean();
+
+        turtleDisabledActions.clear();
+        Converter<String, String> converter = CaseFormat.LOWER_CAMEL.converterTo( CaseFormat.UPPER_UNDERSCORE );
+        for( String value : Config.turtleDisabledActions.getStringList() )
+        {
+            try
+            {
+                turtleDisabledActions.add( TurtleAction.valueOf( converter.convert( value ) ) );
+            }
+            catch( IllegalArgumentException e )
+            {
+                ComputerCraft.log.error( "Unknown turtle action " + value );
+            }
+        }
 
         maxNotesPerTick = Math.max(1, Config.maxNotesPerTick.getInt());
 

--- a/src/main/java/dan200/computercraft/api/turtle/ITurtleUpgrade.java
+++ b/src/main/java/dan200/computercraft/api/turtle/ITurtleUpgrade.java
@@ -8,11 +8,15 @@ package dan200.computercraft.api.turtle;
 
 import dan200.computercraft.api.ComputerCraftAPI;
 import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.api.turtle.event.TurtleAttackEvent;
+import dan200.computercraft.api.turtle.event.TurtleBlockEvent;
 import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.event.entity.player.AttackEntityEvent;
+import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
@@ -99,6 +103,9 @@ public interface ITurtleUpgrade
     /**
      * Will only be called for Tool turtle. Called when turtle.dig() or turtle.attack() is called
      * by the turtle, and the tool is required to do some work.
+     *
+     * Conforming implementations should fire {@link BlockEvent.BreakEvent} and {@link TurtleBlockEvent.Dig}for digging,
+     * {@link AttackEntityEvent} and {@link TurtleAttackEvent} for attacking.
      *
      * @param turtle    Access to the turtle that the tool resides on.
      * @param side      Which side of the turtle (left or right) the tool resides on.

--- a/src/main/java/dan200/computercraft/api/turtle/event/TurtleAction.java
+++ b/src/main/java/dan200/computercraft/api/turtle/event/TurtleAction.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the public ComputerCraft API - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2017. This API may be redistributed unmodified and in full only.
+ * For help using the API, and posting your mods, visit the forums at computercraft.info.
+ */
+
+package dan200.computercraft.api.turtle.event;
+
+/**
+ * A basic action that a turtle may perform, as accessed by the {@code turtle} API.
+ *
+ * @see TurtleActionEvent
+ */
+public enum TurtleAction
+{
+    /**
+     * A turtle moves to a new position.
+     *
+     * @see TurtleBlockEvent.Move
+     */
+    MOVE,
+
+    /**
+     * A turtle turns in a specific direction.
+     */
+    TURN,
+
+    /**
+     * A turtle attempts to dig a block.
+     *
+     * @see TurtleBlockEvent.Dig
+     */
+    DIG,
+
+    /**
+     * A turtle attempts to place a block or item in the world.
+     *
+     * @see TurtleBlockEvent.Place
+     */
+    PLACE,
+
+    /**
+     * A turtle attempts to attack an entity.
+     *
+     * @see TurtleActionEvent
+     */
+    ATTACK,
+
+    /**
+     * Drop an item into an inventory/the world.
+     *
+     * @see TurtleInventoryEvent.Drop
+     */
+    DROP,
+
+    /**
+     * Suck an item from an inventory or the world.
+     *
+     * @see TurtleInventoryEvent.Suck
+     */
+    SUCK,
+
+    /**
+     * Refuel the turtle's fuel levels.
+     */
+    REFUEL,
+
+    /**
+     * Equip or unequip an item.
+     */
+    EQUIP,
+
+    /**
+     * Inspect a block in world
+     *
+     * @see TurtleBlockEvent.Inspect
+     */
+    INSPECT,
+
+    /**
+     * Gather metdata about an item in the turtle's inventory.
+     */
+    INSPECT_ITEM,
+}

--- a/src/main/java/dan200/computercraft/api/turtle/event/TurtleActionEvent.java
+++ b/src/main/java/dan200/computercraft/api/turtle/event/TurtleActionEvent.java
@@ -1,0 +1,76 @@
+package dan200.computercraft.api.turtle.event;
+
+import com.google.common.base.Preconditions;
+import dan200.computercraft.api.turtle.ITurtleAccess;
+import dan200.computercraft.api.turtle.TurtleCommandResult;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An event fired when a turtle is performing a known action.
+ */
+@Cancelable
+public class TurtleActionEvent extends TurtleEvent
+{
+    private final TurtleAction action;
+    private String failureMessage;
+
+    public TurtleActionEvent( @Nonnull ITurtleAccess turtle, @Nonnull TurtleAction action )
+    {
+        super( turtle );
+
+        Preconditions.checkNotNull( action, "action cannot be null" );
+        this.action = action;
+    }
+
+    public TurtleAction getAction()
+    {
+        return action;
+    }
+
+    /**
+     * Sets the cancellation state of this action.
+     *
+     * If {@code cancel} is {@code true}, this action will not be carried out.
+     *
+     * @param cancel The new canceled value.
+     * @see TurtleCommandResult#failure()
+     * @deprecated Use {@link #setCanceled(boolean, String)} instead.
+     */
+    @Override
+    @Deprecated
+    public void setCanceled( boolean cancel )
+    {
+        setCanceled( cancel, null );
+    }
+
+    /**
+     * Set the cancellation state of this action, setting a failure message if required.
+     *
+     * If {@code cancel} is {@code true}, this action will not be carried out.
+     *
+     * @param cancel         The new canceled value.
+     * @param failureMessage The message to return to the user explaining the failure.
+     * @see TurtleCommandResult#failure(String)
+     */
+    public void setCanceled( boolean cancel, @Nullable String failureMessage )
+    {
+        super.setCanceled( cancel );
+        this.failureMessage = cancel ? failureMessage : null;
+    }
+
+    /**
+     * Get the message with which this will fail.
+     *
+     * @return The failure message.
+     * @see TurtleCommandResult#failure()
+     * @see #setCanceled(boolean, String)
+     */
+    @Nullable
+    public String getFailureMessage()
+    {
+        return failureMessage;
+    }
+}

--- a/src/main/java/dan200/computercraft/api/turtle/event/TurtleAttackEvent.java
+++ b/src/main/java/dan200/computercraft/api/turtle/event/TurtleAttackEvent.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of the public ComputerCraft API - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2017. This API may be redistributed unmodified and in full only.
+ * For help using the API, and posting your mods, visit the forums at computercraft.info.
+ */
+
+package dan200.computercraft.api.turtle.event;
+
+import com.google.common.base.Preconditions;
+import dan200.computercraft.api.turtle.ITurtleAccess;
+import dan200.computercraft.api.turtle.ITurtleUpgrade;
+import dan200.computercraft.api.turtle.TurtleSide;
+import dan200.computercraft.api.turtle.TurtleVerb;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.util.FakePlayer;
+import net.minecraftforge.event.entity.player.AttackEntityEvent;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Fired when a turtle attempts to attack an entity.
+ *
+ * This must be fired by {@link ITurtleUpgrade#useTool(ITurtleAccess, TurtleSide, TurtleVerb, EnumFacing)},
+ * as the base {@code turtle.attack()} command does not fire it.
+ *
+ * Note that such commands should also fire {@link AttackEntityEvent}, so you do not need to listen to both.
+ *
+ * @see TurtleAction#ATTACK
+ */
+public class TurtleAttackEvent extends TurtlePlayerEvent
+{
+    private final Entity target;
+    private final ITurtleUpgrade upgrade;
+    private final TurtleSide side;
+
+    public TurtleAttackEvent( @Nonnull ITurtleAccess turtle, @Nonnull FakePlayer player, @Nonnull Entity target, @Nonnull ITurtleUpgrade upgrade, @Nonnull TurtleSide side )
+    {
+        super( turtle, TurtleAction.ATTACK, player );
+        Preconditions.checkNotNull( target, "target cannot be null" );
+        Preconditions.checkNotNull( upgrade, "upgrade cannot be null" );
+        Preconditions.checkNotNull( side, "side cannot be null" );
+        this.target = target;
+        this.upgrade = upgrade;
+        this.side = side;
+    }
+
+    /**
+     * Get the entity being attacked by this turtle.
+     *
+     * @return The entity being attacked.
+     */
+    @Nonnull
+    public Entity getTarget()
+    {
+        return target;
+    }
+
+    /**
+     * Get the upgrade responsible for attacking.
+     *
+     * @return The upgrade responsible for attacking.
+     */
+    @Nonnull
+    public ITurtleUpgrade getUpgrade()
+    {
+        return upgrade;
+    }
+
+    /**
+     * Get the side the attacking upgrade is on.
+     *
+     * @return The upgrade's side.
+     */
+    @Nonnull
+    public TurtleSide getSide()
+    {
+        return side;
+    }
+}

--- a/src/main/java/dan200/computercraft/api/turtle/event/TurtleBlockEvent.java
+++ b/src/main/java/dan200/computercraft/api/turtle/event/TurtleBlockEvent.java
@@ -1,0 +1,241 @@
+/*
+ * This file is part of the public ComputerCraft API - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2017. This API may be redistributed unmodified and in full only.
+ * For help using the API, and posting your mods, visit the forums at computercraft.info.
+ */
+
+package dan200.computercraft.api.turtle.event;
+
+import com.google.common.base.Preconditions;
+import dan200.computercraft.api.lua.ILuaContext;
+import dan200.computercraft.api.peripheral.IComputerAccess;
+import dan200.computercraft.api.turtle.ITurtleAccess;
+import dan200.computercraft.api.turtle.ITurtleUpgrade;
+import dan200.computercraft.api.turtle.TurtleSide;
+import dan200.computercraft.api.turtle.TurtleVerb;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.FakePlayer;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+
+/**
+ * A general event for when a turtle interacts with a block or region.
+ *
+ * You should generally listen to one of the sub-events instead, cancelling them where
+ * appropriate.
+ *
+ * Note that you are not guaranteed to receive this event, if it has been cancelled by other
+ * mechanisms, such as block protection systems.
+ *
+ * Be aware that some events (such as {@link TurtleInventoryEvent}) do not necessarily interact
+ * with a block, simply objects within that block space.
+ */
+@Cancelable
+public abstract class TurtleBlockEvent extends TurtlePlayerEvent
+{
+    private final World world;
+    private final BlockPos pos;
+
+    protected TurtleBlockEvent( @Nonnull ITurtleAccess turtle, @Nonnull TurtleAction action, @Nonnull FakePlayer player, @Nonnull World world, @Nonnull BlockPos pos )
+    {
+        super( turtle, action, player );
+
+        Preconditions.checkNotNull( world, "world cannot be null" );
+        Preconditions.checkNotNull( pos, "pos cannot be null" );
+        this.world = world;
+        this.pos = pos;
+    }
+
+    /**
+     * Get the world the turtle is interacting in.
+     *
+     * @return The world the turtle is interacting in.
+     */
+    public World getWorld()
+    {
+        return world;
+    }
+
+    /**
+     * Get the position the turtle is interacting with. Note that this is different
+     * to {@link ITurtleAccess#getPosition()}.
+     *
+     * @return The position the turtle is interacting with.
+     */
+    public BlockPos getPos()
+    {
+        return pos;
+    }
+
+    /**
+     * Fired when a turtle attempts to dig a block.
+     *
+     * This must be fired by {@link ITurtleUpgrade#useTool(ITurtleAccess, TurtleSide, TurtleVerb, EnumFacing)},
+     * as the base {@code turtle.dig()} command does not fire it.
+     *
+     * Note that such commands should also fire {@link BlockEvent.BreakEvent}, so you do not need to listen to both.
+     *
+     * @see TurtleAction#DIG
+     */
+    @Cancelable
+    public static class Dig extends TurtleBlockEvent
+    {
+        private final IBlockState block;
+        private final ITurtleUpgrade upgrade;
+        private final TurtleSide side;
+
+        public Dig( @Nonnull ITurtleAccess turtle, @Nonnull FakePlayer player, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull IBlockState block, @Nonnull ITurtleUpgrade upgrade, @Nonnull TurtleSide side )
+        {
+            super( turtle, TurtleAction.DIG, player, world, pos );
+
+            Preconditions.checkNotNull( block, "block cannot be null" );
+            Preconditions.checkNotNull( upgrade, "upgrade cannot be null" );
+            Preconditions.checkNotNull( side, "side cannot be null" );
+            this.block = block;
+            this.upgrade = upgrade;
+            this.side = side;
+        }
+
+        /**
+         * Get the block which is about to be broken.
+         *
+         * @return The block which is going to be broken.
+         */
+        @Nonnull
+        public IBlockState getBlock()
+        {
+            return block;
+        }
+
+        /**
+         * Get the upgrade doing the digging
+         *
+         * @return The upgrade doing the digging.
+         */
+        @Nonnull
+        public ITurtleUpgrade getUpgrade()
+        {
+            return upgrade;
+        }
+
+        /**
+         * Get the side the upgrade doing the digging is on.
+         *
+         * @return The upgrade's side.
+         */
+        @Nonnull
+        public TurtleSide getSide()
+        {
+            return side;
+        }
+    }
+
+    /**
+     * Fired when a turtle attempts to move into a block.
+     *
+     * @see TurtleAction#MOVE
+     */
+    @Cancelable
+    public static class Move extends TurtleBlockEvent
+    {
+        public Move( @Nonnull ITurtleAccess turtle, @Nonnull FakePlayer player, @Nonnull World world, @Nonnull BlockPos pos )
+        {
+            super( turtle, TurtleAction.MOVE, player, world, pos );
+        }
+    }
+
+    /**
+     * Fired when a turtle attempts to place a block in the world.
+     *
+     * @see TurtleAction#PLACE
+     */
+    @Cancelable
+    public static class Place extends TurtleBlockEvent
+    {
+        private final ItemStack stack;
+
+        public Place( @Nonnull ITurtleAccess turtle, @Nonnull FakePlayer player, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull ItemStack stack )
+        {
+            super( turtle, TurtleAction.PLACE, player, world, pos );
+
+            Preconditions.checkNotNull( stack, "stack cannot be null" );
+            this.stack = stack;
+        }
+
+        /**
+         * Get the item stack that will be placed. This should not be modified.
+         *
+         * @return The item stack to be placed.
+         */
+        @Nonnull
+        public ItemStack getStack()
+        {
+            return stack;
+        }
+    }
+
+    /**
+     * Fired when a turtle gathers data on a block in world.
+     *
+     * You may prevent blocks being inspected, or add additional information to the result.
+     *
+     * @see TurtleAction#INSPECT
+     */
+    @Cancelable
+    public static class Inspect extends TurtleBlockEvent
+    {
+        private final IBlockState state;
+        private final Map<String, Object> data;
+
+        public Inspect( @Nonnull ITurtleAccess turtle, @Nonnull FakePlayer player, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nonnull Map<String, Object> data )
+        {
+            super( turtle, TurtleAction.INSPECT, player, world, pos );
+
+            Preconditions.checkNotNull( state, "state cannot be null" );
+            Preconditions.checkNotNull( data, "data cannot be null" );
+            this.data = data;
+            this.state = state;
+        }
+
+        /**
+         * Get the block state which is being inspected.
+         *
+         * @return The inspected block state.
+         */
+        @Nonnull
+        public IBlockState getState()
+        {
+            return state;
+        }
+
+        /**
+         * Get the "inspection data" from this block, which will be returned to the user.
+         *
+         * @return This block's inspection data.
+         */
+        @Nonnull
+        public Map<String, Object> getData()
+        {
+            return data;
+        }
+
+        /**
+         * Add new information to the inspection result. Note this will override fields with the same name.
+         *
+         * @param newData The data to add. Note all values should be convertable to Lua (see
+         *                {@link dan200.computercraft.api.peripheral.IPeripheral#callMethod(IComputerAccess, ILuaContext, int, Object[])}).
+         */
+        public void addData( @Nonnull Map<String, ?> newData )
+        {
+            Preconditions.checkNotNull( newData, "newData cannot be null" );
+            data.putAll( newData );
+        }
+    }
+}

--- a/src/main/java/dan200/computercraft/api/turtle/event/TurtleEvent.java
+++ b/src/main/java/dan200/computercraft/api/turtle/event/TurtleEvent.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the public ComputerCraft API - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2017. This API may be redistributed unmodified and in full only.
+ * For help using the API, and posting your mods, visit the forums at computercraft.info.
+ */
+
+package dan200.computercraft.api.turtle.event;
+
+import com.google.common.base.Preconditions;
+import dan200.computercraft.api.turtle.ITurtleAccess;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A base class for all events concerning a turtle. This will only ever constructed and fired on the server side,
+ * so sever specific methods on {@link ITurtleAccess} are safe to use.
+ *
+ * You should generally not need to subscribe to this event, preferring one of the more specific classes.
+ *
+ * @see TurtleActionEvent
+ */
+public abstract class TurtleEvent extends Event
+{
+    private final ITurtleAccess turtle;
+
+    protected TurtleEvent( @Nonnull ITurtleAccess turtle )
+    {
+        Preconditions.checkNotNull( turtle, "turtle cannot be null" );
+        this.turtle = turtle;
+    }
+
+    /**
+     * Get the turtle which is performing this action.
+     *
+     * @return The access for this turtle.
+     */
+    @Nonnull
+    public ITurtleAccess getTurtle()
+    {
+        return turtle;
+    }
+}

--- a/src/main/java/dan200/computercraft/api/turtle/event/TurtleInventoryEvent.java
+++ b/src/main/java/dan200/computercraft/api/turtle/event/TurtleInventoryEvent.java
@@ -1,0 +1,84 @@
+package dan200.computercraft.api.turtle.event;
+
+import com.google.common.base.Preconditions;
+import dan200.computercraft.api.turtle.ITurtleAccess;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.FakePlayer;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.items.IItemHandler;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Fired when a turtle attempts to interact with an inventory.
+ */
+@Cancelable
+public abstract class TurtleInventoryEvent extends TurtleBlockEvent
+{
+    private final IItemHandler handler;
+
+    protected TurtleInventoryEvent( @Nonnull ITurtleAccess turtle, @Nonnull TurtleAction action, @Nonnull FakePlayer player, @Nonnull World world, @Nonnull BlockPos pos, @Nullable IItemHandler handler )
+    {
+        super( turtle, action, player, world, pos );
+        this.handler = handler;
+    }
+
+    /**
+     * Get the inventory being interacted with
+     *
+     * @return The inventory being interacted with, {@code null} if the item will be dropped to/sucked from the world.
+     */
+    @Nullable
+    public IItemHandler getItemHandler()
+    {
+        return handler;
+    }
+
+    /**
+     * Fired when a turtle attempts to suck from an inventory.
+     *
+     * @see TurtleAction#SUCK
+     */
+    @Cancelable
+    public static class Suck extends TurtleInventoryEvent
+    {
+        public Suck( @Nonnull ITurtleAccess turtle, @Nonnull FakePlayer player, @Nonnull World world, @Nonnull BlockPos pos, @Nullable IItemHandler handler )
+        {
+            super( turtle, TurtleAction.SUCK, player, world, pos, handler );
+        }
+    }
+
+    /**
+     * Fired when a turtle attempts to drop an item into an inventory.
+     *
+     * @see TurtleAction#DROP
+     */
+    @Cancelable
+    public static class Drop extends TurtleInventoryEvent
+    {
+        private final ItemStack stack;
+
+        public Drop( @Nonnull ITurtleAccess turtle, @Nonnull FakePlayer player, @Nonnull World world, @Nonnull BlockPos pos, @Nullable IItemHandler handler, @Nonnull ItemStack stack )
+        {
+            super( turtle, TurtleAction.DROP, player, world, pos, handler );
+
+            Preconditions.checkNotNull( stack, "stack cannot be null" );
+            this.stack = stack;
+        }
+
+        /**
+         * The item which will be inserted into the inventory/dropped on the ground.
+         *
+         * Note that this is a copy of the original stack, and so should not be modified, as that will have no effect.
+         *
+         * @return The item stack which will be dropped.
+         */
+        public ItemStack getStack()
+        {
+            return stack.copy();
+        }
+    }
+}

--- a/src/main/java/dan200/computercraft/api/turtle/event/TurtlePlayerEvent.java
+++ b/src/main/java/dan200/computercraft/api/turtle/event/TurtlePlayerEvent.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the public ComputerCraft API - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2017. This API may be redistributed unmodified and in full only.
+ * For help using the API, and posting your mods, visit the forums at computercraft.info.
+ */
+
+package dan200.computercraft.api.turtle.event;
+
+import com.google.common.base.Preconditions;
+import dan200.computercraft.api.turtle.ITurtleAccess;
+import net.minecraftforge.common.util.FakePlayer;
+
+import javax.annotation.Nonnull;
+
+/**
+ * An action done by a turtle which is normally done by a player.
+ *
+ * {@link #getPlayer()} may be used to modify the player's attributes or perform permission checks.
+ */
+public abstract class TurtlePlayerEvent extends TurtleActionEvent
+{
+    private final FakePlayer player;
+
+    protected TurtlePlayerEvent( @Nonnull ITurtleAccess turtle, @Nonnull TurtleAction action, @Nonnull FakePlayer player )
+    {
+        super( turtle, action );
+
+        Preconditions.checkNotNull( player, "player cannot be null" );
+        this.player = player;
+    }
+
+    /**
+     * A fake player, representing this turtle.
+     *
+     * This may be used for triggering permission checks.
+     *
+     * @return A {@link FakePlayer} representing this turtle.
+     */
+    @Nonnull
+    public FakePlayer getPlayer()
+    {
+        return player;
+    }
+}

--- a/src/main/java/dan200/computercraft/api/turtle/event/package-info.java
+++ b/src/main/java/dan200/computercraft/api/turtle/event/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * This file is part of the public ComputerCraft API - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2017. This API may be redistributed unmodified and in full only.
+ * For help using the API, and posting your mods, visit the forums at computercraft.info.
+ */
+
+@API(owner = "ComputerCraft", provides = "ComputerCraft|API|Turtle|Event", apiVersion = "${version}")
+package dan200.computercraft.api.turtle.event;
+
+import net.minecraftforge.fml.common.API;

--- a/src/main/java/dan200/computercraft/shared/proxy/CCTurtleProxyCommon.java
+++ b/src/main/java/dan200/computercraft/shared/proxy/CCTurtleProxyCommon.java
@@ -8,6 +8,7 @@ package dan200.computercraft.shared.proxy;
 
 import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.api.turtle.ITurtleUpgrade;
+import dan200.computercraft.api.turtle.event.TurtleActionEvent;
 import dan200.computercraft.shared.computer.core.ComputerFamily;
 import dan200.computercraft.shared.turtle.blocks.BlockTurtle;
 import dan200.computercraft.shared.turtle.blocks.TileTurtle;
@@ -464,6 +465,14 @@ public abstract class CCTurtleProxyCommon implements ICCTurtleProxy
         public void onEntityLivingDrops( LivingDropsEvent event )
         {
             dispatchEntityDrops( event.getEntity(), event.getDrops() );
+        }
+        
+        @SubscribeEvent
+        public void onTurtleAction( TurtleActionEvent event) {
+            if( ComputerCraft.turtleDisabledActions.contains( event.getAction() ) )
+            {
+                event.setCanceled( true, "Action has been disabled" );
+            }
         }
     }
     

--- a/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
@@ -11,11 +11,14 @@ import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.turtle.ITurtleAccess;
 import dan200.computercraft.api.turtle.ITurtleCommand;
 import dan200.computercraft.api.turtle.TurtleSide;
+import dan200.computercraft.api.turtle.event.TurtleAction;
+import dan200.computercraft.api.turtle.event.TurtleActionEvent;
 import dan200.computercraft.core.apis.IAPIEnvironment;
 import dan200.computercraft.core.apis.ILuaAPI;
 import dan200.computercraft.shared.turtle.core.*;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
 
 import javax.annotation.Nonnull;
 import java.util.HashMap;
@@ -439,6 +442,13 @@ public class TurtleAPI implements ILuaAPI
                     table.put( "name", name );
                     table.put( "damage", damage );
                     table.put( "count", count );
+
+                    TurtleActionEvent event = new TurtleActionEvent( m_turtle, TurtleAction.INSPECT_ITEM );
+                    if( MinecraftForge.EVENT_BUS.post( event ) )
+                    {
+                        return new Object[] { false, event.getFailureMessage() };
+                    }
+
                     return new Object[] { table };
                 }
                 else

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleDropCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleDropCommand.java
@@ -10,12 +10,14 @@ import dan200.computercraft.api.turtle.ITurtleAccess;
 import dan200.computercraft.api.turtle.ITurtleCommand;
 import dan200.computercraft.api.turtle.TurtleAnimation;
 import dan200.computercraft.api.turtle.TurtleCommandResult;
+import dan200.computercraft.api.turtle.event.TurtleInventoryEvent;
 import dan200.computercraft.shared.util.InventoryUtil;
 import dan200.computercraft.shared.util.WorldUtil;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.items.IItemHandler;
 
 import javax.annotation.Nonnull;
@@ -59,6 +61,16 @@ public class TurtleDropCommand implements ITurtleCommand
         EnumFacing side = direction.getOpposite();
 
         IItemHandler inventory = InventoryUtil.getInventory( world, newPosition, side );
+
+        // Fire the event, restoring the inventory and exiting if it is cancelled.
+        TurtlePlayer player = TurtlePlaceCommand.createPlayer( turtle, oldPosition, direction );
+        TurtleInventoryEvent.Drop event = new TurtleInventoryEvent.Drop( turtle, player, world, newPosition, inventory, stack );
+        if( MinecraftForge.EVENT_BUS.post( event ) )
+        {
+            InventoryUtil.storeItems( stack, turtle.getItemHandler(), turtle.getSelectedSlot() );
+            return TurtleCommandResult.failure( event.getFailureMessage() );
+        }
+
         if( inventory != null )
         {
             // Drop the item into the inventory

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleEquipCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleEquipCommand.java
@@ -8,11 +8,14 @@ package dan200.computercraft.shared.turtle.core;
 
 import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.api.turtle.*;
+import dan200.computercraft.api.turtle.event.TurtleAction;
+import dan200.computercraft.api.turtle.event.TurtleActionEvent;
 import dan200.computercraft.shared.proxy.CCTurtleProxyCommon;
 import dan200.computercraft.shared.util.InventoryUtil;
 import dan200.computercraft.shared.util.WorldUtil;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.items.IItemHandler;
 
 import javax.annotation.Nonnull;
@@ -61,6 +64,12 @@ public class TurtleEquipCommand implements ITurtleCommand
         else
         {
             oldUpgradeStack = null;
+        }
+
+        TurtleActionEvent event = new TurtleActionEvent( turtle, TurtleAction.EQUIP );
+        if( MinecraftForge.EVENT_BUS.post( event ) )
+        {
+            return TurtleCommandResult.failure( event.getFailureMessage() );
         }
 
         // Do the swapping:

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleMoveCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleMoveCommand.java
@@ -11,13 +11,15 @@ import dan200.computercraft.api.turtle.ITurtleAccess;
 import dan200.computercraft.api.turtle.ITurtleCommand;
 import dan200.computercraft.api.turtle.TurtleAnimation;
 import dan200.computercraft.api.turtle.TurtleCommandResult;
+import dan200.computercraft.api.turtle.event.TurtleBlockEvent;
 import dan200.computercraft.shared.util.WorldUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -101,6 +103,12 @@ public class TurtleMoveCommand implements ITurtleCommand
             {
                 return TurtleCommandResult.failure( "Movement obstructed" );
             }
+        }
+
+        TurtleBlockEvent.Move moveEvent = new TurtleBlockEvent.Move( turtle, turtlePlayer, oldWorld, newPosition );
+        if( MinecraftForge.EVENT_BUS.post( moveEvent ) )
+        {
+            return TurtleCommandResult.failure( moveEvent.getFailureMessage() );
         }
 
         // Check fuel level

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleRefuelCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleRefuelCommand.java
@@ -10,9 +10,12 @@ import dan200.computercraft.api.turtle.ITurtleAccess;
 import dan200.computercraft.api.turtle.ITurtleCommand;
 import dan200.computercraft.api.turtle.TurtleAnimation;
 import dan200.computercraft.api.turtle.TurtleCommandResult;
+import dan200.computercraft.api.turtle.event.TurtleAction;
+import dan200.computercraft.api.turtle.event.TurtleActionEvent;
 import dan200.computercraft.shared.util.InventoryUtil;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntityFurnace;
+import net.minecraftforge.common.MinecraftForge;
 
 import javax.annotation.Nonnull;
 
@@ -69,6 +72,12 @@ public class TurtleRefuelCommand implements ITurtleCommand
         if( fuelPerItem <= 0 )
         {
             return TurtleCommandResult.failure( "Items not combustible" );
+        }
+
+        TurtleActionEvent event = new TurtleActionEvent( turtle, TurtleAction.REFUEL );
+        if( MinecraftForge.EVENT_BUS.post( event ) )
+        {
+            return TurtleCommandResult.failure( event.getFailureMessage() );
         }
 
         if( !testOnly )

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleSuckCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleSuckCommand.java
@@ -10,6 +10,7 @@ import dan200.computercraft.api.turtle.ITurtleAccess;
 import dan200.computercraft.api.turtle.ITurtleCommand;
 import dan200.computercraft.api.turtle.TurtleAnimation;
 import dan200.computercraft.api.turtle.TurtleCommandResult;
+import dan200.computercraft.api.turtle.event.TurtleInventoryEvent;
 import dan200.computercraft.shared.util.InventoryUtil;
 import dan200.computercraft.shared.util.WorldUtil;
 import net.minecraft.entity.Entity;
@@ -19,6 +20,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.items.IItemHandler;
 
 import javax.annotation.Nonnull;
@@ -56,6 +58,15 @@ public class TurtleSuckCommand implements ITurtleCommand
         EnumFacing side = direction.getOpposite();
 
         IItemHandler inventory = InventoryUtil.getInventory( world, newPosition, side );
+
+        // Fire the event, exiting if it is cancelled.
+        TurtlePlayer player = TurtlePlaceCommand.createPlayer( turtle, oldPosition, direction );
+        TurtleInventoryEvent.Suck event = new TurtleInventoryEvent.Suck( turtle, player, world, newPosition, inventory );
+        if( MinecraftForge.EVENT_BUS.post( event ) )
+        {
+            return TurtleCommandResult.failure( event.getFailureMessage() );
+        }
+        
         if( inventory != null )
         {
             // Take from inventory of thing in front

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleTurnCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleTurnCommand.java
@@ -10,7 +10,10 @@ import dan200.computercraft.api.turtle.ITurtleAccess;
 import dan200.computercraft.api.turtle.ITurtleCommand;
 import dan200.computercraft.api.turtle.TurtleAnimation;
 import dan200.computercraft.api.turtle.TurtleCommandResult;
+import dan200.computercraft.api.turtle.event.TurtleAction;
+import dan200.computercraft.api.turtle.event.TurtleActionEvent;
 import dan200.computercraft.shared.util.DirectionUtil;
+import net.minecraftforge.common.MinecraftForge;
 
 import javax.annotation.Nonnull;
 
@@ -27,6 +30,12 @@ public class TurtleTurnCommand implements ITurtleCommand
     @Override
     public TurtleCommandResult execute( @Nonnull ITurtleAccess turtle )
     {
+        TurtleActionEvent event = new TurtleActionEvent( turtle, TurtleAction.TURN );
+        if( MinecraftForge.EVENT_BUS.post( event ) )
+        {
+            return TurtleCommandResult.failure( event.getFailureMessage() );
+        }
+
         switch( m_direction )
         {
             case Left:

--- a/src/main/resources/assets/computercraft/lang/en_us.lang
+++ b/src/main/resources/assets/computercraft/lang/en_us.lang
@@ -60,5 +60,6 @@ gui.computercraft:config.turtle_fuel_limit=Turtle fuel limit
 gui.computercraft:config.advanced_turtle_fuel_limit=Advanced Turtle fuel limit
 gui.computercraft:config.turtles_obey_block_protection=Turtles obey block protection
 gui.computercraft:config.turtles_can_push=Turtles can push entities
+gui.computercraft:config.turtle_disabled_actions=Disabled turtle actions
 gui.computercraft:config.maximum_files_open=Maximum files open per computer
 gui.computercraft:config.max_notes_per_tick=Maximum notes that a computer can play at once


### PR DESCRIPTION
This makes most turtle actions fire an event describing the action. Other mods may then listen to the event, cancelling it or changing the behaviour. Examples of things which may be done:

 - Prevent turtles from attacking specific mobs or players.
 - Block turtles from sucking from inventories (but still allow sucking item entities).
 - Add additional data to `.inspect*()` methods.
 - Disable any turtle action.

Most of these serve little purpose in the main mod, but do allow for greater flexibility for other mods. Whilst this technically works as is, I'm marking "WIP" as I'd like to get some thoughts on the whole implementation. It may be that this whole system is overkill and we can build something much simpler but equally powerful.

I'd also like to flesh out the event system a little more. Potentially adding the following:

 - Support for refuelling from non-fuel sources (and blocking from existing ones).
 - Control over turtle animation/action speed (as mentioned in #276).
 - Add additional data to `.getItemDetail()` method.
 - Allow reading/writing ItemStack NBT (and turtle upgrade NBT) when equipping upgrades. This would allow items to preserve information when being equipped and unequipped.