### PR TITLE
Change height checks to integrated MC method

### DIFF
--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleMoveCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleMoveCommand.java
@@ -150,13 +150,9 @@ public class TurtleMoveCommand implements ITurtleCommand
 
     private TurtleCommandResult canEnter( TurtlePlayer turtlePlayer, World world, BlockPos position )
     {
-        if( position.getY() < 0 )
+        if( world.isOutsideBuildHeight( position ) )
         {
-            return TurtleCommandResult.failure( "Too low to move" );
-        }
-        else if( position.getY() > world.getHeight() - 1 )
-        {
-            return TurtleCommandResult.failure( "Too high to move" );
+            return TurtleCommandResult.failure( "Move would be outside world height." );
         }
         if( ComputerCraft.turtlesObeyBlockProtection )
         {

--- a/src/main/java/dan200/computercraft/shared/util/InventoryUtil.java
+++ b/src/main/java/dan200/computercraft/shared/util/InventoryUtil.java
@@ -49,8 +49,7 @@ public class InventoryUtil
     public static IItemHandler getInventory( World world, BlockPos pos, EnumFacing side )
     {
         // Look for tile with inventory
-        int y = pos.getY();
-        if( y >= 0 && y < world.getHeight() )
+        if( !world.isOutsideBuildHeight( pos ) )
         {
             TileEntity tileEntity = world.getTileEntity( pos );
             if( tileEntity != null )

--- a/src/main/java/dan200/computercraft/shared/util/WorldUtil.java
+++ b/src/main/java/dan200/computercraft/shared/util/WorldUtil.java
@@ -21,7 +21,7 @@ public class WorldUtil
 {
     public static boolean isBlockInWorld( World world, BlockPos pos )
     {
-        return pos.getY() >= 0 && pos.getY() < world.getHeight();
+        return !world.isOutsideBuildHeight( pos );
     }
 
     public static boolean isLiquidBlock( World world, BlockPos pos )


### PR DESCRIPTION
This effectively still checks if the target position is 0<=y<256, just as separate checks for 0 and world.getHeight() would do.
But by using this, mods like [CubicChunks](https://github.com/OpenCubicChunks/CubicChunks) which modify the world's height limits can change the result of the world.isOutsideBuildHeight() for easy compatibility.