### PR TITLE
Add .getCursorBlink to monitors and terminals

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/TermAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/TermAPI.java
@@ -78,7 +78,8 @@ public class TermAPI implements ILuaAPI
             "setPaletteColour",
             "setPaletteColor",
             "getPaletteColour",
-            "getPaletteColor"
+            "getPaletteColor",
+            "getCursorBlink",
         };
     }
     
@@ -298,6 +299,9 @@ public class TermAPI implements ILuaAPI
                 }
                 return null;
             }
+            case 23:
+                // getCursorBlink
+                return new Object[] { m_terminal.getCursorBlink() };
             default:
             {
                 return null;

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorPeripheral.java
@@ -65,7 +65,8 @@ public class MonitorPeripheral implements IPeripheral
             "setPaletteColour",
             "setPaletteColor",
             "getPaletteColour",
-            "getPaletteColor"
+            "getPaletteColor",
+            "getCursorBlink",
         };
     }
 
@@ -249,8 +250,13 @@ public class MonitorPeripheral implements IPeripheral
                 }
                 return null;
             }
+            case 24:
+                // getCursorBlink
+                Terminal terminal = m_monitor.getTerminal().getTerminal();
+                return new Object[] { terminal.getCursorBlink() };
+            default:
+                return null;
         }
-        return null;
     }
 
     @Override

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
@@ -258,6 +258,10 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
         end
     end
 
+    function window.getCursorBlink()
+        return bCursorBlink
+    end
+
     local function isColor()
         return parent.isColor()
     end


### PR DESCRIPTION
Adds it to the `term` API, `window` API and monitor peripherals. Closes #576.