### PR TITLE
amend typo in keys.lua

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/apis/keys.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/keys.lua
@@ -16,7 +16,7 @@ local tKeys = {
 	"comma",	"period",	"slash",	"rightShift","multiply",	-- 51
 	"leftAlt",	"space",	"capsLock",	"f1",		"f2",			-- 56
 	"f3",		"f4",		"f5",		"f6",		"f7",			-- 61
-	"f8",		"f9",		"f10",		"numLock",	"scollLock",	-- 66	
+	"f8",		"f9",		"f10",		"numLock",	"scrollLock",	-- 66	
 	"numPad7",	"numPad8",	"numPad9",	"numPadSubtract","numPad4",	-- 71
 	"numPad5",	"numPad6",	"numPadAdd","numPad1",	"numPad2",		-- 76
 	"numPad3",	"numPad0",	"numPadDecimal",nil,	nil,			-- 81
@@ -53,6 +53,7 @@ for nKey, sKey in pairs( tKeys ) do
 	keys[sKey] = nKey
 end
 keys["return"] = keys.enter
+keys.scollLock = keys.scrollLock
 
 function getName( _nKey )
     if type( _nKey ) ~= "number" then


### PR DESCRIPTION
Skimming through the CC API for an emulator project and found this bug rendering the game "literally unplayable". I decided to take this game-breaking issue into my own hands and repair it. You're welcome CC.

In other words this is the worst reason to receive a contributor tag.