### PR TITLE
A couple of small improvements to CraftOS

### DIFF
--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -18,9 +18,6 @@ if _VERSION == "Lua 5.1" then
         if env ~= nil and type( env) ~= "table" then
             error( "bad argument #4 (expected table, got " .. type( env ) .. ")", 2 ) 
         end
-        if mode ~= nil and mode ~= "t" then
-            error( "Binary chunk loading prohibited", 2 )
-        end
         local ok, p1, p2 = pcall( function()        
             if type(x) == "string" then
                 local result, err = nativeloadstring( x, name )

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
@@ -421,8 +421,10 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
     function window.reposition( nNewX, nNewY, nNewWidth, nNewHeight )
         if type( nNewX ) ~= "number" then error( "bad argument #1 (expected number, got " .. type( nNewX ) .. ")", 2 ) end
         if type( nNewY ) ~= "number" then error( "bad argument #2 (expected number, got " .. type( nNewY ) .. ")", 2 ) end
-        if nNewWidth ~= nil and type( nNewWidth ) ~= "number" then error( "bad argument #3 (expected number, got " .. type( nNewWidth ) .. ")", 2 ) end
-        if nNewHeight ~= nil and type( nNewHeight ) ~= "number" then error( "bad argument #4 (expected number, got " .. type( nNewHeight ) .. ")", 2 ) end
+        if nNewWidth ~= nil or nNewWidth ~= nil  then
+            if type( nNewWidth ) ~= "number" then error( "bad argument #3 (expected number, got " .. type( nNewWidth ) .. ")", 2 ) end
+            if type( nNewHeight ) ~= "number" then error( "bad argument #4 (expected number, got " .. type( nNewHeight ) .. ")", 2 ) end
+        end
 
         nX = nNewX
         nY = nNewY

--- a/src/main/resources/assets/computercraft/lua/rom/programs/help.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/help.lua
@@ -13,18 +13,14 @@ if sTopic == "index" then
     return
 end
     
-local w,h = term.getSize()
 local sFile = help.lookup( sTopic )
 local file = ((sFile ~= nil) and io.open( sFile )) or nil
-local nLinesPrinted = 0
 if file then
-    local sLine = file:read()
-    local nLines = 0
-    while sLine do
-        nLines = nLines + textutils.pagedPrint( sLine, (h-3) - nLines )
-        sLine = file:read()
-    end
+    local sContents = file:read("*a")
     file:close()
+
+    local _, nHeight = term.getSize()
+    textutils.pagedPrint( sContents, nHeight - 3 )
 else
     print( "No help available" )
 end

--- a/src/main/resources/assets/computercraft/lua/rom/programs/http/pastebin.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/http/pastebin.lua
@@ -113,7 +113,7 @@ elseif sCommand == "run" then
             printError( err )
             return
         end
-        local success, msg = pcall(func, table.unpack(tArgs, 3))
+        local success, msg = pcall(func, select(3, ...))
         if not success then
             printError( msg )
         end

--- a/src/main/resources/assets/computercraft/lua/rom/programs/turtle/dance.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/turtle/dance.lua
@@ -89,18 +89,17 @@ end
 
 print( "Press any key to stop the groove" )
 
-local bEnd = false
-parallel.waitForAll(
+parallel.waitForAny(
     function()
         while not bEnd do
             local event, key = os.pullEvent("key")
             if key ~= keys.escape then
-                bEnd = true
+                return
             end
         end        
     end,
     function()
-        while not bEnd do
+        while true do
             local fnMove = tMoves[math.random(1,#tMoves)]
             fnMove()
         end


### PR DESCRIPTION
 - Make window.reposition's argument validation a little more strict. Previously it would accept `window.reposition(x, y, width)` (no height argument), just not act upon it.
 - Use select instead of table.unpack within `pastebin run`.
 - Use `parallel.waitForAny` instead of `waitForAll` within the dance program.
 - Pipe the entire help file into `textutils.pagedPrint`, rather than doing it line by line.
 - Remove bytecode loading disabling from bios.lua. This never worked correctly, and serves little purpose as LuaJ is not vulnerable to such exploits.

I realise many of these changes are incredibly minor, and so don't really seem worth it. _However_, CraftOS is a great reference to link people to when they're looking for help, and so it's always good if we can show "best practices" for using CC & Lua's features.