### PR TITLE
Be a little smarter about our detection of the placed sign

### DIFF
--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtlePlaceCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtlePlaceCommand.java
@@ -365,7 +365,7 @@ public class TurtlePlaceCommand implements ITurtleCommand
 
         // Do the deploying (put everything in the players inventory)
         boolean placed = false;
-
+        TileEntity existingTile = turtle.getWorld().getTileEntity( position );
 
         // See PlayerInteractionManager.processRightClickBlock
         PlayerInteractEvent.RightClickBlock event = ForgeHooks.onRightClickBlock( turtlePlayer, EnumHand.MAIN_HAND, position, side, new Vec3d( hitX, hitY, hitZ ) );
@@ -409,12 +409,11 @@ public class TurtlePlaceCommand implements ITurtleCommand
             {
                 World world = turtle.getWorld();
                 TileEntity tile = world.getTileEntity( position );
-                if( tile == null )
+                if( tile == null || tile == existingTile )
                 {
-                    BlockPos newPosition = WorldUtil.moveCoords( position, side );
-                    tile = world.getTileEntity( newPosition );
+                    tile = world.getTileEntity( WorldUtil.moveCoords( position, side ) );
                 }
-                if( tile != null && tile instanceof TileEntitySign )
+                if( tile instanceof TileEntitySign )
                 {
                     TileEntitySign signTile = (TileEntitySign) tile;
                     String s = (String)extraArguments[0];


### PR DESCRIPTION
When placing a sign against a tile entity (such as a turtle or chest), we would consider that block the "placed" one instead, meaning the text was never set. This solution isn't entirely ideal either, but short of capturing block snapshots I'm not sure of a better solution.

Fixes #552