### PR TITLE
Socket Support

### DIFF
--- a/src/main/java/dan200/computercraft/ComputerCraft.java
+++ b/src/main/java/dan200/computercraft/ComputerCraft.java
@@ -121,6 +121,7 @@ public class ComputerCraft
     };
     
     public static boolean http_enable = true;
+    public static boolean socket_enable = true;
     public static AddressPredicate http_whitelist = new AddressPredicate( DEFAULT_HTTP_WHITELIST );
     public static AddressPredicate http_blacklist = new AddressPredicate( DEFAULT_HTTP_BLACKLIST );
     public static boolean disable_lua51_features = false;
@@ -202,6 +203,7 @@ public class ComputerCraft
         public static Property http_enable;
         public static Property http_whitelist;
         public static Property http_blacklist;
+		public static Property socket_enable;
         public static Property disable_lua51_features;
         public static Property default_computer_settings;
         public static Property logPeripheralErrors;
@@ -283,6 +285,7 @@ public class ComputerCraft
                 Config.http_whitelist.setValues( currentProperty.getString().split( ";" ) );
             }
         }
+        
         Config.http_whitelist.setComment( "A list of wildcards for domains or IP ranges that can be accessed through the \"http\" API on Computers.\n" +
             "Set this to \"*\" to access to the entire internet. Example: \"*.pastebin.com\" will restrict access to just subdomains of pastebin.com.\n" +
             "You can use domain names (\"pastebin.com\"), wilcards (\"*.pastebin.com\") or CIDR notation (\"127.0.0.0/8\")." );
@@ -292,6 +295,11 @@ public class ComputerCraft
             "If this is empty then all whitelisted domains will be accessible. Example: \"*.github.com\" will block access to all subdomains of github.com.\n" +
             "You can use domain names (\"pastebin.com\"), wilcards (\"*.pastebin.com\") or CIDR notation (\"127.0.0.0/8\")." );
 
+        
+        Config.socket_enable = Config.config.get( Configuration.CATEGORY_GENERAL, "socket_enable", socket_enable );
+        Config.socket_enable.setComment( "Enable the \"socket\" API on Computers (HTTP must also be enabled)" );
+        
+        
         Config.disable_lua51_features = Config.config.get( Configuration.CATEGORY_GENERAL, "disable_lua51_features", disable_lua51_features );
         Config.disable_lua51_features.setComment( "Set this to true to disable Lua 5.1 functions that will be removed in a future update. Useful for ensuring forward compatibility of your programs now." );
 
@@ -364,6 +372,7 @@ public class ComputerCraft
         http_enable = Config.http_enable.getBoolean();
         http_whitelist = new AddressPredicate( Config.http_whitelist.getStringList() );
         http_blacklist = new AddressPredicate( Config.http_blacklist.getStringList() );
+        socket_enable = Config.socket_enable.getBoolean();
         disable_lua51_features = Config.disable_lua51_features.getBoolean();
         default_computer_settings = Config.default_computer_settings.getString();
         logPeripheralErrors = Config.logPeripheralErrors.getBoolean();

--- a/src/main/java/dan200/computercraft/core/apis/SocketAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/SocketAPI.java
@@ -21,6 +21,12 @@ import static dan200.computercraft.core.apis.ArgumentHelper.*;
 public class SocketAPI implements ILuaAPI, IAsyncObject {
     private final IAPIEnvironment m_apiEnvironment;
     private final List < Socket > m_socks;
+	
+	private String[] methods = {
+        "open",
+        "lookup",
+        "checkHost"
+    };
 
     public SocketAPI(IAPIEnvironment environment) {
 		new AsyncAction().startAsyncAction();
@@ -57,11 +63,7 @@ public class SocketAPI implements ILuaAPI, IAsyncObject {
     @Nonnull
     @Override
     public String[] getMethodNames() {
-        return new String[] {
-            "open",
-            "lookup",
-            "checkHost"
-        };
+        return methods;
     }
 
     @Override
@@ -93,8 +95,7 @@ public class SocketAPI implements ILuaAPI, IAsyncObject {
                             URIChecker.ezCheckHost(URL);
                         } catch (Exception e) {
                             return new Object[] {
-                                false,
-                                e.getMessage()
+                                methods[method], false, e.getMessage()
                             };
                         }
 
@@ -116,8 +117,7 @@ public class SocketAPI implements ILuaAPI, IAsyncObject {
                             m_socks.add(sock);
                         }
                         return new Object[] {
-                            true,
-                            SocketWrapper.wrapSocket(sock, certs, m_apiEnvironment)
+                            methods[method], true, SocketWrapper.wrapSocket(sock, certs, m_apiEnvironment)
                         };
                     }
 
@@ -130,8 +130,7 @@ public class SocketAPI implements ILuaAPI, IAsyncObject {
                             address = URIChecker.ezCheckHost(myURL);
                         } catch (Exception e) {
                             return new Object[] {
-                                false,
-                                e.getMessage()
+                                methods[method], false, e.getMessage()
                             };
                         }
                         String addr = address.getHostAddress();
@@ -141,14 +140,11 @@ public class SocketAPI implements ILuaAPI, IAsyncObject {
                         }
                         if (info == null) {
                             return new Object[] {
-                                true,
-                                addr
+                                methods[method], true, addr
                             };
                         }
                         return new Object[] {
-                            true,
-                            addr,
-                            info.getDefaultPort()
+                            methods[method], true, addr, info.getDefaultPort()
                         };
                     }
 
@@ -160,32 +156,28 @@ public class SocketAPI implements ILuaAPI, IAsyncObject {
                             URIChecker.ezCheckHost(myURL);
                         } catch (Exception e) {
                             return new Object[] {
-                                false,
-                                e.getMessage()
+                                methods[method], false, e.getMessage()
                             };
                         }
                         return new Object[] {
-                            true
+                            methods[method], true
                         };
                     }
 
                 default:
                     {
                         return new Object[] {
-                            false,
-                            "Unknown method of \"Socket\" called"
+                            "?", false, "Unknown method of \"Socket\" called"
                         };
                     }
             }
         } catch (UnknownHostException e) {
             return new Object[] {
-                false,
-                "Unknown host: " + e.getMessage()
+                methods[method], false, "Unknown host: " + e.getMessage()
             };
         } catch (Exception e) {
             return new Object[] {
-                false,
-                e.getMessage()
+                methods[method], false, e.getMessage()
             };
         }
     }

--- a/src/main/java/dan200/computercraft/core/apis/SocketAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/SocketAPI.java
@@ -18,181 +18,175 @@ import java.util.*;
 
 import static dan200.computercraft.core.apis.ArgumentHelper.*;
 
-public class SocketAPI implements ILuaAPI, IAsyncObject
-{
-	private final IAPIEnvironment m_apiEnvironment;
-	private final List<AsyncAction> m_threads;
-	private final List<Socket> m_socks;
-	
-	public SocketAPI( IAPIEnvironment environment )
-    {
+public class SocketAPI implements ILuaAPI, IAsyncObject {
+    private final IAPIEnvironment m_apiEnvironment;
+    private final List < Socket > m_socks;
+
+    public SocketAPI(IAPIEnvironment environment) {
+		new AsyncAction().startAsyncAction();
         m_apiEnvironment = environment;
-		m_threads = new ArrayList<AsyncAction>();
-        m_socks = new ArrayList<Socket>();
+        m_socks = new ArrayList < Socket > ();
     }
-    
+
     @Override
-    public String[] getNames()
-    {
+    public String[] getNames() {
         return new String[] {
             "socket"
         };
     }
 
     @Override
-    public void startup( )
-    {
-    }
+    public void startup() {}
 
     @Override
-    public void advance( double _dt )
-    {
-		synchronized( m_threads )
-        {
-			Iterator<AsyncAction> iterator = m_threads.iterator();
-            while( iterator.hasNext() )
-            {
-				AsyncAction curthread = iterator.next();
-				if (curthread.isDone())
-				{
-					iterator.remove();
-				}
-            }
-        }
-    }
-	
-	@Override
-    public void shutdown( )
-    {
-        synchronized( m_socks )
-        {
-            for( Socket sock : m_socks )
-            {
+    public void advance(double _dt) {}
+
+    @Override
+    public void shutdown() {
+        synchronized(m_socks) {
+            for (Socket sock: m_socks) {
                 try {
                     sock.close();
                 } catch (IOException e) {}
             }
             m_socks.clear();
         }
-		synchronized( m_threads )
-        {
-            m_threads.clear();
-        }
+        AsyncAction.clear();
     }
-	
-	@Nonnull
+
+    @Nonnull
     @Override
-    public String[] getMethodNames()
-    {
-         return new String[] {
-             "open",
-             "lookup",
-			 "checkHost"
+    public String[] getMethodNames() {
+        return new String[] {
+            "open",
+            "lookup",
+            "checkHost"
         };
     }
-	
-	@Override
-    public Object[] callMethod( @Nonnull ILuaContext context, int method, @Nonnull Object[] args ) throws LuaException
-    {
-		switch (method)
-		{
-			
-			default:
-			{
-				AsyncAction action = new AsyncAction(
-					this, m_apiEnvironment, context, method, args
-				);
-				synchronized(m_threads)
-				{
-					m_threads.add(action);
-				}
-		
-				return new Object[] {action.ID};
-			}
-			
-		}
-	}
-	
-	public Object[] callAsyncMeth( @Nonnull ILuaContext context, int method, @Nonnull Object[] args )
-	{
-		try {
-			switch (method)
-			{
-				case 0:
-				{
-					//open
-					String URL = getString( args, 0 );
-                	int port = getInt( args, 1 );
-					boolean useSSL = optBoolean( args, 2, false );
-					
-					try {
-					    URIChecker.ezCheckHost(URL);
-					} catch (Exception e) {
-					    return new Object[] { false, e.getMessage() };
-					}
-                
-					Socket sock;
-					CertWrapper certs;
-                    if (useSSL) {
-                        SSLSocketFactory SSLCreator = (SSLSocketFactory) SSLSocketFactory.getDefault();
-						SSLSocket mysock = (SSLSocket) SSLCreator.createSocket(URL, port);
-						certs = new CertWrapper(mysock);
-						sock = (Socket) mysock;
-					} else {
-						sock = new Socket(URL, port);
-						certs = new CertWrapper();
-					}
-                    sock.setKeepAlive(true);
-                    
-                    synchronized( m_socks )
+
+    @Override
+    public Object[] callMethod(@Nonnull ILuaContext context, int method, @Nonnull Object[] args) throws LuaException {
+        switch (method) {
+
+            default: {
+                int ID = AsyncAction.runAsyncAction(
+                    this, m_apiEnvironment, context, method, args
+                );
+
+                return new Object[] { ID };
+            }
+
+        }
+    }
+
+    public Object[] callAsyncMeth(@Nonnull ILuaContext context, int method, @Nonnull Object[] args) {
+        try {
+            switch (method) {
+                case 0:
                     {
-                        m_socks.add( sock );
+                        //open
+                        String URL = getString(args, 0);
+                        int port = getInt(args, 1);
+                        boolean useSSL = optBoolean(args, 2, false);
+
+                        try {
+                            URIChecker.ezCheckHost(URL);
+                        } catch (Exception e) {
+                            return new Object[] {
+                                false,
+                                e.getMessage()
+                            };
+                        }
+
+                        Socket sock;
+                        CertWrapper certs;
+                        if (useSSL) {
+                            SSLSocketFactory SSLCreator = (SSLSocketFactory) SSLSocketFactory.getDefault();
+                            SSLSocket mysock = (SSLSocket) SSLCreator.createSocket(URL, port);
+                            certs = new CertWrapper(mysock);
+                            sock = (Socket) mysock;
+                        } else {
+                            sock = new Socket(URL, port);
+                            certs = new CertWrapper();
+                        }
+                        sock.setKeepAlive(true);
+						sock.setSoTimeout(5000);
+
+                        synchronized(m_socks) {
+                            m_socks.add(sock);
+                        }
+                        return new Object[] {
+                            true,
+                            SocketWrapper.wrapSocket(sock, certs, m_apiEnvironment)
+                        };
                     }
-                    return new Object[] { true, SocketWrapper.wrapSocket( sock, certs, m_threads, m_apiEnvironment ) };
-				}
-				
-				case 1:
-            	{	
-					//lookup
-					String myURL = getString( args, 0 );
-					InetAddress address;
-					try {
-						address = URIChecker.ezCheckHost(myURL);
-					} catch (Exception e) {
-						return new Object[] { false, e.getMessage() };
-					}
-					String addr = address.getHostAddress();
-					URL info = new URL(myURL);
-					if (info == null){
-						info = new URL( "http://" + myURL );
-					}
-					if (info == null){
-						return new Object[] { true, addr };
-					}
-					return new Object[] { true, addr, info.getDefaultPort() };
-				}
-				
-				case 2:
-				{
-					//checkHost
-					String myURL = getString( args, 0 );
-					try {
-						URIChecker.ezCheckHost(myURL);
-					} catch (Exception e) {
-						return new Object[] { false, e.getMessage() };
-					}
-					return new Object[] { true };
-				}
-				
-				default:
-            	{
-                	return new Object[] {false, "Unknown method of \"Socket\" called"};
-            	}
-			}
-		} catch (UnknownHostException e) {
-			return new Object[] { false, "Unknown host: "+e.getMessage() };
-		} catch (Exception e){
-			return new Object[] { false, e.getMessage() };
-		}
-	}
+
+                case 1:
+                    {
+                        //lookup
+                        String myURL = getString(args, 0);
+                        InetAddress address;
+                        try {
+                            address = URIChecker.ezCheckHost(myURL);
+                        } catch (Exception e) {
+                            return new Object[] {
+                                false,
+                                e.getMessage()
+                            };
+                        }
+                        String addr = address.getHostAddress();
+                        URL info = new URL(myURL);
+                        if (info == null) {
+                            info = new URL("http://" + myURL);
+                        }
+                        if (info == null) {
+                            return new Object[] {
+                                true,
+                                addr
+                            };
+                        }
+                        return new Object[] {
+                            true,
+                            addr,
+                            info.getDefaultPort()
+                        };
+                    }
+
+                case 2:
+                    {
+                        //checkHost
+                        String myURL = getString(args, 0);
+                        try {
+                            URIChecker.ezCheckHost(myURL);
+                        } catch (Exception e) {
+                            return new Object[] {
+                                false,
+                                e.getMessage()
+                            };
+                        }
+                        return new Object[] {
+                            true
+                        };
+                    }
+
+                default:
+                    {
+                        return new Object[] {
+                            false,
+                            "Unknown method of \"Socket\" called"
+                        };
+                    }
+            }
+        } catch (UnknownHostException e) {
+            return new Object[] {
+                false,
+                "Unknown host: " + e.getMessage()
+            };
+        } catch (Exception e) {
+            return new Object[] {
+                false,
+                e.getMessage()
+            };
+        }
+    }
 }

--- a/src/main/java/dan200/computercraft/core/apis/SocketAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/SocketAPI.java
@@ -113,7 +113,7 @@ public class SocketAPI implements ILuaAPI, IAsyncObject
 		}
 	}
 	
-	public Object[] realCallMeth( @Nonnull ILuaContext context, int method, @Nonnull Object[] args )
+	public Object[] callAsyncMeth( @Nonnull ILuaContext context, int method, @Nonnull Object[] args )
 	{
 		try {
 			switch (method)

--- a/src/main/java/dan200/computercraft/core/apis/SocketAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/SocketAPI.java
@@ -1,0 +1,198 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2017. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.core.apis;
+
+import dan200.computercraft.api.lua.*;
+import dan200.computercraft.core.apis.socket.*;
+import dan200.computercraft.core.apis.IAPIEnvironment;
+import javax.annotation.Nonnull;
+import javax.net.ssl.*;
+import java.security.cert.Certificate;
+import java.io.*;
+import java.net.*;
+import java.util.*;
+
+import static dan200.computercraft.core.apis.ArgumentHelper.*;
+
+public class SocketAPI implements ILuaAPI, IAsyncObject
+{
+	private final IAPIEnvironment m_apiEnvironment;
+	private final List<AsyncAction> m_threads;
+	private final List<Socket> m_socks;
+	
+	public SocketAPI( IAPIEnvironment environment )
+    {
+        m_apiEnvironment = environment;
+		m_threads = new ArrayList<AsyncAction>();
+        m_socks = new ArrayList<Socket>();
+    }
+    
+    @Override
+    public String[] getNames()
+    {
+        return new String[] {
+            "socket"
+        };
+    }
+
+    @Override
+    public void startup( )
+    {
+    }
+
+    @Override
+    public void advance( double _dt )
+    {
+		synchronized( m_threads )
+        {
+			Iterator<AsyncAction> iterator = m_threads.iterator();
+            while( iterator.hasNext() )
+            {
+				AsyncAction curthread = iterator.next();
+				if (curthread.isDone())
+				{
+					iterator.remove();
+				}
+            }
+        }
+    }
+	
+	@Override
+    public void shutdown( )
+    {
+        synchronized( m_socks )
+        {
+            for( Socket sock : m_socks )
+            {
+                try {
+                    sock.close();
+                } catch (IOException e) {}
+            }
+            m_socks.clear();
+        }
+		synchronized( m_threads )
+        {
+            m_threads.clear();
+        }
+    }
+	
+	@Nonnull
+    @Override
+    public String[] getMethodNames()
+    {
+         return new String[] {
+             "open",
+             "lookup",
+			 "checkHost"
+        };
+    }
+	
+	@Override
+    public Object[] callMethod( @Nonnull ILuaContext context, int method, @Nonnull Object[] args ) throws LuaException
+    {
+		switch (method)
+		{
+			
+			default:
+			{
+				AsyncAction action = new AsyncAction(
+					this, m_apiEnvironment, context, method, args
+				);
+				synchronized(m_threads)
+				{
+					m_threads.add(action);
+				}
+		
+				return new Object[] {action.ID};
+			}
+			
+		}
+	}
+	
+	public Object[] realCallMeth( @Nonnull ILuaContext context, int method, @Nonnull Object[] args )
+	{
+		try {
+			switch (method)
+			{
+				case 0:
+				{
+					//open
+					String URL = getString( args, 0 );
+                	int port = getInt( args, 1 );
+					boolean useSSL = optBoolean( args, 2, false );
+					
+					try {
+					    URIChecker.ezCheckHost(URL);
+					} catch (Exception e) {
+					    return new Object[] { false, e.getMessage() };
+					}
+                
+					Socket sock;
+					CertWrapper certs;
+                    if (useSSL) {
+                        SSLSocketFactory SSLCreator = (SSLSocketFactory) SSLSocketFactory.getDefault();
+						SSLSocket mysock = (SSLSocket) SSLCreator.createSocket(URL, port);
+						certs = new CertWrapper(mysock);
+						sock = (Socket) mysock;
+					} else {
+						sock = new Socket(URL, port);
+						certs = new CertWrapper();
+					}
+                    sock.setKeepAlive(true);
+                    
+                    synchronized( m_socks )
+                    {
+                        m_socks.add( sock );
+                    }
+                    return new Object[] { true, SocketWrapper.wrapSocket( sock, certs, m_threads, m_apiEnvironment ) };
+				}
+				
+				case 1:
+            	{	
+					//lookup
+					String myURL = getString( args, 0 );
+					InetAddress address;
+					try {
+						address = URIChecker.ezCheckHost(myURL);
+					} catch (Exception e) {
+						return new Object[] { false, e.getMessage() };
+					}
+					String addr = address.getHostAddress();
+					URL info = new URL(myURL);
+					if (info == null){
+						info = new URL( "http://" + myURL );
+					}
+					if (info == null){
+						return new Object[] { true, addr };
+					}
+					return new Object[] { true, addr, info.getDefaultPort() };
+				}
+				
+				case 2:
+				{
+					//checkHost
+					String myURL = getString( args, 0 );
+					try {
+						URIChecker.ezCheckHost(myURL);
+					} catch (Exception e) {
+						return new Object[] { false, e.getMessage() };
+					}
+					return new Object[] { true };
+				}
+				
+				default:
+            	{
+                	return new Object[] {false, "Unknown method of \"Socket\" called"};
+            	}
+			}
+		} catch (UnknownHostException e) {
+			return new Object[] { false, "Unknown host: "+e.getMessage() };
+		} catch (Exception e){
+			return new Object[] { false, e.getMessage() };
+		}
+	}
+}

--- a/src/main/java/dan200/computercraft/core/apis/socket/AsyncAction.java
+++ b/src/main/java/dan200/computercraft/core/apis/socket/AsyncAction.java
@@ -7,77 +7,92 @@
 package dan200.computercraft.core.apis.socket;
 
 import javax.annotation.Nonnull;
+import java.util.*;
 import dan200.computercraft.api.lua.ILuaContext;
 import dan200.computercraft.api.lua.ILuaObject;
 import dan200.computercraft.core.apis.IAPIEnvironment;
 import dan200.computercraft.core.apis.socket.IAsyncObject;
 
-public class AsyncAction
-{
+public class AsyncAction implements Runnable {
+
+    private static final List<AsyncMethod> m_actions = new ArrayList<AsyncMethod>();
+
+    public void startAsyncAction() {
+        Thread m_thread = new Thread(this);
+        m_thread.setDaemon(true);
+        m_thread.start();
+    }
 	
-	private Thread m_thread;
-	public int ID;
-	
-	public AsyncAction(IAsyncObject callable, IAPIEnvironment environment, @Nonnull ILuaContext context, int method, @Nonnull Object[] args)
-	{
-		ArgRunnable newThread = new ArgRunnable(callable, environment, context, method, args);
-		ID = newThread.ID;
-		m_thread = new Thread(newThread);
-		m_thread.setDaemon(true);
-		m_thread.start();
+	public static int runAsyncAction (IAsyncObject callable, IAPIEnvironment environment, @Nonnull ILuaContext context, int method, @Nonnull Object[] args) {
+		AsyncMethod meth = new AsyncMethod(callable, environment, context, method, args);
+		synchronized (m_actions) {
+			m_actions.add(meth);
+		}
+		return meth.ID;
 	}
 	
-	public boolean isDone()
-	{
-		return !(m_thread.isAlive());
+	public static void clear() {
+		synchronized (m_actions) {
+			m_actions.clear();
+		}
 	}
 	
+	public void run() {
+		while (true) {
+			synchronized (m_actions) {
+				Iterator<AsyncMethod> acts = m_actions.iterator();
+				while (acts.hasNext()) {
+					AsyncMethod action = acts.next();
+					action.run();
+					acts.remove();
+				}
+			}
+		}
+	}
+}      
+
+class AsyncMethod {
+
+    private IAsyncObject m_callable;
+    private IAPIEnvironment m_environment;
+    private ILuaContext m_context;
+    private int m_method;
+    private Object[] m_args;
+    public int ID;
+
+    public AsyncMethod(IAsyncObject callable, IAPIEnvironment environment, @Nonnull ILuaContext context, int method, @Nonnull Object[] args) {
+        m_callable = callable;
+        m_environment = environment;
+        m_context = context;
+        m_method = method;
+        m_args = args;
+        ID = Counter.value;
+        Counter.inc();
+    }
+
+    public void run() {
+		try {
+			Object[] rtn = m_callable.callAsyncMeth(m_context, m_method, m_args);
+			Object[] finalRtn = new Object[rtn.length + 1];
+			for (int i = 0; i < rtn.length; i++) {
+				finalRtn[i + 1] = rtn[i];
+			};
+			finalRtn[0] = ID;
+			m_environment.queueEvent("async", finalRtn);
+		} catch (Exception e) {
+			m_environment.queueEvent("async", new Object[] {ID, false, e.getMessage()});
+		}
+    }
+
 }
 
-class ArgRunnable implements Runnable
-{
-	
-	private IAsyncObject m_callable;
-	private IAPIEnvironment m_environment;
-	private ILuaContext m_context;
-	private int m_method;
-	private Object[] m_args;
-	public int ID;
-	
-	public ArgRunnable(IAsyncObject callable, IAPIEnvironment environment, @Nonnull ILuaContext context, int method, @Nonnull Object[] args)
-	{
-		m_callable = callable;
-		m_environment = environment;
-		m_context = context;
-		m_method = method;
-		m_args = args;
-		ID = Counter.value;
-		Counter.inc();
-	}
-	
-	public void run()
-	{		
-		Object[] rtn = m_callable.callAsyncMeth(m_context, m_method, m_args);
-		Object[] finalRtn = new Object[rtn.length+1];
-		for (int i = 0; i < rtn.length; i++)
-		{
-			finalRtn[i+1] = rtn[i];
-		};
-		finalRtn[0] = ID;
-		m_environment.queueEvent( "async", finalRtn );
-	}
-	
-}
+class Counter {
 
-class Counter
-{
-	
-	public static int value = 0;
-	
-	public static void inc()
-	{
-		if (value==2147483647) value = -1;
-		value++;
-	}
-	
+    public static int value = 0;
+
+    public static void inc() {
+        if (value == 2147483647) value = -1;
+        value++;
+    }
+
 }

--- a/src/main/java/dan200/computercraft/core/apis/socket/AsyncAction.java
+++ b/src/main/java/dan200/computercraft/core/apis/socket/AsyncAction.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2017. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.core.apis.socket;
+
+import javax.annotation.Nonnull;
+import dan200.computercraft.api.lua.ILuaContext;
+import dan200.computercraft.api.lua.ILuaObject;
+import dan200.computercraft.core.apis.IAPIEnvironment;
+import dan200.computercraft.core.apis.socket.IAsyncObject;
+
+public class AsyncAction
+{
+	
+	private Thread m_thread;
+	public int ID;
+	
+	public AsyncAction(IAsyncObject callable, IAPIEnvironment environment, @Nonnull ILuaContext context, int method, @Nonnull Object[] args)
+	{
+		ArgRunnable newThread = new ArgRunnable(callable, environment, context, method, args);
+		ID = newThread.ID;
+		m_thread = new Thread(newThread);
+		m_thread.setDaemon(true);
+		m_thread.start();
+	}
+	
+	public boolean isDone()
+	{
+		return !(m_thread.isAlive());
+	}
+	
+}
+
+class ArgRunnable implements Runnable
+{
+	
+	private IAsyncObject m_callable;
+	private IAPIEnvironment m_environment;
+	private ILuaContext m_context;
+	private int m_method;
+	private Object[] m_args;
+	public int ID;
+	
+	public ArgRunnable(IAsyncObject callable, IAPIEnvironment environment, @Nonnull ILuaContext context, int method, @Nonnull Object[] args)
+	{
+		m_callable = callable;
+		m_environment = environment;
+		m_context = context;
+		m_method = method;
+		m_args = args;
+		ID = Counter.value;
+		Counter.inc();
+	}
+	
+	public void run()
+	{		
+		Object[] rtn = m_callable.realCallMeth(m_context, m_method, m_args);
+		Object[] finalRtn = new Object[rtn.length+1];
+		for (int i = 0; i < rtn.length; i++)
+		{
+			finalRtn[i+1] = rtn[i];
+		};
+		finalRtn[0] = ID;
+		m_environment.queueEvent( "async", finalRtn );
+	}
+	
+}
+
+class Counter
+{
+	
+	public static int value = 0;
+	
+	public static void inc()
+	{
+		if (value==2147483647) value = -1;
+		value++;
+	}
+	
+}

--- a/src/main/java/dan200/computercraft/core/apis/socket/AsyncAction.java
+++ b/src/main/java/dan200/computercraft/core/apis/socket/AsyncAction.java
@@ -78,9 +78,9 @@ class AsyncMethod {
 				finalRtn[i + 1] = rtn[i];
 			};
 			finalRtn[0] = ID;
-			m_environment.queueEvent("async", finalRtn);
+			m_environment.queueEvent("async_socket", finalRtn);
 		} catch (Exception e) {
-			m_environment.queueEvent("async", new Object[] {ID, false, e.getMessage()});
+			m_environment.queueEvent("async_socket", new Object[] {ID, false, e.getMessage()});
 		}
     }
 

--- a/src/main/java/dan200/computercraft/core/apis/socket/AsyncAction.java
+++ b/src/main/java/dan200/computercraft/core/apis/socket/AsyncAction.java
@@ -57,7 +57,7 @@ class ArgRunnable implements Runnable
 	
 	public void run()
 	{		
-		Object[] rtn = m_callable.realCallMeth(m_context, m_method, m_args);
+		Object[] rtn = m_callable.callAsyncMeth(m_context, m_method, m_args);
 		Object[] finalRtn = new Object[rtn.length+1];
 		for (int i = 0; i < rtn.length; i++)
 		{

--- a/src/main/java/dan200/computercraft/core/apis/socket/CertWrapper.java
+++ b/src/main/java/dan200/computercraft/core/apis/socket/CertWrapper.java
@@ -15,16 +15,16 @@ import java.util.*;
 public class CertWrapper {
     public boolean hasCertificates = false;
     public Certificate[] certificates;
-    
-    public CertWrapper(SSLSocket sock){
+
+    public CertWrapper(SSLSocket sock) {
         try {
-		    sock.startHandshake();
-		    SSLSession sslsock = sock.getSession();
-		    this.certificates = sslsock.getPeerCertificates();
-		    this.hasCertificates = true; 
-	    } catch (Exception e){
-			System.out.println("Failed to initialize SSL connection!\nException reached: " + e.getMessage());
-	    }
+            sock.startHandshake();
+            SSLSession sslsock = sock.getSession();
+            this.certificates = sslsock.getPeerCertificates();
+            this.hasCertificates = true;
+        } catch (Exception e) {
+            System.out.println("Failed to initialize SSL connection!\nException reached: " + e.getMessage());
+        }
     }
-    public CertWrapper(){}
+    public CertWrapper() {}
 }

--- a/src/main/java/dan200/computercraft/core/apis/socket/CertWrapper.java
+++ b/src/main/java/dan200/computercraft/core/apis/socket/CertWrapper.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2017. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.core.apis.socket;
+
+import javax.net.ssl.*;
+import java.security.cert.Certificate;
+import java.io.*;
+import java.net.*;
+import java.util.*;
+
+public class CertWrapper {
+    public boolean hasCertificates = false;
+    public Certificate[] certificates;
+    
+    public CertWrapper(SSLSocket sock){
+        try {
+		    sock.startHandshake();
+		    SSLSession sslsock = sock.getSession();
+		    this.certificates = sslsock.getPeerCertificates();
+		    this.hasCertificates = true; 
+	    } catch (Exception e){
+			System.out.println("Failed to initialize SSL connection!\nException reached: " + e.getMessage());
+	    }
+    }
+    public CertWrapper(){}
+}

--- a/src/main/java/dan200/computercraft/core/apis/socket/IAsyncObject.java
+++ b/src/main/java/dan200/computercraft/core/apis/socket/IAsyncObject.java
@@ -1,0 +1,15 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2017. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.core.apis.socket;
+
+import javax.annotation.Nonnull;
+import dan200.computercraft.api.lua.ILuaContext;
+
+public interface IAsyncObject
+{
+	Object[] realCallMeth( @Nonnull ILuaContext context, int method, @Nonnull Object[] args );
+}

--- a/src/main/java/dan200/computercraft/core/apis/socket/IAsyncObject.java
+++ b/src/main/java/dan200/computercraft/core/apis/socket/IAsyncObject.java
@@ -11,5 +11,5 @@ import dan200.computercraft.api.lua.ILuaContext;
 
 public interface IAsyncObject
 {
-	Object[] realCallMeth( @Nonnull ILuaContext context, int method, @Nonnull Object[] args );
+	Object[] callAsyncMeth( @Nonnull ILuaContext context, int method, @Nonnull Object[] args );
 }

--- a/src/main/java/dan200/computercraft/core/apis/socket/SocketWrapper.java
+++ b/src/main/java/dan200/computercraft/core/apis/socket/SocketWrapper.java
@@ -67,7 +67,7 @@ public class SocketWrapper{
 				}
 			}
 			
-			public Object[] realCallMeth( @Nonnull ILuaContext context, int method, @Nonnull Object[] args )
+			public Object[] callAsyncMeth( @Nonnull ILuaContext context, int method, @Nonnull Object[] args )
 			{
 				try {
 					if ((method != 3) && sock.isClosed())

--- a/src/main/java/dan200/computercraft/core/apis/socket/SocketWrapper.java
+++ b/src/main/java/dan200/computercraft/core/apis/socket/SocketWrapper.java
@@ -1,0 +1,158 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2017. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.core.apis.socket;
+
+import dan200.computercraft.api.lua.*;
+import dan200.computercraft.core.apis.socket.AsyncAction;
+import dan200.computercraft.core.apis.socket.IAsyncObject;
+import dan200.computercraft.core.apis.socket.CertWrapper;
+import dan200.computercraft.core.apis.IAPIEnvironment;
+import javax.annotation.Nonnull;
+import javax.net.ssl.*;
+import java.security.cert.Certificate;
+import java.io.*;
+import java.net.*;
+import java.util.*;
+
+import static dan200.computercraft.core.apis.ArgumentHelper.*;
+
+
+public class SocketWrapper{
+	
+	final static String[] methods = new String[]{
+        "write",
+        "read",
+        "close",
+        "isClosed",
+        "getCertificates",
+        "clear",
+        "length"
+    };
+	
+	public static ILuaObject wrapSocket( final Socket sock, final CertWrapper certs, final List<AsyncAction> m_threads, IAPIEnvironment m_apiEnvironment )
+	{
+		class WrappedSocket implements ILuaObject, IAsyncObject
+		{
+			
+			@Nonnull
+            @Override
+            public String[] getMethodNames()
+            {
+                return methods;
+            }
+			
+			@Override
+            public Object[] callMethod( @Nonnull ILuaContext context, int method, @Nonnull Object[] args ) throws LuaException, InterruptedException
+			{
+				switch (method)
+				{
+			
+					default:
+					{
+						AsyncAction action = new AsyncAction(
+							this, m_apiEnvironment, context, method, args
+						);
+						synchronized(m_threads)
+						{
+							m_threads.add(action);
+						}
+		
+						return new Object[] {action.ID};
+					}
+			
+				}
+			}
+			
+			public Object[] realCallMeth( @Nonnull ILuaContext context, int method, @Nonnull Object[] args )
+			{
+				try {
+					if ((method != 3) && sock.isClosed())
+					{
+						throw new Exception("Attempt to interact with closed socket");
+					};
+					
+              		switch( method )
+             	 	{
+              	    	case 0:
+               	     	{
+                        	// write
+							String arg = getString(args, 0);
+							byte[] bytes = arg.getBytes();
+                        	sock.getOutputStream().write(bytes);
+                        
+                     	    return new Object[] { true };
+                  		}
+                    	case 1:
+                    	{
+                        	// read
+							int times = optInt(args, 0, 1);
+                        
+							String result = "";
+							for (int i=0; i<times; i++) {
+								result = result + sock.getInputStream().read();
+							}
+							return new Object[] { true, result };
+                    	}
+                    	case 2:
+                    	{
+                        	// close
+							sock.close();
+                        
+                        	return new Object[] { true };
+                    	}
+                    	case 3:
+                    	{
+                        	// isClosed
+                        
+                        	return new Object[] { true, sock.isClosed() };
+                    	}
+                    	case 4:
+                    	{
+                        	//getCertificates
+                            if (!certs.hasCertificates) {
+                        	    return new Object[]{ false, "The socket is not secure" };
+                            }
+                            
+                            Object[] rtn = new Object[1+certs.certificates.length];
+                            
+							System.out.println(certs.certificates.length);
+                            for (int i = 0; i < certs.certificates.length; i++) {
+                                rtn[i+1] = certs.certificates[i].getType();
+                            }
+							rtn[0] = true;
+                            
+                            return rtn;
+                    	}
+                    	case 5:
+                    	{
+                        	//clear
+                        	sock.getInputStream().skip(sock.getInputStream().available());
+                        
+                        	return new Object[] { true };
+                    	}
+                    	case 6:
+                    	{
+                        	//length
+                        
+                        	return new Object[] {true, sock.getInputStream().available()};
+                    	}
+                    
+                    	default:
+                    	{
+                        	return new Object[] {false, "Unknown method of \"Sock\" class called"};
+                    	}
+                	}
+				} catch (Exception e){
+					return new Object[] {false, e.getMessage()};
+				}
+			}
+			
+		}
+		return new WrappedSocket();
+	}
+	
+}

--- a/src/main/java/dan200/computercraft/core/apis/socket/SocketWrapper.java
+++ b/src/main/java/dan200/computercraft/core/apis/socket/SocketWrapper.java
@@ -17,142 +17,157 @@ import java.security.cert.Certificate;
 import java.io.*;
 import java.net.*;
 import java.util.*;
+import java.math.BigInteger;
 
 import static dan200.computercraft.core.apis.ArgumentHelper.*;
 
 
-public class SocketWrapper{
-	
-	final static String[] methods = new String[]{
+public class SocketWrapper {
+
+    final static String[] methods = new String[] {
         "write",
         "read",
         "close",
         "isClosed",
         "getCertificates",
-        "clear",
-        "length"
+		"readLine"
     };
-	
-	public static ILuaObject wrapSocket( final Socket sock, final CertWrapper certs, final List<AsyncAction> m_threads, IAPIEnvironment m_apiEnvironment )
-	{
-		class WrappedSocket implements ILuaObject, IAsyncObject
-		{
+
+    public static ILuaObject wrapSocket(final Socket sock, final CertWrapper certs, IAPIEnvironment m_apiEnvironment) {
+        class WrappedSocket implements ILuaObject, IAsyncObject {
+
+			private boolean isEnd = false;
 			
-			@Nonnull
+            @Nonnull
             @Override
-            public String[] getMethodNames()
-            {
+            public String[] getMethodNames() {
                 return methods;
             }
-			
-			@Override
-            public Object[] callMethod( @Nonnull ILuaContext context, int method, @Nonnull Object[] args ) throws LuaException, InterruptedException
-			{
-				switch (method)
-				{
-			
-					default:
-					{
-						AsyncAction action = new AsyncAction(
+
+            @Override
+            public Object[] callMethod(@Nonnull ILuaContext context, int method, @Nonnull Object[] args) throws LuaException, InterruptedException {
+                switch (method) {
+
+                    default: {
+						int ID = AsyncAction.runAsyncAction(
 							this, m_apiEnvironment, context, method, args
 						);
-						synchronized(m_threads)
+
+						return new Object[] { ID };
+                    }
+
+                }
+            }
+
+            public Object[] callAsyncMeth(@Nonnull ILuaContext context, int method, @Nonnull Object[] args) {
+                try {
+                    if ((method != 3) && sock.isClosed()) {
+                        throw new Exception("Attempt to interact with closed socket");
+                    };
+
+                    switch (method) {
+                        case 0:
+                            {
+                                // write
+                                String arg = getString(args, 0);
+                                byte[] bytes = arg.getBytes("UTF-8");
+                                sock.getOutputStream().write(bytes);
+
+                                return new Object[] { true };
+                            }
+                        case 1:
+                            {
+                                // read
+                                int times = optInt(args, 0, 1);
+
+								String res = "";
+								int lastbyte = 0;
+								try {
+									for (int i = 0; i < times; i++) {
+										if (lastbyte != -1){
+											lastbyte = sock.getInputStream().read();
+											if (lastbyte != -1) {
+												byte[] bytes = {(byte) lastbyte};
+												res = res + new String(bytes, "UTF-8");
+											}
+										} else {
+											isEnd = true;
+											break;
+										}
+									}
+								} catch (SocketTimeoutException e) {}
+                                return new Object[] { true, res, isEnd };
+                            }
+                        case 2:
+                            {
+                                // close
+                                sock.close();
+
+                                return new Object[] {
+                                    true
+                                };
+                            }
+                        case 3:
+                            {
+                                // isClosed
+
+                                return new Object[] {
+                                    true,
+                                    sock.isClosed()
+                                };
+                            }
+                        case 4:
+                            {
+                                //getCertificates
+                                if (!certs.hasCertificates) {
+                                    return new Object[] {
+                                        false,
+                                        "The socket is not secure"
+                                    };
+                                }
+
+                                Object[] rtn = new Object[1 + certs.certificates.length];
+
+                                System.out.println(certs.certificates.length);
+                                for (int i = 0; i < certs.certificates.length; i++) {
+                                    rtn[i + 1] = certs.certificates[i].getType();
+                                }
+                                rtn[0] = true;
+
+                                return rtn;
+                            }
+							
+						case 5:
 						{
-							m_threads.add(action);
+							//readLine
+							String res = "";
+							try {
+								res = new BufferedReader(new InputStreamReader(sock.getInputStream(), "UTF-8")).readLine();
+								if (res == null) {
+									isEnd = true;
+								}
+							} catch (SocketTimeoutException e) {}
+                            return new Object[] { true, res, isEnd };
 						}
-		
-						return new Object[] {action.ID};
-					}
-			
-				}
-			}
-			
-			public Object[] callAsyncMeth( @Nonnull ILuaContext context, int method, @Nonnull Object[] args )
-			{
-				try {
-					if ((method != 3) && sock.isClosed())
-					{
-						throw new Exception("Attempt to interact with closed socket");
-					};
-					
-              		switch( method )
-             	 	{
-              	    	case 0:
-               	     	{
-                        	// write
-							String arg = getString(args, 0);
-							byte[] bytes = arg.getBytes();
-                        	sock.getOutputStream().write(bytes);
-                        
-                     	    return new Object[] { true };
-                  		}
-                    	case 1:
-                    	{
-                        	// read
-							int times = optInt(args, 0, 1);
-                        
-							String result = "";
-							for (int i=0; i<times; i++) {
-								result = result + sock.getInputStream().read();
-							}
-							return new Object[] { true, result };
-                    	}
-                    	case 2:
-                    	{
-                        	// close
-							sock.close();
-                        
-                        	return new Object[] { true };
-                    	}
-                    	case 3:
-                    	{
-                        	// isClosed
-                        
-                        	return new Object[] { true, sock.isClosed() };
-                    	}
-                    	case 4:
-                    	{
-                        	//getCertificates
-                            if (!certs.hasCertificates) {
-                        	    return new Object[]{ false, "The socket is not secure" };
+
+                        default:
+                            {
+                                return new Object[] {
+                                    false,
+                                    "Unknown method of \"Sock\" class called"
+                                };
                             }
-                            
-                            Object[] rtn = new Object[1+certs.certificates.length];
-                            
-							System.out.println(certs.certificates.length);
-                            for (int i = 0; i < certs.certificates.length; i++) {
-                                rtn[i+1] = certs.certificates[i].getType();
-                            }
-							rtn[0] = true;
-                            
-                            return rtn;
-                    	}
-                    	case 5:
-                    	{
-                        	//clear
-                        	sock.getInputStream().skip(sock.getInputStream().available());
-                        
-                        	return new Object[] { true };
-                    	}
-                    	case 6:
-                    	{
-                        	//length
-                        
-                        	return new Object[] {true, sock.getInputStream().available()};
-                    	}
-                    
-                    	default:
-                    	{
-                        	return new Object[] {false, "Unknown method of \"Sock\" class called"};
-                    	}
-                	}
-				} catch (Exception e){
-					return new Object[] {false, e.getMessage()};
-				}
-			}
-			
-		}
-		return new WrappedSocket();
-	}
-	
+                    }
+                } catch (Exception e) {
+                    return new Object[] {
+                        false,
+                        e.getMessage()
+                    };
+                }
+            }
+
+        }
+        return new WrappedSocket();
+    }
+
 }

--- a/src/main/java/dan200/computercraft/core/apis/socket/SocketWrapper.java
+++ b/src/main/java/dan200/computercraft/core/apis/socket/SocketWrapper.java
@@ -34,7 +34,7 @@ public class SocketWrapper {
 		"readAll"
     };
 
-    public static ILuaObject wrapSocket(final Socket sock, final CertWrapper certs, IAPIEnvironment m_apiEnvironment) {
+    public static ILuaObject wrapSocket(final Socket sock, final CertWrapper certs, IAPIEnvironment m_apiEnvironment, AsyncAction m_queue) {
         class WrappedSocket implements ILuaObject, IAsyncObject {
 
 			
@@ -49,7 +49,7 @@ public class SocketWrapper {
                 switch (method) {
 
                     default: {
-						int ID = AsyncAction.runAsyncAction(
+						int ID = m_queue.runAsyncAction(
 							this, m_apiEnvironment, context, method, args
 						);
 

--- a/src/main/java/dan200/computercraft/core/apis/socket/URIChecker.java
+++ b/src/main/java/dan200/computercraft/core/apis/socket/URIChecker.java
@@ -15,7 +15,6 @@ public class URIChecker {
     {
         try
         {
-			System.out.println(url);
             InetAddress resolved = InetAddress.getByName( url );
             if( !ComputerCraft.http_whitelist.matches( resolved ) || ComputerCraft.http_blacklist.matches( resolved ) )
             {

--- a/src/main/java/dan200/computercraft/core/apis/socket/URIChecker.java
+++ b/src/main/java/dan200/computercraft/core/apis/socket/URIChecker.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2017. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.core.apis.socket;
+
+import dan200.computercraft.ComputerCraft;
+import dan200.computercraft.core.apis.HTTPRequestException;
+import java.net.*;
+
+public class URIChecker {
+	public static InetAddress checkHost( String url ) throws HTTPRequestException
+    {
+        try
+        {
+			System.out.println(url);
+            InetAddress resolved = InetAddress.getByName( url );
+            if( !ComputerCraft.http_whitelist.matches( resolved ) || ComputerCraft.http_blacklist.matches( resolved ) )
+            {
+                throw new HTTPRequestException( "Domain not permitted" );
+            }
+
+            return resolved;
+        }
+        catch( UnknownHostException e )
+        {
+            throw new HTTPRequestException( "Unknown host" );
+        }
+    }
+	public static InetAddress checkHost( URI url ) throws HTTPRequestException
+	{
+		return checkHost(url.getHost());
+	}
+	public static InetAddress ezCheckHost( String myURL ) throws HTTPRequestException
+	{
+		try {
+			return checkHost(new URI(myURL));
+		} catch (Exception b) {
+			return checkHost(myURL);
+		}
+	}
+}

--- a/src/main/java/dan200/computercraft/core/computer/Computer.java
+++ b/src/main/java/dan200/computercraft/core/computer/Computer.java
@@ -615,6 +615,9 @@ public class Computer
         //m_apis.add( new BufferAPI( m_apiEnvironment ) );
         if( ComputerCraft.http_enable )
         {
+            if( ComputerCraft.socket_enable ){
+                m_apis.add( new SocketAPI( m_apiEnvironment ) );
+            }
             m_apis.add( new HTTPAPI( m_apiEnvironment ) );
         }
     }

--- a/src/main/resources/assets/computercraft/lang/en_us.lang
+++ b/src/main/resources/assets/computercraft/lang/en_us.lang
@@ -48,6 +48,7 @@ gui.computercraft:config.http_blacklist=HTTP blacklist
 gui.computercraft:config.disable_lua51_features=Disable Lua 5.1 features
 gui.computercraft:config.default_computer_settings=Default Computer settings
 gui.computercraft:config.log_peripheral_errors=Log peripheral errors
+gui.computercraft:config.socket_enable=Enable socket API
 gui.computercraft:config.enable_command_block=Enable command block peripheral
 gui.computercraft:config.modem_range=Modem range (default)
 gui.computercraft:config.modem_high_altitude_range=Modem range (high-altitude)

--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -891,6 +891,21 @@ if pocket and fs.isDir( "rom/apis/pocket" ) then
     end
 end
 
+if socket and fs.isDir( "rom/apis/socket" ) then
+    -- Load socket APIs
+    local tApis = fs.list( "rom/apis/socket" )
+    for n,sFile in ipairs( tApis ) do
+        if string.sub( sFile, 1, 1 ) ~= "." then
+            local sPath = fs.combine( "rom/apis/socket", sFile )
+            if not fs.isDir( sPath ) then
+                if not os.loadAPI( sPath ) then
+                    bAPIError = true
+                end
+            end
+        end
+    end
+end
+
 if commands and fs.isDir( "rom/apis/command" ) then
     -- Load command APIs
     if os.loadAPI( "rom/apis/command/commands.lua" ) then

--- a/src/main/resources/assets/computercraft/lua/rom/apis/socket/socket.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/socket/socket.lua
@@ -6,12 +6,12 @@ local function invokeAsyncFunc(func, ...)
   end
   local e = {}
   while not (e[2] == id) do
-    e = {os.pullEvent("async")}
+    e = {os.pullEvent("async_socket")}
   end
-  if not e[3] then
-    error(e[4], 3)
+  if not e[4] then
+    error(e[5], 3)
   end
-  for i = 1, 3 do
+  for i = 1, 4 do
     table.remove(e, 1)
   end
   return table.unpack(e)

--- a/src/main/resources/assets/computercraft/lua/rom/apis/socket/socket.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/socket/socket.lua
@@ -1,0 +1,73 @@
+local nativeSocket = socket
+local function invokeAsyncFunc(func, ...)
+  local ok, id = pcall(func, ...)
+  if not ok then
+	error(id, 2)
+  end
+  local e = {}
+  while not (e[2] == id) do
+    e = {os.pullEvent("async")}
+  end
+  if not e[3] then
+    error(e[4], 3)
+  end
+  for i = 1, 3 do
+    table.remove(e, 1)
+  end
+  return table.unpack(e)
+end
+checkHostAsync = function(URL)
+  if not (type(URL) == "string") then
+    error("Bad argument #1 (expected string, got "..type(URL)..")", 2)
+  end
+  return nativeSocket.checkHost(URL)
+end
+checkHost = function(URL)
+  if not (type(URL) == "string") then
+    error("Bad argument #1 (expected string, got "..type(URL)..")", 2)
+  end
+  return invokeAsyncFunc(nativeSocket.checkHost, URL)
+end
+lookupAsync = function(URL)
+  if not (type(URL) == "string") then
+    error("Bad argument #1 (expected string, got "..type(URL)..")", 2)
+  end
+  return nativeSocket.lookup(URL)
+end
+lookup = function(URL)
+  if not (type(URL) == "string") then
+    error("Bad argument #1 (expected string, got "..type(URL)..")", 2)
+  end
+  return invokeAsyncFunc(nativeSocket.lookup, URL)
+end
+openAsync = function(host, port, isSSL)
+  if not (type(host) == "string") then
+    error("Bad argument #1 (expected string, got "..type(host)..")", 2)
+  end
+  if type(port) ~= "number" then
+    error("Bad argument #2 (expected number, got "..type(port)..")", 2)
+  end
+  if isSSL ~= nil and type(isSSL) ~= "boolean" then
+    error("Bad argument #3 (expected boolean, got "..type(isSSL)..")", 2)
+  end
+  return nativeSocket.open(host, port, isSSL)
+end
+open = function(host, port, isSSL)
+  if not (type(host) == "string") then
+    error("Bad argument #1 (expected string, got "..type(host)..")", 2)
+  end
+  if type(port) ~= "number" then
+    error("Bad argument #2 (expected number, got "..type(port)..")", 2)
+  end
+  if isSSL ~= nil and type(isSSL) ~= "boolean" then
+    error("Bad argument #3 (expected boolean, got "..type(isSSL)..")", 2)
+  end
+  local nativeSock = invokeAsyncFunc(nativeSocket.open, host, port, isSSL)
+  local newSock = {}
+  for k, v in pairs(nativeSock) do
+    newSock[k] = function(...)
+	  return invokeAsyncFunc(v, ...)
+	end
+  end
+  return newSock
+end

--- a/src/main/resources/assets/computercraft/lua/rom/help/socket.txt
+++ b/src/main/resources/assets/computercraft/lua/rom/help/socket.txt
@@ -1,0 +1,21 @@
+The functions included in the socket API are as follows:
+ok, host, port = socket.lookup(uri) --Returns the values required for socket.open
+ok, sock = socket.open(host, port, useSSL) --Returns a socket. Note that the host must be an IP address, which can be found with socket.lookup()
+ok, err = socket.checkHost(host) --Basically http.checkURL, but with URIs
+
+They are also available in an async form.
+Simply append "Async" to the command and wait for the "async" event
+The async variations will return an id, which can be compared to the id of the async event
+id = socket.someMethodAsync(...)
+"async", id, ... = os.pullEvent("async")
+
+Object "sock" is as follow:
+ok, length = sock.length() --Returns length of unread buffer
+ok, text = sock.read(n) --Reads and removes n bytes from buffer
+ok = sock.write(text) --Writes text to the server
+ok = sock.close() --Closes the socket
+true, isClosed = sock.isClosed() --Checks the state of the socket
+ok, certs = sock.getCertificate() --Get a table with the names of certificates. If the socket is not SSL, this will return false
+
+Openning a socket with openAsync will make all methods of the sock object async.
+The method names are not changed.

--- a/src/main/resources/assets/computercraft/lua/rom/help/socket.txt
+++ b/src/main/resources/assets/computercraft/lua/rom/help/socket.txt
@@ -4,17 +4,20 @@ sock = socket.open(host, port, useSSL) --Returns a socket. Note that the host mu
 socket.checkHost(host) --Basically http.checkURL, but with URIs
 
 They are also available in an async form.
-Simply append "Async" to the command and wait for the "async" event
-The async variations will return an id, which can be compared to the id of the async event
+Simply append "Async" to the command and wait for the "async_socket" event
+The async variations will return an id, which can be compared to the id of the async event'
+
 id = socket.someMethodAsync(...)
-"async", id, ok, ... = os.pullEvent("async")
+"async", id, type, ok, ... = os.pullEvent("async_socket")
 
 Object "sock" is as follow:
 text = sock.read(n) --Reads and removes n bytes from buffer
 sock.write(text) --Writes text to the server
 sock.close() --Closes the socket
 isClosed = sock.isClosed() --Checks the state of the socket
-certs = sock.getCertificate() --Get a table with the names of certificates. If the socket is not SSL, this will return false
+certs = sock.getCertificates() --Get a table with the names of certificates.
+text = sock.readLine() --Reads a line, if possible
+text = sock.readAll() --Reads whatever it can
 
 Openning a socket with openAsync will make all methods of the sock object async.
 The method names are not changed.

--- a/src/main/resources/assets/computercraft/lua/rom/help/socket.txt
+++ b/src/main/resources/assets/computercraft/lua/rom/help/socket.txt
@@ -10,7 +10,6 @@ id = socket.someMethodAsync(...)
 "async", id, ok, ... = os.pullEvent("async")
 
 Object "sock" is as follow:
-length = sock.length() --Returns length of unread buffer
 text = sock.read(n) --Reads and removes n bytes from buffer
 sock.write(text) --Writes text to the server
 sock.close() --Closes the socket

--- a/src/main/resources/assets/computercraft/lua/rom/help/socket.txt
+++ b/src/main/resources/assets/computercraft/lua/rom/help/socket.txt
@@ -1,21 +1,23 @@
 The functions included in the socket API are as follows:
-ok, host, port = socket.lookup(uri) --Returns the values required for socket.open
-ok, sock = socket.open(host, port, useSSL) --Returns a socket. Note that the host must be an IP address, which can be found with socket.lookup()
-ok, err = socket.checkHost(host) --Basically http.checkURL, but with URIs
+host, port = socket.lookup(uri) --Returns the values required for socket.open
+sock = socket.open(host, port, useSSL) --Returns a socket. Note that the host must be an IP address, which can be found with socket.lookup()
+socket.checkHost(host) --Basically http.checkURL, but with URIs
 
 They are also available in an async form.
 Simply append "Async" to the command and wait for the "async" event
 The async variations will return an id, which can be compared to the id of the async event
 id = socket.someMethodAsync(...)
-"async", id, ... = os.pullEvent("async")
+"async", id, ok, ... = os.pullEvent("async")
 
 Object "sock" is as follow:
-ok, length = sock.length() --Returns length of unread buffer
-ok, text = sock.read(n) --Reads and removes n bytes from buffer
-ok = sock.write(text) --Writes text to the server
-ok = sock.close() --Closes the socket
-true, isClosed = sock.isClosed() --Checks the state of the socket
-ok, certs = sock.getCertificate() --Get a table with the names of certificates. If the socket is not SSL, this will return false
+length = sock.length() --Returns length of unread buffer
+text = sock.read(n) --Reads and removes n bytes from buffer
+sock.write(text) --Writes text to the server
+sock.close() --Closes the socket
+isClosed = sock.isClosed() --Checks the state of the socket
+certs = sock.getCertificate() --Get a table with the names of certificates. If the socket is not SSL, this will return false
 
 Openning a socket with openAsync will make all methods of the sock object async.
 The method names are not changed.
+
+Note that non-async versions of methods will error if the ok code returned by the async version is false

--- a/src/main/resources/assets/computercraft/lua/rom/help/socket.txt
+++ b/src/main/resources/assets/computercraft/lua/rom/help/socket.txt
@@ -1,5 +1,5 @@
 The functions included in the socket API are as follows:
-host, port = socket.lookup(uri) --Returns the values required for socket.open
+host, port, scheme = socket.lookup(uri) --Returns the values required for socket.open. If scheme is not recognized, port will be -1
 sock = socket.open(host, port, useSSL) --Returns a socket. Note that the host must be an IP address, which can be found with socket.lookup()
 socket.checkHost(host) --Basically http.checkURL, but with URIs
 


### PR DESCRIPTION
Adds socket support.

Here is an example script:

```
local host, port = socket.lookup("https://google.com/")
local sock = socket.open(host, port, true)
sock.write("GET /search?q=Google HTTP/1.1\n\n")
print(sock.readAll())
```

Also supports ASYNC requests

There is a small minor bug with sock.length and sock.clear, where Java seems to divide the output into buffers, but it does not matter too much.